### PR TITLE
feat: add allow registration toggle flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,11 @@ EMAIL_FROM=noreply@brewform.local
 # === OpenAPI ===
 OPENAPI_ENABLED=true
 
+# === Registration ===
+# Set to 'false' to disable new user registrations.
+# Existing users can still log in. Default: true.
+ENABLE_REGISTRATION=true
+
 # === Storage ===
 STORAGE_DRIVER=local
 

--- a/.eser/specs/add-enableregistration-environment-variable/progress.json
+++ b/.eser/specs/add-enableregistration-environment-variable/progress.json
@@ -1,0 +1,29 @@
+{
+  "spec": "add-enableregistration-environment-variable",
+  "status": "completed",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "Version: Dedicated GET /api/v1/auth/registration-status endpoint (public, no auth). Navbar conditionally hides/shows register link based ...",
+      "status": "done"
+    },
+    {
+      "id": "task-2",
+      "title": "Backend tests: env.test.ts — test ENABLE_REGISTRATION defaults to true, accepts false, rejects invalid values. auth/index.test.ts (new) — test POST /register returns 403 REGISTRATION_DISABLED when flag is false; test GET /registration-status returns {enabled: true/false}. auth/service.test.ts — test register() throws REGISTRATION_DISABLED when config says false. Frontend tests: RegisterPage — test disabled state shows closed message with login link; test enabled state shows form. Navbar — test register link hidden when registration disabled; shown when enabled. API client — test registration-status endpoint call. Documentation: .env.example updated with ENABLE_REGISTRATION, docs/auth.md updated with new config option.",
+      "status": "done"
+    },
+    {
+      "id": "task-3",
+      "title": "Write or update tests for all new and changed behavior",
+      "status": "done"
+    },
+    {
+      "id": "task-4",
+      "title": "Update documentation for all public-facing changes (README, API docs, CHANGELOG)",
+      "status": "done"
+    }
+  ],
+  "decisions": [],
+  "debt": [],
+  "updatedAt": "2026-05-16T21:59:03.387Z"
+}

--- a/.eser/specs/add-enableregistration-environment-variable/spec.md
+++ b/.eser/specs/add-enableregistration-environment-variable/spec.md
@@ -1,0 +1,133 @@
+# Spec: add-enableregistration-environment-variable
+
+## Status: completed
+
+## Concerns: well-engineered, beautiful-product, open-source
+
+## Discovery Answers
+
+### status_quo
+
+Today anyone can register at any time with no mechanism to close registrations. The /register endpoint always accepts new users, RegisterPage is always accessible, Navbar always shows Sign Up for unauthenticated users. If an admin wants to stop registrations (spam wave, invite-only period), they have no option short of taking the server down. Current registration UX is clean but has no disabled-state handling.
+
+_-- Arda Kilicdagi_
+
+### ambition
+
+10-star version: Dedicated GET /api/v1/auth/registration-status endpoint (public, no auth). Navbar conditionally hides/shows register link based on status endpoint. RegisterPage handles all states: loading (checking status), disabled (friendly message with login link), error (API unreachable — show register form as fallback). Structured logging on backend when registration attempted while disabled. OpenAPI docs updated. Comprehensive tests: backend (env config, auth route 403, status endpoint), frontend (RegisterPage disabled state, Navbar conditional rendering, API client). .env.example and docs/auth.md updated. User feels: app respects their time — tells them upfront if they can register, gives clear path to login if not.
+
+_-- Arda Kilicdagi_
+
+### reversibility
+
+Fully reversible. The toggle is an env var (ENABLE_REGISTRATION, default true) — change back to true and redeploy. No database schema changes needed — purely runtime config check following existing OPENAPI_ENABLED pattern. No user data affected — existing users can still log in regardless of flag. The new GET /auth/registration-status endpoint is additive. Only one-way door concern: if clients hardcode dependency on status endpoint and we later remove it, but that is standard API deprecation.
+
+_-- Arda Kilicdagi_
+
+### user_impact
+
+Existing users are completely unaffected — login, token refresh, password reset all work regardless of the flag. Only new registration attempts are blocked when disabled. No breaking API changes — /register POST still exists but returns 403 when disabled. The new /registration-status GET is additive. Navbar change is cosmetic for unauthenticated users (one less button). RegisterPage change only affects users who navigate directly to /register. No migration, no data changes, no backward compatibility concerns.
+
+_-- Arda Kilicdagi_
+
+### verification
+
+Backend tests: env.test.ts — test ENABLE_REGISTRATION defaults to true, accepts false, rejects invalid values. auth/index.test.ts (new) — test POST /register returns 403 REGISTRATION_DISABLED when flag is false; test GET /registration-status returns {enabled: true/false}. auth/service.test.ts — test register() throws REGISTRATION_DISABLED when config says false. Frontend tests: RegisterPage — test disabled state shows closed message with login link; test enabled state shows form. Navbar — test register link hidden when registration disabled; shown when enabled. API client — test registration-status endpoint call. Documentation: .env.example updated with ENABLE_REGISTRATION, docs/auth.md updated with new config option.
+
+_-- Arda Kilicdagi_
+
+### scope_boundary
+
+Out of scope: No admin panel UI toggle (env var only). No per-user registration control (invite codes, waitlists). No registration rate limiting changes. No changes to login, token refresh, or password reset flows. No email notification changes. No database schema changes. No changes to the admin setup/seed flow. The feature is strictly: one env var → blocks new registrations at the API level → frontend reflects the state via a status endpoint.
+
+_-- Arda Kilicdagi_
+
+## Test Strategy (well-engineered)
+
+_To be addressed during execution._
+
+## Performance Considerations (well-engineered)
+
+_To be addressed during execution._
+
+## Observability Plan (well-engineered)
+
+_To be addressed during execution._
+
+## Error Handling (well-engineered)
+
+_To be addressed during execution._
+
+## Security & Threat Model (well-engineered)
+
+_To be addressed during execution._
+
+## Developer Ergonomics (well-engineered)
+
+_To be addressed during execution._
+
+## Design States (empty, loading, error, success) (beautiful-product)
+
+_To be addressed during execution._
+
+## Mobile Layout (beautiful-product)
+
+_To be addressed during execution._
+
+## Interaction Design (beautiful-product)
+
+_To be addressed during execution._
+
+## Accessibility (beautiful-product)
+
+_To be addressed during execution._
+
+## Contributor Guide (open-source)
+
+_To be addressed during execution._
+
+## Public API Surface (open-source)
+
+_To be addressed during execution._
+
+## Out of Scope
+
+- Out of scope: No admin panel UI toggle (env var only)
+- No per-user registration control (invite codes, waitlists)
+- No registration rate limiting changes
+- No changes to login, token refresh, or password reset flows
+- No email notification changes
+- No database schema changes
+- No changes to the admin setup/seed flow
+- The feature is strictly: one env var → blocks new registrations at the API level → frontend reflects the state via a status endpoint.
+
+## Tasks
+
+- [x] task-1: Add ENABLE_REGISTRATION env var to config schema (apps/api/src/config/env.ts) following the OPENAPI_ENABLED pattern: z.enum(["true","false"]).default("true").transform(v => v === "true"). Files: apps/api/src/config/env.ts
+- [x] task-2: Guard POST /auth/register in auth controller (apps/api/src/modules/auth/index.ts) — check config.enableRegistration before calling service.register(), return 403 REGISTRATION_DISABLED if false. Files: apps/api/src/modules/auth/index.ts
+- [x] task-3: Add GET /auth/registration-status endpoint (apps/api/src/modules/auth/index.ts) — public, no auth, returns {enabled: boolean} from config. Add OpenAPI describeRoute. Files: apps/api/src/modules/auth/index.ts
+- [x] task-4: Add structured logging when registration is attempted while disabled. Files: apps/api/src/modules/auth/index.ts
+- [x] task-5: Update .env.example with ENABLE_REGISTRATION=true. Files: .env.example
+- [x] task-6: Update docs/auth.md with ENABLE_REGISTRATION config option. Files: docs/auth.md
+- [x] task-7: Backend tests — env.test.ts: test ENABLE_REGISTRATION defaults, accepts false, rejects invalid. auth/index.test.ts (new): test POST /register returns 403 when disabled, test GET /registration-status returns correct values. auth/service.test.ts: test register() throws REGISTRATION_DISABLED. Files: apps/api/src/config/env.test.ts, apps/api/src/modules/auth/index.test.ts (new), apps/api/src/modules/auth/service.test.ts
+- [x] task-8: Frontend — Add registrationStatus() to authApi in api/index.ts. Files: apps/web/src/api/index.ts
+- [x] task-9: Frontend — Update RegisterPage to check registration status on mount, show friendly closed message with login link when disabled, handle loading/error states. Files: apps/web/src/pages/auth/RegisterPage.tsx
+- [x] task-10: Frontend — Update Navbar to conditionally hide register link based on registration status (desktop and mobile). Files: apps/web/src/components/layout/Navbar.tsx
+- [x] task-11: Frontend tests — RegisterPage disabled/enabled/loading/error states. Navbar register link visibility. API client registration-status call. Files: apps/web/src/pages/auth/RegisterPage.test.tsx (new or extend), apps/web/src/components/layout/Navbar.test.tsx
+
+## Verification
+
+- Backend tests: env.test.ts — test ENABLE_REGISTRATION defaults to true, accepts false, rejects invalid values. auth/index.test.ts (new) — test POST /register returns 403 REGISTRATION_DISABLED when flag is false
+- test GET /registration-status returns {enabled: true/false}. auth/service.test.ts — test register() throws REGISTRATION_DISABLED when config says false
+- Frontend tests: RegisterPage — test disabled state shows closed message with login link
+- test enabled state shows form
+- Navbar — test register link hidden when registration disabled
+- shown when enabled
+- API client — test registration-status endpoint call
+- Documentation: .env.example updated with ENABLE_REGISTRATION, docs/auth.md updated with new config option.
+
+## Transition History
+
+| From | To | User | Timestamp | Reason |
+|------|----|------|-----------|--------|
+| IDLE | DISCOVERY | Arda Kilicdagi | 2026-05-16T21:13:25.020Z | - |

--- a/apps/api/src/config/env.test.ts
+++ b/apps/api/src/config/env.test.ts
@@ -21,6 +21,7 @@ const envSchema = z.object({
   SMTP_SECURE: z.coerce.boolean().default(false),
   EMAIL_FROM: z.string().default('noreply@brewform.local'),
   OPENAPI_ENABLED: z.coerce.boolean().default(true),
+  ENABLE_REGISTRATION: z.enum(['true', 'false']).default('true').transform((v) => v === 'true'),
   UPLOAD_DIR: z.string().default('./uploads'),
   UPLOAD_MAX_SIZE_BYTES: z.coerce.number().default(10 * 1024 * 1024),
   UPLOAD_ALLOWED_TYPES: z.string().default('image/jpeg,image/png,image/webp'),
@@ -167,5 +168,51 @@ describe('Environment Config Schema', () => {
         expect(result.data.LOG_LEVEL).toBe(level);
       }
     }
+  });
+});
+
+describe('ENABLE_REGISTRATION', () => {
+  it('should default to true', () => {
+    const result = envSchema.safeParse({
+      DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+      JWT_SECRET: 'a-very-long-secret-key-for-testing-12345',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ENABLE_REGISTRATION).toBe(true);
+    }
+  });
+
+  it('should accept false', () => {
+    const result = envSchema.safeParse({
+      DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+      JWT_SECRET: 'a-very-long-secret-key-for-testing-12345',
+      ENABLE_REGISTRATION: 'false',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ENABLE_REGISTRATION).toBe(false);
+    }
+  });
+
+  it('should accept true', () => {
+    const result = envSchema.safeParse({
+      DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+      JWT_SECRET: 'a-very-long-secret-key-for-testing-12345',
+      ENABLE_REGISTRATION: 'true',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ENABLE_REGISTRATION).toBe(true);
+    }
+  });
+
+  it('should reject invalid values', () => {
+    const result = envSchema.safeParse({
+      DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+      JWT_SECRET: 'a-very-long-secret-key-for-testing-12345',
+      ENABLE_REGISTRATION: 'maybe',
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -31,6 +31,7 @@ const envSchema = z.object({
   EMAIL_FROM: z.string().default('noreply@brewform.local'),
 
   OPENAPI_ENABLED: z.enum(['true', 'false']).default('true').transform((v) => v === 'true'),
+  ENABLE_REGISTRATION: z.enum(['true', 'false']).default('true').transform((v) => v === 'true'),
 
   // Storage
   STORAGE_DRIVER: z.enum(['local', 's3']).default('local'),
@@ -83,4 +84,9 @@ function loadEnv(): Env {
   return result.data;
 }
 
-export const config = loadEnv();
+export let config: Env = loadEnv();
+
+/** Re-parse env vars and update the singleton — used in tests to toggle config between cases. */
+export function reloadConfig(): void {
+  config = loadEnv();
+}

--- a/apps/api/src/modules/auth/index.test.ts
+++ b/apps/api/src/modules/auth/index.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { Hono } from 'hono';
+import auth from './index.ts';
+import { reloadConfig } from '../../config/env.ts';
+
+function createTestApp() {
+  const app = new Hono();
+  app.route('/auth', auth);
+  return app;
+}
+
+describe('Auth Routes', () => {
+  afterAll(() => {
+    Deno.env.delete('ENABLE_REGISTRATION');
+    reloadConfig();
+  });
+
+  describe('GET /auth/registration-status', () => {
+    it('should return enabled status', async () => {
+      const app = createTestApp();
+      const res = await app.request('/auth/registration-status');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.data.enabled).toBe(true);
+    });
+  });
+
+  describe('POST /auth/register', () => {
+    it('should return 400 for invalid body', async () => {
+      const app = createTestApp();
+      const res = await app.request('/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'not-an-email' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 403 when registration is disabled', async () => {
+      Deno.env.set('ENABLE_REGISTRATION', 'false');
+      reloadConfig();
+
+      const app = createTestApp();
+      const res = await app.request('/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'newuser@test.com', username: 'newuser', password: 'Test12345!' }),
+      });
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('REGISTRATION_DISABLED');
+    });
+  });
+});

--- a/apps/api/src/modules/auth/index.test.ts
+++ b/apps/api/src/modules/auth/index.test.ts
@@ -46,7 +46,11 @@ describe('Auth Routes', () => {
       const res = await app.request('/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: 'newuser@test.com', username: 'newuser', password: 'Test12345!' }),
+        body: JSON.stringify({
+          email: 'newuser@test.com',
+          username: 'newuser',
+          password: 'Test12345!',
+        }),
       });
       expect(res.status).toBe(403);
       const body = await res.json();

--- a/apps/api/src/modules/auth/index.test.ts
+++ b/apps/api/src/modules/auth/index.test.ts
@@ -1,4 +1,5 @@
-import { afterAll, describe, it } from 'jsr:@std/testing/bdd';
+import '../../test-setup.ts';
+import { describe, it } from 'jsr:@std/testing/bdd';
 import { expect } from 'jsr:@std/expect';
 import { Hono } from 'hono';
 import auth from './index.ts';
@@ -11,11 +12,6 @@ function createTestApp() {
 }
 
 describe('Auth Routes', () => {
-  afterAll(() => {
-    Deno.env.delete('ENABLE_REGISTRATION');
-    reloadConfig();
-  });
-
   describe('GET /auth/registration-status', () => {
     it('should return enabled status', async () => {
       const app = createTestApp();
@@ -39,23 +35,33 @@ describe('Auth Routes', () => {
     });
 
     it('should return 403 when registration is disabled', async () => {
-      Deno.env.set('ENABLE_REGISTRATION', 'false');
-      reloadConfig();
+      const original = Deno.env.get('ENABLE_REGISTRATION');
+      try {
+        Deno.env.set('ENABLE_REGISTRATION', 'false');
+        reloadConfig();
 
-      const app = createTestApp();
-      const res = await app.request('/auth/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          email: 'newuser@test.com',
-          username: 'newuser',
-          password: 'Test12345!',
-        }),
-      });
-      expect(res.status).toBe(403);
-      const body = await res.json();
-      expect(body.success).toBe(false);
-      expect(body.error.code).toBe('REGISTRATION_DISABLED');
+        const app = createTestApp();
+        const res = await app.request('/auth/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: 'newuser@test.com',
+            username: 'newuser',
+            password: 'Test12345!',
+          }),
+        });
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.success).toBe(false);
+        expect(body.error.code).toBe('REGISTRATION_DISABLED');
+      } finally {
+        if (original === undefined) {
+          Deno.env.delete('ENABLE_REGISTRATION');
+        } else {
+          Deno.env.set('ENABLE_REGISTRATION', original);
+        }
+        reloadConfig();
+      }
     });
   });
 });

--- a/apps/api/src/modules/auth/index.ts
+++ b/apps/api/src/modules/auth/index.ts
@@ -42,8 +42,16 @@ auth.post(
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       if (message === 'REGISTRATION_DISABLED') {
-        log.warn({ ip: c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown' }, 'Registration attempt while disabled');
-        return error(c, 'REGISTRATION_DISABLED', 'New account registration is currently disabled', 403);
+        log.warn(
+          { ip: c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown' },
+          'Registration attempt while disabled',
+        );
+        return error(
+          c,
+          'REGISTRATION_DISABLED',
+          'New account registration is currently disabled',
+          403,
+        );
       }
       if (message === 'EMAIL_ALREADY_EXISTS') {
         return error(c, 'CONFLICT', 'Email already registered', 409);

--- a/apps/api/src/modules/auth/index.ts
+++ b/apps/api/src/modules/auth/index.ts
@@ -26,6 +26,7 @@ auth.post(
       'Email and username are checked for uniqueness.',
     responses: {
       201: { description: 'Account created; tokens issued' },
+      403: { description: 'Registration disabled' },
       409: { description: 'Email or username already in use' },
     },
   }),

--- a/apps/api/src/modules/auth/index.ts
+++ b/apps/api/src/modules/auth/index.ts
@@ -10,6 +10,10 @@ import {
 } from '@brewform/shared/schemas';
 import * as authService from './service.ts';
 import { error, success } from '../../utils/response/index.ts';
+import { config } from '../../config/env.ts';
+import { createLogger } from '../../utils/logger/index.ts';
+
+const log = createLogger('auth');
 
 const auth = new Hono();
 
@@ -37,6 +41,10 @@ auth.post(
       }, 201);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
+      if (message === 'REGISTRATION_DISABLED') {
+        log.warn({ ip: c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown' }, 'Registration attempt while disabled');
+        return error(c, 'REGISTRATION_DISABLED', 'New account registration is currently disabled', 403);
+      }
       if (message === 'EMAIL_ALREADY_EXISTS') {
         return error(c, 'CONFLICT', 'Email already registered', 409);
       }
@@ -164,6 +172,22 @@ auth.post(
       }
       throw err;
     }
+  },
+);
+
+auth.get(
+  '/registration-status',
+  describeRoute({
+    tags: ['Auth'],
+    summary: 'Check if new user registration is enabled',
+    description: 'Returns whether the server currently accepts new account registrations. ' +
+      'Public endpoint — no authentication required.',
+    responses: {
+      200: { description: 'Registration status returned' },
+    },
+  }),
+  (c) => {
+    return success(c, { enabled: config.ENABLE_REGISTRATION });
   },
 );
 

--- a/apps/api/src/modules/auth/service.test.ts
+++ b/apps/api/src/modules/auth/service.test.ts
@@ -1,5 +1,7 @@
 import { describe, it } from 'jsr:@std/testing/bdd';
 import { expect } from 'jsr:@std/expect';
+import { reloadConfig } from '../../config/env.ts';
+import { register } from './service.ts';
 
 describe('Auth Service Logic', () => {
   describe('Registration validation', () => {
@@ -96,6 +98,19 @@ describe('Auth Service Logic', () => {
       } catch (err) {
         expect((err as Error).message).toBe('TOKEN_EXPIRED');
       }
+    });
+  });
+
+  describe('Registration toggle', () => {
+    it('should throw REGISTRATION_DISABLED when config disables registration', async () => {
+      Deno.env.set('ENABLE_REGISTRATION', 'false');
+      reloadConfig();
+
+      await expect(register({
+        email: 'test@test.com',
+        username: 'testuser',
+        password: 'Test12345!',
+      })).rejects.toThrow('REGISTRATION_DISABLED');
     });
   });
 

--- a/apps/api/src/modules/auth/service.test.ts
+++ b/apps/api/src/modules/auth/service.test.ts
@@ -1,3 +1,4 @@
+import '../../test-setup.ts';
 import { describe, it } from 'jsr:@std/testing/bdd';
 import { expect } from 'jsr:@std/expect';
 import { reloadConfig } from '../../config/env.ts';
@@ -103,14 +104,24 @@ describe('Auth Service Logic', () => {
 
   describe('Registration toggle', () => {
     it('should throw REGISTRATION_DISABLED when config disables registration', async () => {
-      Deno.env.set('ENABLE_REGISTRATION', 'false');
-      reloadConfig();
+      const original = Deno.env.get('ENABLE_REGISTRATION');
+      try {
+        Deno.env.set('ENABLE_REGISTRATION', 'false');
+        reloadConfig();
 
-      await expect(register({
-        email: 'test@test.com',
-        username: 'testuser',
-        password: 'Test12345!',
-      })).rejects.toThrow('REGISTRATION_DISABLED');
+        await expect(register({
+          email: 'test@test.com',
+          username: 'testuser',
+          password: 'Test12345!',
+        })).rejects.toThrow('REGISTRATION_DISABLED');
+      } finally {
+        if (original === undefined) {
+          Deno.env.delete('ENABLE_REGISTRATION');
+        } else {
+          Deno.env.set('ENABLE_REGISTRATION', original);
+        }
+        reloadConfig();
+      }
     });
   });
 

--- a/apps/api/src/modules/auth/service.ts
+++ b/apps/api/src/modules/auth/service.ts
@@ -2,6 +2,7 @@ import * as jwt from './jwt.ts';
 import * as model from './model.ts';
 import { sendPasswordResetEmail, sendWelcomeEmail } from './email.ts';
 import { createLogger } from '../../utils/logger/index.ts';
+import { config } from '../../config/env.ts';
 
 const logger = createLogger('auth-service');
 
@@ -34,6 +35,10 @@ export async function register(data: {
   password: string;
   displayName?: string;
 }) {
+  if (!config.ENABLE_REGISTRATION) {
+    throw new Error('REGISTRATION_DISABLED');
+  }
+
   const existingEmail = await model.findUserByEmail(data.email);
   if (existingEmail) {
     throw new Error('EMAIL_ALREADY_EXISTS');

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -13,6 +13,8 @@ export const authApi = {
     api.post<{ message: string }>('/auth/forgot-password', data),
   resetPassword: (data: { token: string; newPassword: string }) =>
     api.post<{ message: string }>('/auth/reset-password', data),
+  registrationStatus: () =>
+    api.get<{ enabled: boolean }>('/auth/registration-status'),
 };
 
 export const userApi = {

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -13,8 +13,7 @@ export const authApi = {
     api.post<{ message: string }>('/auth/forgot-password', data),
   resetPassword: (data: { token: string; newPassword: string }) =>
     api.post<{ message: string }>('/auth/reset-password', data),
-  registrationStatus: () =>
-    api.get<{ enabled: boolean }>('/auth/registration-status'),
+  registrationStatus: () => api.get<{ enabled: boolean }>('/auth/registration-status'),
 };
 
 export const userApi = {

--- a/apps/web/src/components/layout/Footer.test.tsx
+++ b/apps/web/src/components/layout/Footer.test.tsx
@@ -80,7 +80,7 @@ describe('Footer — Language Switcher', () => {
 
     await userEvent.click(trigger);
 
-    const options = screen.getAllByRole('option');
+    const options = await screen.findAllByRole('option');
     expect(options).toHaveLength(2);
     expect(options[0]).toHaveTextContent('🇬🇧 English');
     expect(options[1]).toHaveTextContent('🇹🇷 Türkçe');

--- a/apps/web/src/components/layout/Navbar.test.tsx
+++ b/apps/web/src/components/layout/Navbar.test.tsx
@@ -59,8 +59,18 @@ vi.mock('../../contexts/ThemeContext', () => ({
 }));
 
 vi.mock('../../api/index', () => ({
-  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn(), upload: vi.fn() },
-  ApiError: class extends Error { code = ''; status = 500; },
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    upload: vi.fn(),
+  },
+  ApiError: class extends Error {
+    code = '';
+    status = 500;
+  },
   clearTokens: vi.fn(),
   getAccessToken: vi.fn(() => null),
   setAccessToken: vi.fn(),

--- a/apps/web/src/components/layout/Navbar.test.tsx
+++ b/apps/web/src/components/layout/Navbar.test.tsx
@@ -1,6 +1,6 @@
 import fc from 'fast-check';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Navbar } from './Navbar';
 
@@ -58,9 +58,21 @@ vi.mock('../../contexts/ThemeContext', () => ({
   useTheme: vi.fn(),
 }));
 
+vi.mock('../../api/index', () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn(), upload: vi.fn() },
+  ApiError: class extends Error { code = ''; status = 500; },
+  clearTokens: vi.fn(),
+  getAccessToken: vi.fn(() => null),
+  setAccessToken: vi.fn(),
+  authApi: {
+    registrationStatus: vi.fn().mockResolvedValue({ enabled: true }),
+  },
+}));
+
 import { useTranslation } from '../../contexts/I18nContext';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
+import { authApi } from '../../api/index';
 
 const mockUseTranslation = vi.mocked(useTranslation);
 const mockUseAuth = vi.mocked(useAuth);
@@ -898,6 +910,52 @@ describe('Navbar — active route indicator', () => {
     // Deduplicate by href (desktop + mobile render the same links twice)
     const activeHrefs = new Set(activeLinks.map((el) => el.getAttribute('href')));
     expect(activeHrefs.size).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('Navbar — registration toggle', () => {
+  it('should show register link when registration is enabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: true });
+    render(<Navbar />);
+    await waitFor(() => {
+      expect(screen.getByText('Sign Up')).toBeInTheDocument();
+    });
+  });
+
+  it('should hide register link when registration is disabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: false });
+    render(<Navbar />);
+    await waitFor(() => {
+      expect(screen.queryByText('Sign Up')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should still show login link when registration is disabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: false });
+    render(<Navbar />);
+    await waitFor(() => {
+      expect(screen.getByText('Log In')).toBeInTheDocument();
+    });
+  });
+
+  it('should not fetch registration status for authenticated users', async () => {
+    mockUseAuth.mockReturnValue({
+      ...defaultAuth,
+      user: {
+        id: 'user-1',
+        email: 'alice@example.com',
+        username: 'alice',
+        displayName: 'Alice',
+        avatarUrl: null,
+        isAdmin: false,
+        onboardingCompleted: true,
+      },
+      isAuthenticated: true,
+    } as ReturnType<typeof useAuth>);
+    render(<Navbar />);
+    await waitFor(() => {
+      expect(authApi.registrationStatus).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/apps/web/src/components/layout/Navbar.tsx
+++ b/apps/web/src/components/layout/Navbar.tsx
@@ -4,6 +4,7 @@ import { Select } from '@base-ui/react/select';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useTranslation } from '../../contexts/I18nContext';
+import { authApi } from '../../api/index';
 
 const FOCUSABLE_SELECTOR =
   'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
@@ -172,6 +173,14 @@ export function Navbar() {
   const { theme, setTheme } = useTheme();
   const { t } = useTranslation();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [registrationEnabled, setRegistrationEnabled] = useState(true);
+
+  useEffect(() => {
+    if (user) return;
+    authApi.registrationStatus()
+      .then(({ enabled }) => setRegistrationEnabled(enabled))
+      .catch(() => setRegistrationEnabled(true));
+  }, [user]);
 
   const hamburgerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -283,12 +292,14 @@ export function Navbar() {
                 >
                   {t('nav.login')}
                 </Link>
-                <Link
-                  to='/register'
-                  className='btn-primary text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]'
-                >
-                  {t('nav.register')}
-                </Link>
+                {registrationEnabled && (
+                  <Link
+                    to='/register'
+                    className='btn-primary text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]'
+                  >
+                    {t('nav.register')}
+                  </Link>
+                )}
               </>
             )}
         </nav>
@@ -456,13 +467,15 @@ export function Navbar() {
                     >
                       {t('nav.login')}
                     </Link>
-                    <Link
-                      to='/register'
-                      onClick={() => setIsMenuOpen(false)}
-                      className='btn-primary text-sm text-center focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]'
-                    >
-                      {t('nav.register')}
-                    </Link>
+                    {registrationEnabled && (
+                      <Link
+                        to='/register'
+                        onClick={() => setIsMenuOpen(false)}
+                        className='btn-primary text-sm text-center focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]'
+                      >
+                        {t('nav.register')}
+                      </Link>
+                    )}
                   </div>
                 )}
             </div>

--- a/apps/web/src/components/recipe/BeanSection.test.tsx
+++ b/apps/web/src/components/recipe/BeanSection.test.tsx
@@ -140,7 +140,9 @@ describe('BeanSection — conditional rendering unit tests', () => {
  */
 const nullableString = fc.option(fc.string({ minLength: 1, maxLength: 50 }), { nil: null });
 const nullableDateString = fc.option(
-  fc.date({ min: new Date('2020-01-01'), max: new Date('2030-12-31') }).map((d) => d.toISOString()),
+  fc.date({ min: new Date('2020-01-01'), max: new Date('2030-12-31') })
+    .filter((d) => !isNaN(d.getTime()))
+    .map((d) => d.toISOString()),
   { nil: null },
 );
 

--- a/apps/web/src/components/recipe/IntensityDots.test.tsx
+++ b/apps/web/src/components/recipe/IntensityDots.test.tsx
@@ -53,13 +53,14 @@ describe('IntensityDots', () => {
     }
   });
 
-  it('filled dots have no border', () => {
+  it('filled dots have no visible border', () => {
     const { container } = render(<IntensityDots intensity={3} />);
     const dots = Array.from(
       container.querySelectorAll('span[aria-hidden="true"]'),
     ) as HTMLElement[];
     for (const dot of dots) {
-      expect(dot.style.border).toBe('');
+      expect(dot.style.border).not.toBe('1px solid var(--text-tertiary)');
+      expect(dot.style.borderStyle).toBe('none');
     }
   });
 

--- a/apps/web/src/components/recipe/TasteNotesFilter.test.tsx
+++ b/apps/web/src/components/recipe/TasteNotesFilter.test.tsx
@@ -255,7 +255,7 @@ describe('TasteNotesFilter — styling consistency', () => {
       />,
     );
 
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('combobox');
     await user.click(trigger);
 
     // The popup is the ancestor of the listbox that has the max-h and overflow classes

--- a/apps/web/src/pages/auth/RegisterPage.test.tsx
+++ b/apps/web/src/pages/auth/RegisterPage.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { RegisterPage } from './RegisterPage';
+import { AuthProvider } from '../../contexts/AuthContext';
+import { I18nProvider } from '../../contexts/I18nContext';
+import { authApi } from '../../api/index';
+
+vi.mock('../../api/index', () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn(), upload: vi.fn() },
+  ApiError: class extends Error { code = ''; status = 500; },
+  clearTokens: vi.fn(),
+  getAccessToken: vi.fn(() => null),
+  setAccessToken: vi.fn(),
+  authApi: {
+    registrationStatus: vi.fn(),
+  },
+}));
+
+function renderRegisterPage() {
+  return render(
+    <MemoryRouter>
+      <I18nProvider>
+        <AuthProvider>
+          <RegisterPage />
+        </AuthProvider>
+      </I18nProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should show loading state while checking registration status', () => {
+    vi.mocked(authApi.registrationStatus).mockReturnValue(new Promise(() => {}));
+    renderRegisterPage();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('should show registration form when enabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: true });
+    renderRegisterPage();
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('you@example.com')).toBeInTheDocument();
+    });
+  });
+
+  it('should show closed message when registration is disabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: false });
+    renderRegisterPage();
+    await waitFor(() => {
+      expect(screen.getByText(/registration.*disabled/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should show login link when registration is disabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: false });
+    renderRegisterPage();
+    await waitFor(() => {
+      const loginLink = screen.getByRole('link', { name: /log in/i });
+      expect(loginLink).toBeInTheDocument();
+      expect(loginLink.getAttribute('href')).toBe('/login');
+    });
+  });
+
+  it('should fall back to showing form when status check fails', async () => {
+    vi.mocked(authApi.registrationStatus).mockRejectedValue(new Error('Network error'));
+    renderRegisterPage();
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('you@example.com')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/pages/auth/RegisterPage.test.tsx
+++ b/apps/web/src/pages/auth/RegisterPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { RegisterPage } from './RegisterPage';
@@ -7,8 +7,18 @@ import { I18nProvider } from '../../contexts/I18nContext';
 import { authApi } from '../../api/index';
 
 vi.mock('../../api/index', () => ({
-  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn(), upload: vi.fn() },
-  ApiError: class extends Error { code = ''; status = 500; },
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    upload: vi.fn(),
+  },
+  ApiError: class extends Error {
+    code = '';
+    status = 500;
+  },
   clearTokens: vi.fn(),
   getAccessToken: vi.fn(() => null),
   setAccessToken: vi.fn(),

--- a/apps/web/src/pages/auth/RegisterPage.tsx
+++ b/apps/web/src/pages/auth/RegisterPage.tsx
@@ -1,7 +1,8 @@
-import { type FormEvent, useState } from 'react';
+import { type FormEvent, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTranslation } from '../../contexts/I18nContext';
+import { authApi } from '../../api/index';
 
 export function RegisterPage() {
   const { register } = useAuth();
@@ -14,6 +15,23 @@ export function RegisterPage() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+
+  const [statusLoading, setStatusLoading] = useState(true);
+  const [registrationEnabled, setRegistrationEnabled] = useState(true);
+
+  useEffect(() => {
+    async function checkStatus() {
+      try {
+        const { enabled } = await authApi.registrationStatus();
+        setRegistrationEnabled(enabled);
+      } catch {
+        setRegistrationEnabled(true);
+      } finally {
+        setStatusLoading(false);
+      }
+    }
+    checkStatus();
+  }, []);
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -34,6 +52,38 @@ export function RegisterPage() {
     } finally {
       setLoading(false);
     }
+  }
+
+  if (statusLoading) {
+    return (
+      <div className='mx-auto max-w-md px-6 py-12 text-center'>
+        <p style={{ color: 'var(--text-secondary)' }}>Loading...</p>
+      </div>
+    );
+  }
+
+  if (!registrationEnabled) {
+    return (
+      <div className='mx-auto max-w-md px-6 py-12'>
+        <h1 className='text-2xl font-bold' style={{ color: 'var(--text-primary)' }}>
+          {t('auth.register.title')}
+        </h1>
+        <div
+          className='mt-6 rounded p-6'
+          style={{ backgroundColor: 'var(--bg-secondary)', border: '1px solid var(--border-primary)' }}
+        >
+          <p className='text-base' style={{ color: 'var(--text-primary)' }}>
+            {t('auth.register.registrationClosed')}
+          </p>
+          <p className='mt-3 text-sm' style={{ color: 'var(--text-secondary)' }}>
+            {t('auth.register.hasAccount')}{' '}
+            <Link to='/login' style={{ color: 'var(--accent-primary)' }}>
+              {t('auth.register.logIn')}
+            </Link>
+          </p>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/apps/web/src/pages/auth/RegisterPage.tsx
+++ b/apps/web/src/pages/auth/RegisterPage.tsx
@@ -70,7 +70,10 @@ export function RegisterPage() {
         </h1>
         <div
           className='mt-6 rounded p-6'
-          style={{ backgroundColor: 'var(--bg-secondary)', border: '1px solid var(--border-primary)' }}
+          style={{
+            backgroundColor: 'var(--bg-secondary)',
+            border: '1px solid var(--border-primary)',
+          }}
         >
           <p className='text-base' style={{ color: 'var(--text-primary)' }}>
             {t('auth.register.registrationClosed')}

--- a/apps/web/src/utils/relative-date.test.ts
+++ b/apps/web/src/utils/relative-date.test.ts
@@ -139,7 +139,8 @@ describe('grindDateLabel', () => {
  * positive integer.
  */
 describe('Property 3: Relative date calculation (PBT)', () => {
-  const dateArb = fc.date({ min: new Date('2020-01-01'), max: new Date('2030-12-31') });
+  const dateArb = fc.date({ min: new Date('2020-01-01'), max: new Date('2030-12-31') })
+    .filter((d) => !isNaN(d.getTime()));
 
   /**
    * Helper: strip time component to midnight UTC so two dates on the same

--- a/deno.lock
+++ b/deno.lock
@@ -49,6 +49,7 @@
     "npm:typescript@6": "6.0.3",
     "npm:vite@*": "8.0.13",
     "npm:vite@8": "8.0.13",
+    "npm:vitest@*": "4.1.6_@vitest+coverage-v8@4.1.6_jsdom@29.1.1_vite@8.0.13",
     "npm:vitest@4": "4.1.6_@vitest+coverage-v8@4.1.6_jsdom@29.1.1_vite@8.0.13",
     "npm:zod@4": "4.4.3"
   },

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -16,7 +16,7 @@ to access protected endpoints.
 
 ## Registration
 
-```
+```text
 POST /api/v1/auth/register
 ```
 
@@ -53,7 +53,7 @@ available) for observability.
 
 ## Registration Status
 
-```
+```text
 GET /api/v1/auth/registration-status
 ```
 
@@ -83,7 +83,7 @@ see the full navigation regardless of the flag.
 
 ## Login
 
-```
+```text
 POST /api/v1/auth/login
 ```
 
@@ -96,7 +96,7 @@ On success, returns `200 OK` with user, access token, and refresh token. Banned 
 
 ## Token Refresh
 
-```
+```text
 POST /api/v1/auth/refresh
 ```
 
@@ -112,7 +112,7 @@ immediately).
 
 ### Step 1: Request Reset
 
-```
+```text
 POST /api/v1/auth/forgot-password
 ```
 
@@ -125,7 +125,7 @@ exists, a reset link is sent to the user with a token valid for 1 hour.
 
 ### Step 2: Confirm Reset
 
-```
+```text
 POST /api/v1/auth/reset-password
 ```
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -32,6 +32,55 @@ POST /api/v1/auth/register
 On success, returns `201 Created` with the user object and both tokens. A welcome email is sent
 asynchronously. Passwords are hashed with bcryptjs (10 rounds).
 
+### Registration Disabled
+
+When the `ENABLE_REGISTRATION` environment variable is set to `false`, the register endpoint returns
+a `403 Forbidden` response:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "REGISTRATION_DISABLED",
+    "message": "New account registration is currently disabled",
+    "requestId": "req_abc123"
+  }
+}
+```
+
+A structured warning log is also emitted (with IP from `x-forwarded-for` or `x-real-ip` when
+available) for observability.
+
+## Registration Status
+
+```
+GET /api/v1/auth/registration-status
+```
+
+Public endpoint — no authentication required. Returns whether the server currently accepts new
+account registrations:
+
+```json
+{
+  "success": true,
+  "data": {
+    "enabled": true
+  }
+}
+```
+
+The frontend uses this endpoint to conditionally render the registration UI:
+
+| Status   | RegisterPage                                                                      | Navbar                     |
+| -------- | --------------------------------------------------------------------------------- | -------------------------- |
+| Enabled  | Shows the registration form                                                       | Shows "Sign Up" link       |
+| Disabled | Shows a friendly closed message with a link to the login page                     | Hides "Sign Up" link       |
+| Loading  | Shows a centered "Loading..." indicator                                           | Assumes enabled (shows form & link until status resolves) |
+| Error    | Falls back to enabled (API unreachable — shows the registration form)             | Falls back to enabled      |
+
+The Navbar fetches registration status only for unauthenticated users; authenticated users always
+see the full navigation regardless of the flag.
+
 ## Login
 
 ```
@@ -117,5 +166,6 @@ JWT behaviour is configured via environment variables:
 | `JWT_SECRET`         | —       | **Required.** Cryptographically random, at least 16 characters |
 | `JWT_ACCESS_EXPIRY`  | `15m`   | Access token validity period                                   |
 | `JWT_REFRESH_EXPIRY` | `7d`    | Refresh token validity period                                  |
+| `ENABLE_REGISTRATION` | `true`  | When `false`, `POST /auth/register` returns `403 REGISTRATION_DISABLED`, `GET /auth/registration-status` returns `{ enabled: false }`, the RegisterPage shows a closed message with login link, and the Navbar hides the "Sign Up" link. Existing users can still log in, refresh tokens, and reset passwords — only new account creation is blocked. |
 
 Expiry values use human-readable strings parsed by `parseExpiry()` (`15m`, `1h`, `7d`, etc.).

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -334,6 +334,7 @@
   "auth.register.logIn": "Log in",
   "auth.register.displayName": "Display Name",
   "auth.register.passwordsMismatch": "Passwords do not match",
+  "auth.register.registrationClosed": "New account registration is currently disabled.",
   "auth.forgotPassword.title": "Forgot Password",
   "auth.forgotPassword.desc": "Enter your email and we'll send you a reset link.",
   "auth.forgotPassword.sending": "Sending...",

--- a/packages/shared/src/i18n/tr.json
+++ b/packages/shared/src/i18n/tr.json
@@ -334,6 +334,7 @@
   "auth.register.logIn": "Giriş yap",
   "auth.register.displayName": "Görünen Ad",
   "auth.register.passwordsMismatch": "Şifreler eşleşmiyor",
+  "auth.register.registrationClosed": "Yeni hesap kaydı şu anda devre dışı.",
   "auth.forgotPassword.title": "Şifremi Unuttum",
   "auth.forgotPassword.desc": "E-postanızı girin, size sıfırlama bağlantısı gönderelim.",
   "auth.forgotPassword.sending": "Gönderiliyor...",

--- a/plan_toggle_registration.md
+++ b/plan_toggle_registration.md
@@ -1,0 +1,897 @@
+# Plan: Enable/Disable Registration Toggle
+
+**Status:** Approved  
+**Spec:** `add-enableregistration-environment-variable`  
+**Approach:** Full-stack with dedicated status endpoint (Approach A)  
+**Effort:** S (~11 files)  
+**Risk:** Low  
+
+---
+
+## Overview
+
+Add an `ENABLE_REGISTRATION` environment variable (default: `true`) that controls whether new users can register. When set to `false`:
+
+- **Backend:** `POST /api/v1/auth/register` returns `403 REGISTRATION_DISABLED`
+- **Backend:** New `GET /api/v1/auth/registration-status` endpoint returns `{ enabled: boolean }`
+- **Frontend:** Navbar hides the "Sign Up" link for unauthenticated users
+- **Frontend:** `/register` page shows a friendly "Registrations are currently closed" message with a login link
+- **Frontend:** All interaction states handled (loading, disabled, error fallback)
+
+Existing users are completely unaffected — login, token refresh, and password reset all work regardless of the flag.
+
+---
+
+## Files to Modify/Create
+
+### Backend (API)
+
+| # | File | Action | Description |
+|---|------|--------|-------------|
+| 1 | [`apps/api/src/config/env.ts`](apps/api/src/config/env.ts:9) | Modify | Add `ENABLE_REGISTRATION` to Zod schema |
+| 2 | [`apps/api/src/modules/auth/index.ts`](apps/api/src/modules/auth/index.ts:16) | Modify | Guard register route + add status endpoint |
+| 3 | [`apps/api/src/config/env.test.ts`](apps/api/src/config/env.test.ts:1) | Modify | Add tests for `ENABLE_REGISTRATION` |
+| 4 | [`apps/api/src/modules/auth/index.test.ts`](apps/api/src/modules/auth/index.test.ts) | **Create** | Test register 403 + status endpoint |
+| 5 | [`apps/api/src/modules/auth/service.test.ts`](apps/api/src/modules/auth/service.test.ts:1) | Modify | Add registration-disabled test |
+| 6 | [`.env.example`](.env.example:1) | Modify | Add `ENABLE_REGISTRATION=true` |
+| 7 | [`docs/auth.md`](docs/auth.md:1) | Modify | Document new config option |
+
+### Frontend (Web)
+
+| # | File | Action | Description |
+|---|------|--------|-------------|
+| 8 | [`apps/web/src/api/index.ts`](apps/web/src/api/index.ts:1) | Modify | Add `registrationStatus()` to `authApi` |
+| 9 | [`apps/web/src/pages/auth/RegisterPage.tsx`](apps/web/src/pages/auth/RegisterPage.tsx:1) | Modify | Check status on mount, show disabled message |
+| 10 | [`apps/web/src/components/layout/Navbar.tsx`](apps/web/src/components/layout/Navbar.tsx:286) | Modify | Conditionally hide register link |
+| 11 | [`apps/web/src/pages/auth/RegisterPage.test.tsx`](apps/web/src/pages/auth/RegisterPage.test.tsx) | **Create** | Test disabled/enabled/loading/error states |
+| 12 | [`apps/web/src/components/layout/Navbar.test.tsx`](apps/web/src/components/layout/Navbar.test.tsx:1) | Modify | Test register link visibility |
+
+---
+
+## Detailed Changes with Example Code
+
+### Task 1: Add `ENABLE_REGISTRATION` to env config
+
+**File:** [`apps/api/src/config/env.ts`](apps/api/src/config/env.ts:9)
+
+Add the following line inside the `envSchema` object, after the `OPENAPI_ENABLED` line (line 33) to follow the existing pattern:
+
+```typescript
+// Add after line 33 (OPENAPI_ENABLED):
+ENABLE_REGISTRATION: z.enum(['true', 'false']).default('true').transform((v) => v === 'true'),
+```
+
+This follows the exact same pattern as `OPENAPI_ENABLED`:
+- Accepts string `'true'` or `'false'` from environment
+- Defaults to `'true'` (registration enabled by default)
+- Transforms to a boolean via `.transform((v) => v === 'true')`
+
+The `Env` type will automatically include `enableRegistration: boolean` via `z.infer`.
+
+---
+
+### Task 2: Guard `POST /auth/register` with config check
+
+**File:** [`apps/api/src/modules/auth/index.ts`](apps/api/src/modules/auth/index.ts:16)
+
+Add the config import at the top of the file:
+
+```typescript
+// Add after existing imports (after line 12):
+import { config } from '../../config/env.ts';
+```
+
+Then modify the register route handler (lines 29-48) to check the flag before proceeding:
+
+```typescript
+// Replace the existing async (c) => { ... } block at lines 29-48:
+async (c) => {
+  if (!config.enableRegistration) {
+    return error(c, 'REGISTRATION_DISABLED', 'New account registration is currently disabled', 403);
+  }
+
+  const body = c.req.valid('json');
+  try {
+    const result = await authService.register(body);
+    return success(c, {
+      user: sanitizeUser(result.user),
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+    }, 201);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message === 'EMAIL_ALREADY_EXISTS') {
+      return error(c, 'CONFLICT', 'Email already registered', 409);
+    }
+    if (message === 'USERNAME_ALREADY_EXISTS') {
+      return error(c, 'CONFLICT', 'Username already taken', 409);
+    }
+    throw err;
+  }
+},
+```
+
+---
+
+### Task 3: Add `GET /auth/registration-status` endpoint
+
+**File:** [`apps/api/src/modules/auth/index.ts`](apps/api/src/modules/auth/index.ts:16)
+
+Add a new route **before** the `export default auth;` line (before line 176):
+
+```typescript
+// Add before line 176 (export default auth;):
+auth.get(
+  '/registration-status',
+  describeRoute({
+    tags: ['Auth'],
+    summary: 'Check if new user registration is enabled',
+    description: 'Returns whether the server currently accepts new account registrations. ' +
+      'Public endpoint — no authentication required.',
+    responses: {
+      200: { description: 'Registration status returned' },
+    },
+  }),
+  (c) => {
+    return success(c, { enabled: config.enableRegistration });
+  },
+);
+```
+
+---
+
+### Task 4: Structured logging for disabled registration attempts
+
+**File:** [`apps/api/src/modules/auth/index.ts`](apps/api/src/modules/auth/index.ts:16)
+
+Add a logger import at the top:
+
+```typescript
+// Add after existing imports:
+import { createLogger } from '../../utils/logger/index.ts';
+
+const logger = createLogger('auth-routes');
+```
+
+Then modify the guard added in Task 2 to include logging:
+
+```typescript
+// Inside the register handler, replace the guard:
+if (!config.enableRegistration) {
+  logger.warn({ body: c.req.valid('json') }, 'Registration attempted while disabled');
+  return error(c, 'REGISTRATION_DISABLED', 'New account registration is currently disabled', 403);
+}
+```
+
+**Note:** Logging the request body is acceptable here because it's a registration attempt (email/username) — no passwords are logged since the guard runs before `c.req.valid('json')` is called. If you prefer to avoid logging PII, log only the fact of the attempt:
+
+```typescript
+if (!config.enableRegistration) {
+  logger.warn('Registration attempted while registrations are disabled');
+  return error(c, 'REGISTRATION_DISABLED', 'New account registration is currently disabled', 403);
+}
+```
+
+---
+
+### Task 5: Update `.env.example`
+
+**File:** [`.env.example`](.env.example:1)
+
+Add after the `OPENAPI_ENABLED=true` line (line 41):
+
+```env
+# === Registration ===
+# Set to 'false' to disable new user registrations.
+# Existing users can still log in. Default: true.
+ENABLE_REGISTRATION=true
+```
+
+---
+
+### Task 6: Update `docs/auth.md`
+
+**File:** [`docs/auth.md`](docs/auth.md:1)
+
+Add to the "Environment Configuration" table (after line 119):
+
+```markdown
+| `ENABLE_REGISTRATION` | `true`  | Set to `false` to disable new account creation. Existing users can still log in. |
+```
+
+---
+
+### Task 7: Backend tests
+
+#### 7a: Env config tests
+
+**File:** [`apps/api/src/config/env.test.ts`](apps/api/src/config/env.test.ts:1)
+
+Add `ENABLE_REGISTRATION` to the test schema (line 23 area) and add new test cases:
+
+```typescript
+// Add ENABLE_REGISTRATION to the test schema (after OPENAPI_ENABLED line):
+ENABLE_REGISTRATION: z.coerce.boolean().default(true),
+
+// Add new test cases at the end of the describe block:
+
+describe('ENABLE_REGISTRATION', () => {
+  it('should default to true', () => {
+    const result = envSchema.safeParse({
+      DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+      JWT_SECRET: 'a-very-long-secret-key-for-testing-12345',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ENABLE_REGISTRATION).toBe(true);
+    }
+  });
+
+  it('should accept false', () => {
+    const result = envSchema.safeParse({
+      DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+      JWT_SECRET: 'a-very-long-secret-key-for-testing-12345',
+      ENABLE_REGISTRATION: 'false',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ENABLE_REGISTRATION).toBe(false);
+    }
+  });
+
+  it('should accept true', () => {
+    const result = envSchema.safeParse({
+      DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+      JWT_SECRET: 'a-very-long-secret-key-for-testing-12345',
+      ENABLE_REGISTRATION: 'true',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ENABLE_REGISTRATION).toBe(true);
+    }
+  });
+
+  it('should reject invalid values', () => {
+    const result = envSchema.safeParse({
+      DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+      JWT_SECRET: 'a-very-long-secret-key-for-testing-12345',
+      ENABLE_REGISTRATION: 'maybe',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+```
+
+#### 7b: Auth routes integration tests (new file)
+
+**File:** [`apps/api/src/modules/auth/index.test.ts`](apps/api/src/modules/auth/index.test.ts) **(CREATE NEW)**
+
+```typescript
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { Hono } from 'hono';
+import auth from './index.ts';
+
+// Create a test app with the auth routes mounted
+function createTestApp() {
+  const app = new Hono();
+  app.route('/auth', auth);
+  return app;
+}
+
+describe('Auth Routes', () => {
+  describe('GET /auth/registration-status', () => {
+    it('should return enabled status', async () => {
+      // Note: This test relies on the default config (ENABLE_REGISTRATION=true)
+      // For testing the false case, you would need to mock Deno.env or the config module.
+      // See the service test below for the unit-level test of the disabled case.
+      const app = createTestApp();
+      const res = await app.request('/auth/registration-status');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.data.enabled).toBe(true);
+    });
+  });
+
+  describe('POST /auth/register', () => {
+    it('should return 400 for invalid body', async () => {
+      const app = createTestApp();
+      const res = await app.request('/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'not-an-email' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 403 when registration is disabled', async () => {
+      // Set env var to disable registration for this test
+      const originalEnv = Deno.env.get('ENABLE_REGISTRATION');
+      Deno.env.set('ENABLE_REGISTRATION', 'false');
+      
+      // Re-import to get fresh config — in practice you'd use a mock
+      // This test demonstrates the expected behavior
+      
+      try {
+        const app = createTestApp();
+        const res = await app.request('/auth/register', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: 'test@example.com',
+            username: 'testuser',
+            password: 'password123',
+          }),
+        });
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.error.code).toBe('REGISTRATION_DISABLED');
+      } finally {
+        // Restore original env
+        if (originalEnv !== undefined) {
+          Deno.env.set('ENABLE_REGISTRATION', originalEnv);
+        } else {
+          Deno.env.delete('ENABLE_REGISTRATION');
+        }
+      }
+    });
+  });
+});
+```
+
+#### 7c: Auth service tests
+
+**File:** [`apps/api/src/modules/auth/service.test.ts`](apps/api/src/modules/auth/service.test.ts:1)
+
+Add a new describe block:
+
+```typescript
+describe('Registration toggle', () => {
+  it('should throw REGISTRATION_DISABLED when config disables registration', () => {
+    // This is a unit test for the error code that the controller checks.
+    // The actual config check happens in the controller (index.ts),
+    // not in the service. This test validates the error message convention.
+    try {
+      throw new Error('REGISTRATION_DISABLED');
+    } catch (err) {
+      expect((err as Error).message).toBe('REGISTRATION_DISABLED');
+    }
+  });
+});
+```
+
+---
+
+### Task 8: Add `registrationStatus()` to frontend API client
+
+**File:** [`apps/web/src/api/index.ts`](apps/web/src/api/index.ts:1)
+
+Add to the `authApi` object (after line 15, before the closing `};`):
+
+```typescript
+registrationStatus: () =>
+  api.get<{ enabled: boolean }>('/auth/registration-status'),
+```
+
+The complete `authApi` will look like:
+
+```typescript
+export const authApi = {
+  register: (data: { email: string; username: string; password: string; displayName?: string }) =>
+    api.post<{ user: AuthUser; accessToken: string; refreshToken: string }>('/auth/register', data),
+  login: (data: { email: string; password: string }) =>
+    api.post<{ user: AuthUser; accessToken: string; refreshToken: string }>('/auth/login', data),
+  refresh: (data: { refreshToken: string }) =>
+    api.post<{ user: AuthUser; accessToken: string; refreshToken: string }>('/auth/refresh', data),
+  forgotPassword: (data: { email: string }) =>
+    api.post<{ message: string }>('/auth/forgot-password', data),
+  resetPassword: (data: { token: string; newPassword: string }) =>
+    api.post<{ message: string }>('/auth/reset-password', data),
+  registrationStatus: () =>
+    api.get<{ enabled: boolean }>('/auth/registration-status'),
+};
+```
+
+---
+
+### Task 9: Update RegisterPage with status check
+
+**File:** [`apps/web/src/pages/auth/RegisterPage.tsx`](apps/web/src/pages/auth/RegisterPage.tsx:1)
+
+The page needs to:
+1. Check registration status on mount
+2. Show loading state while checking
+3. Show the registration form when enabled
+4. Show a friendly "closed" message when disabled
+5. Fall back to showing the form if the status check fails (API unreachable)
+
+```typescript
+import { type FormEvent, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { useAuth } from '../../contexts/AuthContext';
+import { useTranslation } from '../../contexts/I18nContext';
+import { authApi } from '../../api/index';
+
+export function RegisterPage() {
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  // Registration status state
+  const [statusLoading, setStatusLoading] = useState(true);
+  const [registrationEnabled, setRegistrationEnabled] = useState(true);
+
+  useEffect(() => {
+    async function checkStatus() {
+      try {
+        const { enabled } = await authApi.registrationStatus();
+        setRegistrationEnabled(enabled);
+      } catch {
+        // If the status check fails (API unreachable), default to showing the form.
+        // The actual registration attempt will still be guarded by the backend.
+        setRegistrationEnabled(true);
+      } finally {
+        setStatusLoading(false);
+      }
+    }
+    checkStatus();
+  }, []);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError('');
+
+    if (password !== confirmPassword) {
+      setError(t('auth.register.passwordsMismatch'));
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await register({ email, username, password, displayName: displayName || undefined });
+      navigate('/');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Registration failed';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // Loading state while checking registration status
+  if (statusLoading) {
+    return (
+      <div className='mx-auto max-w-md px-6 py-12 text-center'>
+        <p style={{ color: 'var(--text-secondary)' }}>Loading...</p>
+      </div>
+    );
+  }
+
+  // Registration disabled state
+  if (!registrationEnabled) {
+    return (
+      <div className='mx-auto max-w-md px-6 py-12'>
+        <h1 className='text-2xl font-bold' style={{ color: 'var(--text-primary)' }}>
+          {t('auth.register.title')}
+        </h1>
+        <div
+          className='mt-6 rounded p-6'
+          style={{ backgroundColor: 'var(--bg-secondary)', border: '1px solid var(--border-primary)' }}
+        >
+          <p className='text-base' style={{ color: 'var(--text-primary)' }}>
+            {t('auth.register.registrationClosed')}
+          </p>
+          <p className='mt-3 text-sm' style={{ color: 'var(--text-secondary)' }}>
+            {t('auth.register.hasAccount')}{' '}
+            <Link to='/login' style={{ color: 'var(--accent-primary)' }}>
+              {t('auth.register.logIn')}
+            </Link>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Normal registration form (existing code, unchanged)
+  return (
+    <div className='mx-auto max-w-md px-6 py-12'>
+      <h1 className='text-2xl font-bold' style={{ color: 'var(--text-primary)' }}>
+        {t('auth.register.title')}
+      </h1>
+      {error && (
+        <div
+          className='mt-4 rounded p-3 text-sm'
+          style={{ backgroundColor: 'var(--error)', color: 'white' }}
+        >
+          {error}
+        </div>
+      )}
+      <form onSubmit={handleSubmit} className='mt-6 flex flex-col gap-4'>
+        {/* ... existing form fields unchanged ... */}
+        <div>
+          <label
+            className='mb-1 block text-sm font-medium'
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            {t('auth.email')}
+          </label>
+          <input
+            type='email'
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder='you@example.com'
+            className='input-field'
+            required
+          />
+        </div>
+        <div>
+          <label
+            className='mb-1 block text-sm font-medium'
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            {t('auth.username')}
+          </label>
+          <input
+            type='text'
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder='coffee_lover'
+            className='input-field'
+            required
+          />
+        </div>
+        <div>
+          <label
+            className='mb-1 block text-sm font-medium'
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            {t('auth.register.displayName')}{' '}
+            <span style={{ color: 'var(--text-tertiary)' }}>({t('common.optional')})</span>
+          </label>
+          <input
+            type='text'
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder='Coffee Lover'
+            className='input-field'
+          />
+        </div>
+        <div>
+          <label
+            className='mb-1 block text-sm font-medium'
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            {t('auth.password')}
+          </label>
+          <input
+            type='password'
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder='At least 8 characters'
+            className='input-field'
+            required
+            minLength={8}
+          />
+        </div>
+        <div>
+          <label
+            className='mb-1 block text-sm font-medium'
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            {t('auth.confirmPassword')}
+          </label>
+          <input
+            type='password'
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder='Re-enter your password'
+            className='input-field'
+            required
+          />
+        </div>
+        <button type='submit' className='btn-primary' disabled={loading}>
+          {loading ? t('auth.register.creating') : t('nav.register')}
+        </button>
+      </form>
+      <p className='mt-4 text-sm' style={{ color: 'var(--text-secondary)' }}>
+        {t('auth.register.hasAccount')}{' '}
+        <Link to='/login' style={{ color: 'var(--accent-primary)' }}>
+          {t('auth.register.logIn')}
+        </Link>
+      </p>
+    </div>
+  );
+}
+```
+
+**Note:** You'll need to add the i18n key `auth.register.registrationClosed` with value `"New account registration is currently disabled."` to the translation files.
+
+---
+
+### Task 10: Update Navbar to conditionally hide register link
+
+**File:** [`apps/web/src/components/layout/Navbar.tsx`](apps/web/src/components/layout/Navbar.tsx:286)
+
+The Navbar needs to:
+1. Fetch registration status on mount (only for unauthenticated users)
+2. Conditionally render the register link
+
+Add imports at the top:
+
+```typescript
+// Add after existing imports:
+import { authApi } from '../../api/index';
+```
+
+Add state inside the `Navbar` component:
+
+```typescript
+// Add inside the Navbar component, after existing useState declarations:
+const [registrationEnabled, setRegistrationEnabled] = useState(true);
+
+useEffect(() => {
+  // Only check if user is not authenticated
+  if (user) return;
+  
+  authApi.registrationStatus()
+    .then(({ enabled }) => setRegistrationEnabled(enabled))
+    .catch(() => setRegistrationEnabled(true)); // Fallback: show link if check fails
+}, [user]);
+```
+
+Then modify the desktop register link (around lines 278-293) to be conditional:
+
+```typescript
+// Replace the unauthenticated desktop block (lines 278-293):
+: (
+  <>
+    <Link
+      to='/login'
+      className='rounded-sm text-sm text-[color:var(--text-secondary)] transition-colors duration-150 motion-reduce:duration-0 hover:text-[color:var(--text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]'
+    >
+      {t('nav.login')}
+    </Link>
+    {registrationEnabled && (
+      <Link
+        to='/register'
+        className='btn-primary text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]'
+      >
+        {t('nav.register')}
+      </Link>
+    )}
+  </>
+)}
+```
+
+And the mobile register link (around lines 450-467):
+
+```typescript
+// Replace the unauthenticated mobile block (lines 450-467):
+: (
+  <div className='flex flex-col gap-2'>
+    <Link
+      to='/login'
+      onClick={() => setIsMenuOpen(false)}
+      className='rounded-sm text-sm text-center text-[color:var(--text-secondary)] transition-colors duration-150 motion-reduce:duration-0 hover:text-[color:var(--text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]'
+    >
+      {t('nav.login')}
+    </Link>
+    {registrationEnabled && (
+      <Link
+        to='/register'
+        onClick={() => setIsMenuOpen(false)}
+        className='btn-primary text-sm text-center focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]'
+      >
+        {t('nav.register')}
+      </Link>
+    )}
+  </div>
+)}
+```
+
+---
+
+### Task 11: Frontend tests
+
+#### 11a: RegisterPage tests (new file)
+
+**File:** [`apps/web/src/pages/auth/RegisterPage.test.tsx`](apps/web/src/pages/auth/RegisterPage.test.tsx) **(CREATE NEW)**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { RegisterPage } from './RegisterPage';
+import { AuthProvider } from '../../contexts/AuthContext';
+import { I18nProvider } from '../../contexts/I18nContext';
+import { authApi } from '../../api/index';
+
+// Mock the auth API
+vi.mock('../../api/index', () => ({
+  authApi: {
+    registrationStatus: vi.fn(),
+    register: vi.fn(),
+    login: vi.fn(),
+    refresh: vi.fn(),
+    forgotPassword: vi.fn(),
+    resetPassword: vi.fn(),
+  },
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+  clearTokens: vi.fn(),
+  getAccessToken: vi.fn(() => null),
+  setAccessToken: vi.fn(),
+}));
+
+function renderRegisterPage() {
+  return render(
+    <MemoryRouter>
+      <I18nProvider>
+        <AuthProvider>
+          <RegisterPage />
+        </AuthProvider>
+      </I18nProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should show loading state while checking registration status', () => {
+    // Don't resolve the promise yet — loading state should show
+    vi.mocked(authApi.registrationStatus).mockReturnValue(new Promise(() => {}));
+    renderRegisterPage();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('should show registration form when enabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: true });
+    renderRegisterPage();
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('you@example.com')).toBeInTheDocument();
+    });
+  });
+
+  it('should show closed message when registration is disabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: false });
+    renderRegisterPage();
+    await waitFor(() => {
+      expect(screen.getByText(/registration.*closed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should show login link when registration is disabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: false });
+    renderRegisterPage();
+    await waitFor(() => {
+      const loginLink = screen.getByRole('link', { name: /log in/i });
+      expect(loginLink).toBeInTheDocument();
+      expect(loginLink.getAttribute('href')).toBe('/login');
+    });
+  });
+
+  it('should fall back to showing form when status check fails', async () => {
+    vi.mocked(authApi.registrationStatus).mockRejectedValue(new Error('Network error'));
+    renderRegisterPage();
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('you@example.com')).toBeInTheDocument();
+    });
+  });
+});
+```
+
+#### 11b: Navbar tests (extend existing)
+
+**File:** [`apps/web/src/components/layout/Navbar.test.tsx`](apps/web/src/components/layout/Navbar.test.tsx:1)
+
+Add new test cases to the existing Navbar test suite:
+
+```typescript
+describe('Registration toggle in Navbar', () => {
+  it('should show register link when registration is enabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: true });
+    renderNavbar({ user: null }); // unauthenticated
+    await waitFor(() => {
+      expect(screen.getByText(t('nav.register'))).toBeInTheDocument();
+    });
+  });
+
+  it('should hide register link when registration is disabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: false });
+    renderNavbar({ user: null }); // unauthenticated
+    await waitFor(() => {
+      expect(screen.queryByText(t('nav.register'))).not.toBeInTheDocument();
+    });
+  });
+
+  it('should still show login link when registration is disabled', async () => {
+    vi.mocked(authApi.registrationStatus).mockResolvedValue({ enabled: false });
+    renderNavbar({ user: null }); // unauthenticated
+    await waitFor(() => {
+      expect(screen.getByText(t('nav.login'))).toBeInTheDocument();
+    });
+  });
+
+  it('should not fetch registration status for authenticated users', async () => {
+    renderNavbar({ user: mockUser }); // authenticated
+    await waitFor(() => {
+      expect(authApi.registrationStatus).not.toHaveBeenCalled();
+    });
+  });
+});
+```
+
+---
+
+## Interaction State Matrix
+
+| Component | Loading | Enabled | Disabled | Error (API down) |
+|-----------|---------|---------|----------|------------------|
+| **RegisterPage** | "Loading..." text | Show registration form | Show "closed" message + login link | Show form (fallback — backend still guards) |
+| **Navbar (desktop)** | Show login link only (no flicker) | Show login + register links | Show login link only | Show both links (fallback) |
+| **Navbar (mobile)** | Show login link only (no flicker) | Show login + register links | Show login link only | Show both links (fallback) |
+
+---
+
+## Error/Rescue Map
+
+| Codepath | Failure Mode | Handling |
+|----------|-------------|----------|
+| `GET /auth/registration-status` | API unreachable (network error) | Frontend falls back to showing register form — backend still guards `POST /register` |
+| `POST /auth/register` when disabled | 403 REGISTRATION_DISABLED | Frontend shows error message; user can still log in |
+| `POST /auth/register` when enabled | Normal flow (409 conflict, etc.) | Existing error handling unchanged |
+| `ENABLE_REGISTRATION` env var missing | Defaults to `true` | Zod `.default('true')` — registrations remain open |
+| `ENABLE_REGISTRATION` env var invalid | Zod parse error at startup | Server exits with descriptive error (existing pattern) |
+
+---
+
+## Architectural Decisions
+
+1. **Env var over database toggle:** Follows existing `OPENAPI_ENABLED` pattern. Requires redeploy to change, but keeps the implementation simple and consistent with the codebase.
+
+2. **Dedicated status endpoint over error-only approach:** Provides clean UX — users know upfront if they can register. The extra API call is negligible (trivial endpoint, no DB query).
+
+3. **Fallback to showing form on status check failure:** If the API is unreachable, the user can still attempt registration. The backend guard is the authoritative check — the frontend status check is a UX optimization, not a security boundary.
+
+4. **No auth on status endpoint:** The endpoint is public. Registration status is not sensitive information — it's a feature flag, not user data.
+
+---
+
+## Out of Scope
+
+- No admin panel UI toggle (env var only)
+- No per-user registration control (invite codes, waitlists)
+- No registration rate limiting changes
+- No changes to login, token refresh, or password reset flows
+- No email notification changes
+- No database schema changes
+- No changes to the admin setup/seed flow
+
+---
+
+## Verification Checklist
+
+- [ ] `ENABLE_REGISTRATION=true` → registrations work normally
+- [ ] `ENABLE_REGISTRATION=false` → `POST /register` returns 403
+- [ ] `ENABLE_REGISTRATION=false` → `GET /registration-status` returns `{ enabled: false }`
+- [ ] `ENABLE_REGISTRATION=false` → Navbar hides register link (desktop + mobile)
+- [ ] `ENABLE_REGISTRATION=false` → RegisterPage shows "closed" message with login link
+- [ ] `ENABLE_REGISTRATION=false` → Login still works
+- [ ] `ENABLE_REGISTRATION` not set → defaults to `true`
+- [ ] `ENABLE_REGISTRATION=invalid` → server fails to start with clear error
+- [ ] All backend tests pass: `deno task test --filter=@brewform/api`
+- [ ] All frontend tests pass: `deno task test --filter=@brewform/web`
+- [ ] TypeScript compilation passes: `deno task check`


### PR DESCRIPTION
## Add `ENABLE_REGISTRATION` environment variable toggle

### Motivation

Today anyone can register at any time with no mechanism to close registrations. If an admin wants to stop registrations (spam wave, invite-only period), they have no option short of taking the server down. This PR introduces a single env var toggle — `ENABLE_REGISTRATION` (default `true`) — that blocks new registrations at the API level and reflects the state in the frontend.

---

### Feature Overview

| Layer | Change |
|-------|--------|
| **Config** | `ENABLE_REGISTRATION` env var (Zod schema, `z.enum(["true","false"]).default("true")`) |
| **Backend** | `POST /auth/register` returns `403 REGISTRATION_DISABLED` when disabled; `GET /auth/registration-status` (public) returns `{ enabled: boolean }` |
| **Frontend** | `RegisterPage` shows loading/closed/form states; `Navbar` conditionally hides "Sign Up" link |
| **i18n** | `auth.register.registrationClosed` key in `en.json` and `tr.json` |
| **Docs** | Registers new `GET /auth/registration-status` endpoint, error response format, and UI state matrix in `docs/auth.md` |

---

### Architectural Decisions

**1. Config check belongs in the service layer, not the route handler.**

Initially the `ENABLE_REGISTRATION` guard was an early-return in the route handler. This made testing impossible (the config singleton is loaded at module import time — you can't change env vars after import). The guard was moved into `authService.register()` where it throws `REGISTRATION_DISABLED`. The route handler catches it in the existing try/catch alongside `EMAIL_ALREADY_EXISTS` and `USERNAME_ALREADY_EXISTS`, with structured IP logging. This follows the existing error-handling pattern and makes the business rule testable at the service layer.

**2. `reloadConfig()` — a testing seam for the singleton config.**

`env.ts` exports `config` as a module-level singleton (`export const config = loadEnv()`). To test both enabled and disabled paths in the same test file, `config` was changed to a `let` binding and a `reloadConfig()` function was added that re-parses `Deno.env.toObject()` and reassigns the exported variable. ES module live bindings ensure all importers see the updated value immediately. This is scoped to tests via `afterAll` cleanup:

```typescript
Deno.env.set('ENABLE_REGISTRATION', 'false');
reloadConfig();
// ... test the disabled path ...
```

Without this, the only way to test the disabled path would be separate test files with different env configurations.

**3. `z.enum(["true","false"])` — not `z.coerce.boolean()`.**

Using `z.enum` with `.transform(v => v === 'true')` matches the existing `OPENAPI_ENABLED` pattern. `z.coerce.boolean()` would incorrectly coerce the string `"false"` to `true` (since `Boolean("false")` is `true` in JavaScript).

**4. Navbar only fetches registration status for unauthenticated users.**

There's no need to check the status for authenticated users — they're already logged in. This avoids an unnecessary API call on every page navigation for the common case.

**5. RegisterPage error fallback: enabled.**

If the `GET /auth/registration-status` call fails (API unreachable, network error), the RegisterPage falls back to showing the registration form. This is the safer default — we'd rather let a user attempt registration and get a clear error than block them because of a transient network issue.

---

### Test Infrastructure Changes

The single largest change in this PR is fixing tests that were testing throw-string-literals instead of actual code paths.

**`apps/api/src/modules/auth/index.test.ts`**

Before:
```typescript
it('should return 403 when registration is disabled', async () => {
  try {
    throw new Error('REGISTRATION_DISABLED');
  } catch (err) {
    expect((err as Error).message).toBe('REGISTRATION_DISABLED');
  }
});
```

After — actual Hono integration test with env var toggle via `reloadConfig()`:
```typescript
it('should return 403 when registration is disabled', async () => {
  Deno.env.set('ENABLE_REGISTRATION', 'false');
  reloadConfig();

  const res = await app.request('/auth/register', {
    method: 'POST',
    headers: { 'Content-Type': 'application/json' },
    body: JSON.stringify({ email: 'newuser@test.com', username: 'newuser', password: 'Test12345!' }),
  });
  expect(res.status).toBe(403);
  const body = await res.json();
  expect(body.success).toBe(false);
  expect(body.error.code).toBe('REGISTRATION_DISABLED');
});
```

**`apps/api/src/modules/auth/service.test.ts`**

Before:
```typescript
it('should throw REGISTRATION_DISABLED when config disables registration', () => {
  try {
    throw new Error('REGISTRATION_DISABLED');
  } catch (err) {
    expect((err as Error).message).toBe('REGISTRATION_DISABLED');
  }
});
```

After — calls the real `register()` function with env toggled:
```typescript
it('should throw REGISTRATION_DISABLED when config disables registration', async () => {
  Deno.env.set('ENABLE_REGISTRATION', 'false');
  reloadConfig();

  await expect(register({
    email: 'test@test.com',
    username: 'testuser',
    password: 'Test12345!',
  })).rejects.toThrow('REGISTRATION_DISABLED');
});
```

---

### Pre-existing Test Failures Fixed

While working on this feature, 6 pre-existing test failures in the web test suite were fixed:

| File | Failure | Fix |
|------|---------|-----|
| `relative-date.test.ts` | `fast-check` generated `new Date(NaN)` as a counterexample in 3 PBTs, causing `toISOString()` to throw `RangeError` | Added `.filter(d => !isNaN(d.getTime()))` to the `dateArb` arbitrary |
| `TasteNotesFilter.test.tsx` | `screen.getByRole('button')` couldn't find the trigger because the component uses a `<button>` with `role="combobox"` | Changed to `screen.getByRole('combobox')` |
| `IntensityDots.test.tsx` | `expect(dot.style.border).toBe('')` failed because JSDOM returns `'medium'` as the default value of the `border` shorthand when no inline border is set | Changed assertion to verify `borderStyle` is `'none'` and border value is not the empty-dot value |
| `BeanSection.test.tsx` | Same `new Date(NaN)` issue as `relative-date.test.ts` in a PBT that maps date arbitraries through `toISOString()` | Added `.filter(d => !isNaN(d.getTime()))` before the `.map()` |
| `Footer.test.tsx` | `screen.getAllByRole('option')` threw synchronously when the popup animation hadn't finished rendering — a flaky timing issue | Changed to `screen.findAllByRole('option')` (async) |

These were all genuine bugs in test code (not production code). Root cause analysis:

- **PBT NaN dates**: `fast-check`'s `fc.date()` can produce `new Date(NaN)` when shrinking counterexamples. The `noNaN` filter is the recommended mitigation.
- **Combobox role**: The `@base-ui-components/react` select renders `<button role="combobox">`, not `<button role="button">`. `getByRole` queries by ARIA role, not HTML element.
- **JSDOM border default**: `elm.style.border` in JSDOM returns `'medium'` for elements without inline border styles, which differs from real browsers where it returns `''`. This is a known JSDOM quirk.
- **Popup timing**: `getAllByRole` is synchronous and throws if no match is found; `findAllByRole` retries until a timeout. The popup uses a portal with animation frames that can cause a brief rendering delay.

---

### Commits

This PR is not yet committed — the user will review and create commits.

---

### Test Results

```
API:  46 passed (310 steps) | 0 failed
Web:  511 passed             | 0 failed (36 test files)
```

All API and web tests pass cleanly. No regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration can now be toggled on/off through environment configuration; when disabled, the Sign Up link is hidden from navigation and the registration page displays a closed-registration message with a login link
  * New registration status endpoint available to check current registration availability

* **Documentation**
  * Added comprehensive authentication documentation for the registration toggle feature; updated UI translations for closed registration messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ardakilic/BrewForm/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->