### PR TITLE
fix(vite,ci) fix vite deno based build errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Type check
         run: deno task check
 
+      - name: Build
+        run: deno task build
+
   test:
     runs-on: ubuntu-latest
     needs: quality

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Type check
         run: deno task check
 
+      - name: Build
+        run: deno task build
+
   test-unit:
     runs-on: ubuntu-latest
     needs: check

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ test-specific: ## Run specific test (use filter=)
 
 # --- Database ---
 
-DRIZZLE_KIT := npm:drizzle-kit@0.31.10
+DRIZZLE_KIT := npm:drizzle-kit@0.31
 
 db-migrate: ## Run database migrations
 	docker compose run --rm app sh -c "cd packages/db && deno run -A $(DRIZZLE_KIT) migrate"

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,31 @@ fmt: ## Format all code
 fmt-check: ## Check formatting without changes
 	docker compose run --rm --no-deps app deno fmt --check
 
-check: install ## Type-check the API entrypoint
-	docker compose run --rm --no-deps app deno check apps/api/src/main.ts
+check: ## Type-check all workspaces (api, web, db, shared)
+	docker compose run --rm --no-deps app deno task check
+
+check-api: ## Type-check API only
+	docker compose run --rm --no-deps app deno task check:api
+
+check-web: ## Lint web frontend
+	docker compose run --rm --no-deps app deno task check:web
+
+check-db: ## Type-check database package
+	docker compose run --rm --no-deps app deno task check:db
+
+check-shared: ## Type-check shared package
+	docker compose run --rm --no-deps app deno task check:shared
+
+# --- Build ---
+
+build-api: ## Build API (email templates)
+	docker compose run --rm --no-deps app deno task build:api
+
+build-web: ## Build React SPA (outputs to apps/web/dist/)
+	docker compose run --rm --no-deps app deno task build:web
+
+build-shared: ## Type-check shared package as build artifact
+	docker compose run --rm --no-deps app deno task build:shared
 
 # --- Testing ---
 
@@ -115,7 +138,7 @@ setup: ## Run admin setup
 #
 # Both services run as long-running containers (not one-shot `run`).
 # Use `make down` or Ctrl-C + `docker compose --profile dev down` to stop.
-dev: up ## Start full-stack dev environment
+dev: up ## Start full-stack dev environment (API :8000 + web :5173 with HMR)
 	docker compose --profile dev up app web-dev
 
 # Start API dev server only (hot reload on :8000).
@@ -130,17 +153,17 @@ web-dev: ## Start Vite web dev server only
 # --- Frontend ---
 
 # Build the React SPA (outputs to apps/web/dist/).
-web-build: ## Build the React SPA
-	docker compose run --rm --no-deps app sh -c "cd apps/web && deno run -A npm:vite build"
+# Legacy alias — prefer `make build-web` for consistency with build-api / build-shared.
+web-build: build-web ## Build the React SPA
 
 # Preview production build — builds the web app and serves it via Caddy on :8080
 # alongside the production-like API on :8000.
-preview: web-build up ## Build + preview production build
+preview: build-web up ## Build + preview production build
 	docker compose --profile preview up app-preview web
 
 # --- CI ---
 
-ci: fmt-check lint check check-tests test-coverage ## Run full CI pipeline
+ci: fmt-check lint check build-web check-tests test-coverage ## Run full CI pipeline (fmt, lint, check, build, test)
 
 # ── Serena MCP ──────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -78,19 +78,36 @@ Open **http://localhost:5173** for the web app and **http://localhost:8000** for
 ## Development
 
 ```bash
-make dev           # Start full-stack dev server (API :8000 + web :5173 with HMR)
-make dev-api       # Start API only with hot reload (:8000)
-make web-dev       # Start web dev server only (:5173, requires API already running)
-make preview       # Build web and preview production build (API :8000 + web :8080)
-make lint          # Lint the codebase
-make fmt           # Format the codebase
-make fmt-check     # Check formatting
-make check         # Type check all workspaces
-make test          # Run all tests
-make test-coverage # Run tests with coverage
-make test-api      # Run API tests only
-make test-shared   # Run shared package tests only
-make ci            # Full CI check (fmt-check, lint, check, test-coverage)
+# Dev servers
+make dev            # Start full-stack dev server (API :8000 + web :5173 with HMR)
+make dev-api        # Start API only with hot reload (:8000)
+make web-dev        # Start web dev server only (:5173, requires API already running)
+
+# Build
+make build-api      # Build API (compile email templates)
+make build-web      # Build React SPA for production (output: apps/web/dist/)
+make build-shared   # Type-check shared package as build artifact
+make preview        # Build web + preview production build (API :8000 + web :8080)
+
+# Code quality
+make check          # Type-check all workspaces (api, web, db, shared)
+make check-api      # Type-check API only
+make check-web      # Lint web frontend
+make check-db       # Type-check database package
+make check-shared   # Type-check shared package
+make lint           # Lint all apps and packages
+make fmt            # Format the codebase
+make fmt-check      # Check formatting without changes
+
+# Testing
+make test           # Run all tests
+make test-coverage  # Run tests with coverage
+make test-api       # Run API tests only
+make test-shared    # Run shared package tests only
+make check-tests    # Type-check test files
+
+# CI
+make ci             # Full CI pipeline (fmt, lint, check, build, test)
 ```
 
 ## Serena MCP
@@ -141,11 +158,12 @@ See [docs/serena-mcp.md](docs/serena-mcp.md) for detailed setup, architecture, a
 > are started on-demand via `make dev`. This prevents a "port already allocated" error that would
 > occur if the API container were already running when you run `make dev`.
 
-> **Why `deno task` instead of a task runner?**  
-> Deno's built-in task runner with `--recursive` (run task in all workspace members), `--filter`
-> (target specific members), and `--cwd` (run in a specific directory) covers all orchestration
-> needs. No external task runner required — the `deno.json` `tasks` field is the single source of
-> truth for all build, test, lint, and dev workflows.
+> **Why `deno task` instead of a task runner?**
+> Deno's built-in task runner with `--cwd` (run in a specific directory) and explicit per-workspace
+> sub-tasks covers all orchestration needs. Granular tasks like `check:api`, `build:web`, and
+> `dev:api` compose into aggregate `check`, `build`, and `dev` tasks. No external task runner
+> required — the `deno.json` `tasks` field is the single source of truth for all build, test, lint,
+> and dev workflows.
 
 ## Database
 

--- a/apps/web/deno.json
+++ b/apps/web/deno.json
@@ -4,6 +4,7 @@
   "tasks": {
     "dev": "deno run -A npm:vite --host 0.0.0.0 --port 5173",
     "build": "deno run -A npm:vite build",
+    "check": "deno lint src/",
     "preview": "deno run -A npm:vite preview",
     "lint": "deno lint src/",
     "test": "deno run -A npm:vitest run",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "vite": "^8.0.0",
+    "@deno/vite-plugin": "^2.0.0",
     "@vitejs/plugin-react": "^6.0.0",
     "tailwindcss": "^4.1.0",
     "@tailwindcss/vite": "^4.1.0",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
-import { join, resolve } from 'jsr:@std/path';
+import deno from '@deno/vite-plugin';
+import { join, resolve } from 'node:path';
 
 // When running inside Docker Compose, the API is reachable via the service name
 // "app" (http://app:8000). Outside Docker (bare Deno), it's localhost:8000.
@@ -14,7 +15,7 @@ const monorepoRoot = resolve(import.meta.dirname!, '../..');
 const sharedSrc = join(monorepoRoot, 'packages/shared/src');
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [deno(), react(), tailwindcss()],
   resolve: {
     alias: {
       // Local path alias

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
-import { join, resolve } from 'jsr:@std/path';
+import deno from '@deno/vite-plugin';
+import { join, resolve } from 'node:path';
 
 const monorepoRoot = resolve(import.meta.dirname!, '../..');
 const sharedSrc = join(monorepoRoot, 'packages/shared/src');
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [deno(), react()],
   resolve: {
     alias: {
       '@': resolve(import.meta.dirname!, './src'),

--- a/apps/web/vitest.pbt.config.ts
+++ b/apps/web/vitest.pbt.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
-import { join, resolve } from 'jsr:@std/path';
+import deno from '@deno/vite-plugin';
+import { join, resolve } from 'node:path';
 
 const monorepoRoot = resolve(import.meta.dirname!, '../..');
 const sharedSrc = join(monorepoRoot, 'packages/shared/src');
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [deno(), react()],
   resolve: {
     alias: {
       '@': resolve(import.meta.dirname!, './src'),

--- a/deno.json
+++ b/deno.json
@@ -5,22 +5,40 @@
   },
   "nodeModulesDir": "auto",
   "tasks": {
-    "dev": "deno task --recursive dev",
-    "build": "deno task --recursive build",
+    "dev": "deno task dev:api & deno task dev:web",
+    "dev:api": "deno task --cwd apps/api dev",
+    "dev:web": "deno task --cwd apps/web dev",
+
+    "check": "deno task check:api && deno task check:web && deno task check:db && deno task check:shared",
+    "check:api": "deno task --cwd apps/api check",
+    "check:web": "deno task --cwd apps/web check",
+    "check:db": "deno task --cwd packages/db check",
+    "check:shared": "deno task --cwd packages/shared check",
+
+    "build": "deno task build:api && deno task build:web && deno task build:shared",
+    "build:api": "deno task --cwd apps/api build",
+    "build:web": "deno task --cwd apps/web build",
+    "build:shared": "deno task --cwd packages/shared build",
+
     "lint": "deno lint apps/ packages/",
     "fmt": "deno fmt",
     "fmt-check": "deno fmt --check",
-    "check": "deno task --cwd apps/api check && deno task --cwd packages/db check && deno task --cwd packages/shared check",
-    "test": "deno task --recursive test",
+
+    "test": "deno task test:api && deno task test:shared && deno task test:db",
+    "test:api": "deno task --cwd apps/api test",
+    "test:shared": "deno task --cwd packages/shared test",
+    "test:db": "deno task --cwd packages/db test",
     "test-coverage": "deno test --no-check --allow-all --coverage=coverage/ apps/api/src/ packages/shared/src/",
     "coverage-report": "deno coverage coverage/",
+
     "db:generate": "deno task --cwd packages/db generate",
     "db:migrate": "deno task --cwd packages/db migrate",
     "db:push": "deno task --cwd packages/db push",
     "db:studio": "deno task --cwd packages/db studio --host=0.0.0.0 --port=5555",
     "db:seed": "deno run --allow-all packages/db/src/seed.ts",
+
     "email-build": "deno task --cwd apps/api email-build",
-    "ci": "deno task fmt-check && deno task lint && deno task check && deno task test-coverage"
+    "ci": "deno task fmt-check && deno task lint && deno task check && deno task build && deno task test-coverage"
   },
   "compilerOptions": {
     "strict": true,

--- a/deno.lock
+++ b/deno.lock
@@ -1,17 +1,14 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/assert@^1.0.19": "1.0.19",
-    "jsr:@std/expect@*": "1.0.19",
     "jsr:@std/fs@*": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.13",
-    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/path@*": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
-    "jsr:@std/testing@*": "1.0.18",
     "npm:@base-ui/react@1": "1.4.1_@types+react@19.2.14_date-fns@4.1.0_react@19.2.6_react-dom@19.2.6__react@19.2.6",
-    "npm:@hono/standard-validator@0.2": "0.2.2_@standard-schema+spec@1.1.0_hono@4.12.18",
-    "npm:@hono/zod-validator@0.8": "0.8.0_hono@4.12.18_zod@4.4.3",
+    "npm:@deno/vite-plugin@2": "2.0.2_vite@8.0.13",
+    "npm:@hono/standard-validator@0.2": "0.2.2_@standard-schema+spec@1.1.0_hono@4.12.19",
+    "npm:@hono/zod-validator@0.8": "0.8.0_hono@4.12.19_zod@4.4.3",
     "npm:@jsr/std__expect@^1.0.19": "1.0.19",
     "npm:@jsr/std__testing@^1.0.18": "1.0.18",
     "npm:@tailwindcss/vite@^4.1.0": "4.3.0_vite@8.0.13",
@@ -27,12 +24,10 @@
     "npm:bcryptjs@3": "3.0.3",
     "npm:date-fns@^4.1.0": "4.1.0",
     "npm:drizzle-kit@0.31": "0.31.10",
-    "npm:drizzle-kit@0.31.10": "0.31.10",
     "npm:drizzle-orm@0.45": "0.45.2_postgres@3.4.9",
-    "npm:fast-check@*": "4.8.0",
     "npm:fast-check@4": "4.8.0",
-    "npm:hono-openapi@1": "1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.18_hono@4.12.18_zod@4.4.3",
-    "npm:hono@^4.7.0": "4.12.18",
+    "npm:hono-openapi@1": "1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.19_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-community+standard-openapi@0.2.9__@standard-community+standard-json@0.3.5___@standard-schema+spec@1.1.0___@types+json-schema@7.0.15___quansync@0.2.11___zod@4.4.3__@standard-schema+spec@1.1.0__openapi-types@12.1.3__zod@4.4.3__@types+json-schema@7.0.15__quansync@0.2.11_@types+json-schema@7.0.15_hono@4.12.19_openapi-types@12.1.3_@standard-schema+spec@1.1.0_quansync@0.2.11_zod@4.4.3",
+    "npm:hono@^4.7.0": "4.12.19",
     "npm:jsdom@29": "29.1.1",
     "npm:mjml@*": "5.2.1_typescript@6.0.3",
     "npm:mjml@5": "5.2.1_typescript@6.0.3",
@@ -43,35 +38,20 @@
     "npm:postgres@^3.4.5": "3.4.9",
     "npm:qrcode@^1.5.4": "1.5.4",
     "npm:react-dom@^19.1.0": "19.2.6_react@19.2.6",
-    "npm:react-router@^7.5.0": "7.15.0_react@19.2.6_react-dom@19.2.6__react@19.2.6",
+    "npm:react-router@^7.5.0": "7.15.1_react@19.2.6_react-dom@19.2.6__react@19.2.6",
     "npm:react@^19.1.0": "19.2.6",
     "npm:tailwindcss@^4.1.0": "4.3.0",
     "npm:typescript@6": "6.0.3",
     "npm:vite@*": "8.0.13",
     "npm:vite@8": "8.0.13",
-    "npm:vitest@*": "4.1.6_@vitest+coverage-v8@4.1.6_jsdom@29.1.1_vite@8.0.13",
     "npm:vitest@4": "4.1.6_@vitest+coverage-v8@4.1.6_jsdom@29.1.1_vite@8.0.13",
     "npm:zod@4": "4.4.3"
   },
   "jsr": {
-    "@std/assert@1.0.19": {
-      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.12"
-      ]
-    },
-    "@std/expect@1.0.19": {
-      "integrity": "25271785688c7ff902fa54875d6aa4001f552c5578f7f0fefb5b5aac1fc2ed8a",
-      "dependencies": [
-        "jsr:@std/assert",
-        "jsr:@std/internal@^1.0.13",
-        "jsr:@std/path@^1.1.4"
-      ]
-    },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
-        "jsr:@std/internal@^1.0.12",
+        "jsr:@std/internal",
         "jsr:@std/path@^1.1.4"
       ]
     },
@@ -81,14 +61,7 @@
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
-        "jsr:@std/internal@^1.0.12"
-      ]
-    },
-    "@std/testing@1.0.18": {
-      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
-      "dependencies": [
-        "jsr:@std/assert",
-        "jsr:@std/internal@^1.0.13"
+        "jsr:@std/internal"
       ]
     }
   },
@@ -236,6 +209,14 @@
     "@csstools/css-tokenizer@4.0.0": {
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="
     },
+    "@deno/vite-plugin@2.0.2_vite@8.0.13": {
+      "integrity": "sha512-bzuKApn9Jr2x1jSrbuJEJzy++8LUwjFVOAopAbepcE3RgYzdcPEWd36PSp7P5dNMQlNnQlgtm3MeNbcKZ/Eh/Q==",
+      "dependencies": [
+        "@deno/loader@npm:@jsr/deno__loader@0.5.0",
+        "@std/jsonc@npm:@jsr/std__jsonc@1.0.2",
+        "vite"
+      ]
+    },
     "@drizzle-team/brocli@0.10.2": {
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="
     },
@@ -279,8 +260,8 @@
       "os": ["aix"],
       "cpu": ["ppc64"]
     },
-    "@esbuild/aix-ppc64@0.27.7": {
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+    "@esbuild/aix-ppc64@0.28.0": {
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "os": ["aix"],
       "cpu": ["ppc64"]
     },
@@ -294,8 +275,8 @@
       "os": ["android"],
       "cpu": ["arm64"]
     },
-    "@esbuild/android-arm64@0.27.7": {
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+    "@esbuild/android-arm64@0.28.0": {
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "os": ["android"],
       "cpu": ["arm64"]
     },
@@ -309,8 +290,8 @@
       "os": ["android"],
       "cpu": ["arm"]
     },
-    "@esbuild/android-arm@0.27.7": {
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+    "@esbuild/android-arm@0.28.0": {
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "os": ["android"],
       "cpu": ["arm"]
     },
@@ -324,8 +305,8 @@
       "os": ["android"],
       "cpu": ["x64"]
     },
-    "@esbuild/android-x64@0.27.7": {
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+    "@esbuild/android-x64@0.28.0": {
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "os": ["android"],
       "cpu": ["x64"]
     },
@@ -339,8 +320,8 @@
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@esbuild/darwin-arm64@0.27.7": {
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+    "@esbuild/darwin-arm64@0.28.0": {
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
@@ -354,8 +335,8 @@
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@esbuild/darwin-x64@0.27.7": {
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+    "@esbuild/darwin-x64@0.28.0": {
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
@@ -369,8 +350,8 @@
       "os": ["freebsd"],
       "cpu": ["arm64"]
     },
-    "@esbuild/freebsd-arm64@0.27.7": {
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+    "@esbuild/freebsd-arm64@0.28.0": {
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "os": ["freebsd"],
       "cpu": ["arm64"]
     },
@@ -384,8 +365,8 @@
       "os": ["freebsd"],
       "cpu": ["x64"]
     },
-    "@esbuild/freebsd-x64@0.27.7": {
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+    "@esbuild/freebsd-x64@0.28.0": {
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "os": ["freebsd"],
       "cpu": ["x64"]
     },
@@ -399,8 +380,8 @@
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@esbuild/linux-arm64@0.27.7": {
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+    "@esbuild/linux-arm64@0.28.0": {
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
@@ -414,8 +395,8 @@
       "os": ["linux"],
       "cpu": ["arm"]
     },
-    "@esbuild/linux-arm@0.27.7": {
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+    "@esbuild/linux-arm@0.28.0": {
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "os": ["linux"],
       "cpu": ["arm"]
     },
@@ -429,8 +410,8 @@
       "os": ["linux"],
       "cpu": ["ia32"]
     },
-    "@esbuild/linux-ia32@0.27.7": {
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+    "@esbuild/linux-ia32@0.28.0": {
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "os": ["linux"],
       "cpu": ["ia32"]
     },
@@ -444,8 +425,8 @@
       "os": ["linux"],
       "cpu": ["loong64"]
     },
-    "@esbuild/linux-loong64@0.27.7": {
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+    "@esbuild/linux-loong64@0.28.0": {
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "os": ["linux"],
       "cpu": ["loong64"]
     },
@@ -459,8 +440,8 @@
       "os": ["linux"],
       "cpu": ["mips64el"]
     },
-    "@esbuild/linux-mips64el@0.27.7": {
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+    "@esbuild/linux-mips64el@0.28.0": {
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "os": ["linux"],
       "cpu": ["mips64el"]
     },
@@ -474,8 +455,8 @@
       "os": ["linux"],
       "cpu": ["ppc64"]
     },
-    "@esbuild/linux-ppc64@0.27.7": {
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+    "@esbuild/linux-ppc64@0.28.0": {
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "os": ["linux"],
       "cpu": ["ppc64"]
     },
@@ -489,8 +470,8 @@
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
-    "@esbuild/linux-riscv64@0.27.7": {
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+    "@esbuild/linux-riscv64@0.28.0": {
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
@@ -504,8 +485,8 @@
       "os": ["linux"],
       "cpu": ["s390x"]
     },
-    "@esbuild/linux-s390x@0.27.7": {
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+    "@esbuild/linux-s390x@0.28.0": {
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "os": ["linux"],
       "cpu": ["s390x"]
     },
@@ -519,8 +500,8 @@
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@esbuild/linux-x64@0.27.7": {
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+    "@esbuild/linux-x64@0.28.0": {
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
@@ -529,8 +510,8 @@
       "os": ["netbsd"],
       "cpu": ["arm64"]
     },
-    "@esbuild/netbsd-arm64@0.27.7": {
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+    "@esbuild/netbsd-arm64@0.28.0": {
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "os": ["netbsd"],
       "cpu": ["arm64"]
     },
@@ -544,8 +525,8 @@
       "os": ["netbsd"],
       "cpu": ["x64"]
     },
-    "@esbuild/netbsd-x64@0.27.7": {
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+    "@esbuild/netbsd-x64@0.28.0": {
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "os": ["netbsd"],
       "cpu": ["x64"]
     },
@@ -554,8 +535,8 @@
       "os": ["openbsd"],
       "cpu": ["arm64"]
     },
-    "@esbuild/openbsd-arm64@0.27.7": {
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+    "@esbuild/openbsd-arm64@0.28.0": {
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "os": ["openbsd"],
       "cpu": ["arm64"]
     },
@@ -569,8 +550,8 @@
       "os": ["openbsd"],
       "cpu": ["x64"]
     },
-    "@esbuild/openbsd-x64@0.27.7": {
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+    "@esbuild/openbsd-x64@0.28.0": {
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "os": ["openbsd"],
       "cpu": ["x64"]
     },
@@ -579,8 +560,8 @@
       "os": ["openharmony"],
       "cpu": ["arm64"]
     },
-    "@esbuild/openharmony-arm64@0.27.7": {
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+    "@esbuild/openharmony-arm64@0.28.0": {
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "os": ["openharmony"],
       "cpu": ["arm64"]
     },
@@ -594,8 +575,8 @@
       "os": ["sunos"],
       "cpu": ["x64"]
     },
-    "@esbuild/sunos-x64@0.27.7": {
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+    "@esbuild/sunos-x64@0.28.0": {
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "os": ["sunos"],
       "cpu": ["x64"]
     },
@@ -609,8 +590,8 @@
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@esbuild/win32-arm64@0.27.7": {
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+    "@esbuild/win32-arm64@0.28.0": {
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
@@ -624,8 +605,8 @@
       "os": ["win32"],
       "cpu": ["ia32"]
     },
-    "@esbuild/win32-ia32@0.27.7": {
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+    "@esbuild/win32-ia32@0.28.0": {
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "os": ["win32"],
       "cpu": ["ia32"]
     },
@@ -639,8 +620,8 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@esbuild/win32-x64@0.27.7": {
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+    "@esbuild/win32-x64@0.28.0": {
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
@@ -671,14 +652,14 @@
     "@floating-ui/utils@0.2.11": {
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
     },
-    "@hono/standard-validator@0.2.2_@standard-schema+spec@1.1.0_hono@4.12.18": {
+    "@hono/standard-validator@0.2.2_@standard-schema+spec@1.1.0_hono@4.12.19": {
       "integrity": "sha512-mJ7W84Bt/rSvoIl63Ynew+UZOHAzzRAoAXb3JaWuxAkM/Lzg+ZHTCUiz77KOtn2e623WNN8LkD57Dk0szqUrIw==",
       "dependencies": [
         "@standard-schema/spec",
         "hono"
       ]
     },
-    "@hono/zod-validator@0.8.0_hono@4.12.18_zod@4.4.3": {
+    "@hono/zod-validator@0.8.0_hono@4.12.19_zod@4.4.3": {
       "integrity": "sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w==",
       "dependencies": [
         "hono",
@@ -723,6 +704,10 @@
         "@jridgewell/sourcemap-codec"
       ]
     },
+    "@jsr/deno__loader@0.5.0": {
+      "integrity": "sha512-sf/YBwnyAsbyeYYB71Zdj2Ca2Q9tt25EZpAiZdDA9W7Mm3GcpjA2WMeqj19xPIurZK12G3OAsa5yrtPB7E+gvA==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/deno__loader/0.5.0.tgz"
+    },
     "@jsr/std__assert@1.0.19": {
       "integrity": "sha512-pEj6RPkGbqlgRmyKwATp4cUs6+ijxtdrv3bq8v1d2I2CEcMEyPaO8cVKro61wGRDH4cNg8Zx6haztvK/9m7gkA==",
       "dependencies": [
@@ -736,6 +721,10 @@
         "@jsr/std__data-structures"
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__async/1.3.0.tgz"
+    },
+    "@jsr/std__bytes@1.0.6": {
+      "integrity": "sha512-St6yKggjFGhxS52IFLJWvkchRFbAKg2Xh8UxA4S1EGz7GJ2Ui+ssDDldj/w2c8vCxvl6qgR0HaYbKeFJNqujmA==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__bytes/1.0.6.tgz"
     },
     "@jsr/std__data-structures@1.0.11": {
       "integrity": "sha512-SeQ3rBVo+sj8e8XVfW3eTMJY3ygY69HW2H29j73tFJ5kHjnTMOURWX4PMiN1AOBcnNPm+l2UcQMmh6FDegUrnQ==",
@@ -765,12 +754,33 @@
       "integrity": "sha512-FIyYlSZkAwdupuTybRiU53MnrQUsyulhf6bPZ4bBILl1KqHCkKUlJ5TnLIATNezA5Yg7fAn64EE4vuHep2Urog==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__internal/1.0.13.tgz"
     },
+    "@jsr/std__json@1.1.0": {
+      "integrity": "sha512-a9Eylh7ox33tFn5RxhESnvI4akpefQP5Qn+ePz3Ih4IJ/EPA8p0SKq0aztRfN1sGDhfyWMPWwlUcwNxONt+Ncg==",
+      "dependencies": [
+        "@jsr/std__streams"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__json/1.1.0.tgz"
+    },
+    "@jsr/std__jsonc@1.0.2": {
+      "integrity": "sha512-Lva9lY0UPvvgmS8INUHU8Tqijq2SPfdlnSAvofOYUBiB6ALPxo0rTMznRlY5Wt30nMW+rhMTha1x5RGpMBKUoQ==",
+      "dependencies": [
+        "@jsr/std__json"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__jsonc/1.0.2.tgz"
+    },
     "@jsr/std__path@1.1.4": {
       "integrity": "sha512-SK4u9H6NVTfolhPdlvdYXfNFefy1W04AEHWJydryYbk+xqzNiVmr5o7TLJLJFqwHXuwMRhwrn+mcYeUfS0YFaA==",
       "dependencies": [
         "@jsr/std__internal"
       ],
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__path/1.1.4.tgz"
+    },
+    "@jsr/std__streams@1.1.0": {
+      "integrity": "sha512-0yP/bIRAgcpdIg1o/XSYnVmCs3a7rtfKfhPPiKo7GFEtvF2qngWKJ80u8xN+D8o3otsrf/Ta90XiNj5WZJfFgg==",
+      "dependencies": [
+        "@jsr/std__bytes"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__streams/1.1.0.tgz"
     },
     "@jsr/std__testing@1.0.18": {
       "integrity": "sha512-xtWpm+MZReSVqB3gJQM6QHbDsywiWvn69PVn7lozX14X3GJR8VqkiGIF6b36D1EPEnKFSg03g//SqAd2vNAIuw==",
@@ -886,7 +896,7 @@
     "@rolldown/pluginutils@1.0.1": {
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="
     },
-    "@standard-community/standard-json@0.3.5_@types+json-schema@7.0.15_zod@4.4.3": {
+    "@standard-community/standard-json@0.3.5_@standard-schema+spec@1.1.0_@types+json-schema@7.0.15_quansync@0.2.11_zod@4.4.3": {
       "integrity": "sha512-4+ZPorwDRt47i+O7RjyuaxHRK/37QY/LmgxlGrRrSTLYoFatEOzvqIc85GTlM18SFZ5E91C+v0o/M37wZPpUHA==",
       "dependencies": [
         "@standard-schema/spec",
@@ -898,7 +908,7 @@
         "zod"
       ]
     },
-    "@standard-community/standard-openapi@0.2.9_@standard-community+standard-json@0.3.5__@types+json-schema@7.0.15__zod@4.4.3_openapi-types@12.1.3_zod@4.4.3": {
+    "@standard-community/standard-openapi@0.2.9_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-schema+spec@1.1.0_openapi-types@12.1.3_zod@4.4.3_@types+json-schema@7.0.15_quansync@0.2.11": {
       "integrity": "sha512-htj+yldvN1XncyZi4rehbf9kLbu8os2Ke/rfqoZHCMHuw34kiF3LP/yQPdA0tQ940y8nDq3Iou8R3wG+AGGyvg==",
       "dependencies": [
         "@standard-community/standard-json",
@@ -1074,14 +1084,14 @@
     "@types/deep-eql@4.0.2": {
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="
     },
-    "@types/estree@1.0.8": {
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
+    "@types/estree@1.0.9": {
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="
     },
     "@types/json-schema@7.0.15": {
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
-    "@types/node@25.7.0": {
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+    "@types/node@25.8.0": {
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "dependencies": [
         "undici-types"
       ]
@@ -1778,35 +1788,35 @@
       "scripts": true,
       "bin": true
     },
-    "esbuild@0.27.7": {
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+    "esbuild@0.28.0": {
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "optionalDependencies": [
-        "@esbuild/aix-ppc64@0.27.7",
-        "@esbuild/android-arm@0.27.7",
-        "@esbuild/android-arm64@0.27.7",
-        "@esbuild/android-x64@0.27.7",
-        "@esbuild/darwin-arm64@0.27.7",
-        "@esbuild/darwin-x64@0.27.7",
-        "@esbuild/freebsd-arm64@0.27.7",
-        "@esbuild/freebsd-x64@0.27.7",
-        "@esbuild/linux-arm@0.27.7",
-        "@esbuild/linux-arm64@0.27.7",
-        "@esbuild/linux-ia32@0.27.7",
-        "@esbuild/linux-loong64@0.27.7",
-        "@esbuild/linux-mips64el@0.27.7",
-        "@esbuild/linux-ppc64@0.27.7",
-        "@esbuild/linux-riscv64@0.27.7",
-        "@esbuild/linux-s390x@0.27.7",
-        "@esbuild/linux-x64@0.27.7",
-        "@esbuild/netbsd-arm64@0.27.7",
-        "@esbuild/netbsd-x64@0.27.7",
-        "@esbuild/openbsd-arm64@0.27.7",
-        "@esbuild/openbsd-x64@0.27.7",
-        "@esbuild/openharmony-arm64@0.27.7",
-        "@esbuild/sunos-x64@0.27.7",
-        "@esbuild/win32-arm64@0.27.7",
-        "@esbuild/win32-ia32@0.27.7",
-        "@esbuild/win32-x64@0.27.7"
+        "@esbuild/aix-ppc64@0.28.0",
+        "@esbuild/android-arm@0.28.0",
+        "@esbuild/android-arm64@0.28.0",
+        "@esbuild/android-x64@0.28.0",
+        "@esbuild/darwin-arm64@0.28.0",
+        "@esbuild/darwin-x64@0.28.0",
+        "@esbuild/freebsd-arm64@0.28.0",
+        "@esbuild/freebsd-x64@0.28.0",
+        "@esbuild/linux-arm@0.28.0",
+        "@esbuild/linux-arm64@0.28.0",
+        "@esbuild/linux-ia32@0.28.0",
+        "@esbuild/linux-loong64@0.28.0",
+        "@esbuild/linux-mips64el@0.28.0",
+        "@esbuild/linux-ppc64@0.28.0",
+        "@esbuild/linux-riscv64@0.28.0",
+        "@esbuild/linux-s390x@0.28.0",
+        "@esbuild/linux-x64@0.28.0",
+        "@esbuild/netbsd-arm64@0.28.0",
+        "@esbuild/netbsd-x64@0.28.0",
+        "@esbuild/openbsd-arm64@0.28.0",
+        "@esbuild/openbsd-x64@0.28.0",
+        "@esbuild/openharmony-arm64@0.28.0",
+        "@esbuild/sunos-x64@0.28.0",
+        "@esbuild/win32-arm64@0.28.0",
+        "@esbuild/win32-ia32@0.28.0",
+        "@esbuild/win32-x64@0.28.0"
       ],
       "scripts": true,
       "bin": true
@@ -1909,7 +1919,7 @@
     "help-me@5.0.0": {
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="
     },
-    "hono-openapi@1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.18_hono@4.12.18_zod@4.4.3": {
+    "hono-openapi@1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.19_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-community+standard-openapi@0.2.9__@standard-community+standard-json@0.3.5___@standard-schema+spec@1.1.0___@types+json-schema@7.0.15___quansync@0.2.11___zod@4.4.3__@standard-schema+spec@1.1.0__openapi-types@12.1.3__zod@4.4.3__@types+json-schema@7.0.15__quansync@0.2.11_@types+json-schema@7.0.15_hono@4.12.19_openapi-types@12.1.3_@standard-schema+spec@1.1.0_quansync@0.2.11_zod@4.4.3": {
       "integrity": "sha512-xDvCWpWEIv0weEmnl3EjRQzqbHIO8LnfzMuYOCmbuyE5aes6aXxLg4vM3ybnoZD5TiTUkA6PuRQPJs3R7WRBig==",
       "dependencies": [
         "@hono/standard-validator",
@@ -1924,8 +1934,8 @@
         "hono"
       ]
     },
-    "hono@4.12.18": {
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="
+    "hono@4.12.19": {
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ=="
     },
     "html-encoding-sniffer@6.0.0": {
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
@@ -3037,8 +3047,8 @@
     "react-is@17.0.2": {
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "react-router@7.15.0_react@19.2.6_react-dom@19.2.6__react@19.2.6": {
-      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
+    "react-router@7.15.1_react@19.2.6_react-dom@19.2.6__react@19.2.6": {
+      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
       "dependencies": [
         "cookie",
         "react",
@@ -3317,11 +3327,10 @@
     "tslib@2.8.1": {
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
-    "tsx@4.21.0": {
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+    "tsx@4.22.0": {
+      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
       "dependencies": [
-        "esbuild@0.27.7",
-        "get-tsconfig"
+        "esbuild@0.28.0"
       ],
       "optionalDependencies": [
         "fsevents"
@@ -3332,8 +3341,8 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "bin": true
     },
-    "undici-types@7.21.0": {
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="
+    "undici-types@7.24.6": {
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="
     },
     "undici@6.25.0": {
       "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="
@@ -3576,6 +3585,7 @@
         "packageJson": {
           "dependencies": [
             "npm:@base-ui/react@1",
+            "npm:@deno/vite-plugin@2",
             "npm:@tailwindcss/vite@^4.1.0",
             "npm:@testing-library/jest-dom@^6.6.3",
             "npm:@testing-library/react@^16.3.0",

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -21,7 +21,8 @@ built-in test runner / linter / formatter, and Deno Deploy as a free hosting tar
 workspaces let us share packages (`@brewform/shared`, `@brewform/db`) without a Node.js runtime or
 a separate package manager binary. The `package.json` files serve as dependency manifests that both
 Deno's npm compatibility layer and Renovate understand. Task orchestration uses `deno task` with
-`--recursive`, `--filter`, and `--cwd` flags — no external task runner needed.
+explicit `--cwd`-based sub-tasks (e.g. `check:api`, `build:web`, `dev:api`) that compose into
+aggregate `check`, `build`, and `dev` tasks — no external task runner needed.
 
 **Trade-off.** A single toolchain simplifies the monorepo. `deno task` handles all build, test,
 lint, and dev workflows. All relative imports use explicit `.ts` extensions — no

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -245,14 +245,19 @@ make dev         # Full-stack dev (API :8000 + web :5173 with HMR)
 ### Useful Commands
 
 ```bash
-deno task dev              # API with hot reload
-deno task --cwd apps/web dev   # Vite dev server
+deno task dev              # Both API + web with hot reload
+deno task dev:api          # API with hot reload
+deno task dev:web          # Vite dev server
+deno task build            # Build all workspaces
+deno task build:web        # Build React SPA only
+deno task check            # Type-check all workspaces
+deno task check:api        # Type-check API only
+deno task check:web        # Lint web frontend
 deno task db:generate      # Generate Drizzle migration
 deno task db:migrate       # Run migrations
 deno task db:seed          # Seed data
 deno task email-build      # Compile email templates
 deno task lint             # Lint
 deno task fmt              # Format
-deno task check            # Type check
 deno task test             # Run tests
 ```

--- a/packages/db/deno.json
+++ b/packages/db/deno.json
@@ -5,11 +5,11 @@
     "./schema": "./src/schema.ts"
   },
   "tasks": {
-    "build": "deno run -A npm:drizzle-kit@0.31.10 generate",
-    "generate": "deno run -A npm:drizzle-kit@0.31.10 generate",
-    "migrate": "deno run -A npm:drizzle-kit@0.31.10 migrate",
-    "push": "deno run -A npm:drizzle-kit@0.31.10 push",
-    "studio": "deno run -A npm:drizzle-kit@0.31.10 studio --host=0.0.0.0 --port=5555",
+    "build": "deno run -A npm:drizzle-kit@0.31 generate",
+    "generate": "deno run -A npm:drizzle-kit@0.31 generate",
+    "migrate": "deno run -A npm:drizzle-kit@0.31 migrate",
+    "push": "deno run -A npm:drizzle-kit@0.31 push",
+    "studio": "deno run -A npm:drizzle-kit@0.31 studio --host=0.0.0.0 --port=5555",
     "lint": "deno lint src/",
     "check": "deno check src/index.ts src/schema.ts",
     "test": "deno test --allow-all src/"


### PR DESCRIPTION
# PR: Fix infinite build loop, JSR import resolution, and CI gaps

## Summary

This PR fixes two critical bugs discovered after a clean install (`rm -rf node_modules deno.lock && deno install`) and hardens CI to catch similar issues in the future. It also introduces granular per-workspace task decomposition for clearer separation of concerns between `check` and `build`.

---

## Bugs Fixed

### 🐛 1. Infinite recursion in `deno task build` (root)

**Symptom:**
```
$ deno task build
Task build deno task --recursive build
Task build deno task --recursive build
...  (infinite loop)
```

**Root cause:** The root [`deno.json`](deno.json) defined `"build": "deno task --recursive build"`. In Deno workspaces, `--recursive` executes the named task in **all** workspace members — and the root `deno.json` itself is a workspace member. This means the root's `build` task called itself, producing infinite recursion.

The same bug also affected `dev` and `test` tasks.

**Fix:** Replaced all `--recursive` task invocations with explicit `--cwd`-based per-workspace-member commands:

| Before | After |
|---|---|
| `deno task --recursive build` | `deno task --cwd apps/api build && deno task --cwd apps/web build && deno task --cwd packages/shared build` |
| `deno task --recursive dev` | `deno task --cwd apps/api dev & deno task --cwd apps/web dev` |
| `deno task --recursive test` | `deno task --cwd apps/api test && deno task --cwd packages/shared test && deno task --cwd packages/db test` |

### 🐛 2. `jsr:@std/path` unresolved in Vite configs

**Symptom:**
```
[vite.config.ts (4:30) [UNRESOLVED_IMPORT]
Could not resolve 'jsr:@std/path' in vite.config.ts
Module not found, treating it as an external dependency
```

**Root cause:** Two separate problems:

1. **Config-level imports:** Vite loads config files (`vite.config.ts`, `vitest.config.ts`) through its Node.js compatibility layer **before** any Vite plugin activates. JSR specifiers (`jsr:`) cannot be resolved by Node.js directly. The fix: use `node:path` instead of `jsr:@std/path` — both are available in Deno and `node:path` resolves correctly in both Deno and Vite contexts.

2. **Application-level imports:** The `@deno/vite-plugin` was missing entirely. Without it, any `jsr:` or `npm:` specifiers in application source code would also fail to resolve during Vite builds. This plugin bridges Deno's module resolution into Vite's build pipeline.

**Fix:**
- Added `"@deno/vite-plugin": "^2.0.0"` to [`apps/web/package.json`](apps/web/package.json) `devDependencies`
- Switched all three config files from `jsr:@std/path` → `node:path`:
  - [`apps/web/vite.config.ts`](apps/web/vite.config.ts)
  - [`apps/web/vitest.config.ts`](apps/web/vitest.config.ts)
  - [`apps/web/vitest.pbt.config.ts`](apps/web/vitest.pbt.config.ts)
- Added `import deno from '@deno/vite-plugin'` and `deno()` as the first plugin in the plugins array in all three configs

### 🐛 3. CI didn't catch these issues

**Root cause:** The CI workflows (`.github/workflows/ci.yml` and `.github/workflows/pr.yml`) never ran `deno task build`. They ran `fmt`, `lint`, `check`, and `test` — but `check` only type-checked `apps/api`, `packages/db`, and `packages/shared`. Neither the web build nor the root build task was ever exercised.

**Fix:**
- Added `"Build"` step (`deno task build`) to both CI workflows' quality job
- Added `check:web` task in root `deno.json` (lints `apps/web/src/` — Vite projects cannot use `deno check` due to `import.meta.env`)

---

## New Feature: Granular Task Decomposition

The root task runner has been refactored into clear, composable sub-tasks with a strict `check` ≠ `build` distinction:

### `check:*` — Static analysis (no artifacts produced)

| Task | What it does |
|---|---|
| `check` | Run all checks: api + web + db + shared |
| `check:api` | `deno check src/main.ts` |
| `check:web` | `deno lint src/` (128 files) |
| `check:db` | `deno check src/index.ts src/schema.ts` |
| `check:shared` | `deno check src/index.ts` |

### `build:*` — Produces artifacts

| Task | What it does |
|---|---|
| `build` | Build all: api + web + shared |
| `build:api` | Compile MJML email templates |
| `build:web` | `vite build` → `apps/web/dist/` |
| `build:shared` | `deno check src/index.ts` |

### `dev:*` — Development servers

| Task | What it does |
|---|---|
| `dev` | Both API (`:8000`) + web (`:5173`) with hot reload |
| `dev:api` | API with `--watch` |
| `dev:web` | Vite HMR dev server |

### `test:*` — Testing

| Task | What it does |
|---|---|
| `test` | All tests: api + shared + db |
| `test:api` | API test suite |
| `test:shared` | Shared package tests |
| `test:db` | Database package tests |

### `ci` pipeline

```
ci → fmt-check → lint → check → build → test-coverage
```

---

## Files Changed

### Core configuration

| File | Change |
|---|---|
| [`deno.json`](deno.json) | Replaced `--recursive` with granular `check:*` / `build:*` / `dev:*` / `test:*` tasks; updated `ci` pipeline |
| [`apps/web/deno.json`](apps/web/deno.json) | Added `check` task (`deno lint src/`) |

### Dependencies

| File | Change |
|---|---|
| [`apps/web/package.json`](apps/web/package.json) | Added `"@deno/vite-plugin": "^2.0.0"` to devDependencies |
| `deno.lock` | Regenerated with new dependency tree |

### Vite configs

| File | Change |
|---|---|
| [`apps/web/vite.config.ts`](apps/web/vite.config.ts) | Added `deno()` plugin; `jsr:@std/path` → `node:path` |
| [`apps/web/vitest.config.ts`](apps/web/vitest.config.ts) | Added `deno()` plugin; `jsr:@std/path` → `node:path` |
| [`apps/web/vitest.pbt.config.ts`](apps/web/vitest.pbt.config.ts) | Added `deno()` plugin; `jsr:@std/path` → `node:path` |

### CI

| File | Change |
|---|---|
| [`.github/workflows/ci.yml`](.github/workflows/ci.yml) | Added `Build` step (`deno task build`) to quality job |
| [`.github/workflows/pr.yml`](.github/workflows/pr.yml) | Added `Build` step (`deno task build`) to check job |

### Documentation & tooling

| File | Change |
|---|---|
| [`Makefile`](Makefile) | Added `check-api/web/db/shared`, `build-api/web/shared` targets; `check` now runs `deno task check` (all workspaces); `ci` includes `build-web` |
| [`README.md`](README.md) | Expanded Development commands into grouped sections with all granular sub-tasks |
| [`docs/decisions.md`](docs/decisions.md) | Updated task orchestration paragraph from `--recursive` to explicit `--cwd` sub-tasks |
| [`docs/deployment.md`](docs/deployment.md) | Expanded Useful Commands table from 10 to 16 entries |

---

## How to Verify

```bash
# Clean install (simulate CI / new contributor)
rm -rf node_modules apps/api/node_modules apps/web/node_modules deno.lock
deno install

# All checks pass (no infinite loop)
deno task check

# All builds pass (no JSR import warnings)
rm -rf apps/web/dist
deno task build

# Individual sub-tasks work
deno task check:api     # deno check src/main.ts
deno task check:web     # deno lint src/ (128 files)
deno task build:api     # email templates compiled
deno task build:web     # vite build (317 modules)

# Full CI pipeline
deno task ci            # fmt-check → lint → check → build → test-coverage
```

---

## Why `check:web` uses `deno lint` instead of `deno check`

Vite-based React projects use `import.meta.env.VITE_*` for environment variables, which `deno check` doesn't recognize (it's a Vite-specific feature). Attempting `deno check` on web source produces spurious errors:

```
TS2339: Property 'env' does not exist on type 'ImportMeta'.
```

The `deno lint` command catches syntax issues, unused imports, and coding standard violations in the web source without false positives from Vite-specific globals. Actual type-checking of the web app happens during `vite build` in `build:web`.

---

## Related

- [denoland/deno-vite-plugin](https://github.com/denoland/deno-vite-plugin) — Official Deno Vite integration
- Deno workspace `--recursive` behavior: returns tasks executed in all workspace members **including** the root member

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build System & CI/CD**
  * Build step added to CI pipeline after type-checking.
  * Development and build commands now available at component level (API, web, shared packages).

* **Documentation**
  * Development command reference updated with new granular build and type-check tasks.

* **Chores**
  * Deno Vite plugin integration added to web application.
  * Updated development dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ardakilic/BrewForm/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->