### PR TITLE
Development Plan 01: Security & Stability Hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,8 @@ ci: fmt-check lint check build-web check-tests test-coverage ## Run full CI pipe
 serena-up: ## Start Serena MCP service
 	docker compose --profile serena up serena -d
 
-serena-stop: ## Stop Serena MCP service
-	docker compose --profile serena stop serena
+serena-down: ## Down Serena MCP service (removes container)
+	docker compose --profile serena down serena
 
 serena-logs: ## Follow Serena logs
 	docker compose logs -f serena
@@ -182,4 +182,4 @@ serena-index: ## Index project with Serena
 serena-health: ## Check Serena health
 	@curl -sf --max-time 5 --connect-timeout 2 http://localhost:10122/sse > /dev/null 2>&1 && echo "✓ Serena is healthy" || echo "✗ Serena is not responding"
 
-.PHONY: help up down build logs restart install email-build lint fmt fmt-check check check-tests test test-coverage test-api test-shared test-specific db-migrate db-generate db-push db-seed db-studio db-reset setup dev dev-api web-dev web-build preview ci serena-up serena-stop serena-logs serena-index serena-health
+.PHONY: help up down build logs restart install email-build lint fmt fmt-check check check-tests test test-coverage test-api test-shared test-specific db-migrate db-generate db-push db-seed db-studio db-reset setup dev dev-api web-dev web-build preview ci serena-up serena-down serena-logs serena-index serena-health

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Access the Serena dashboard at http://localhost:34283.
 | Command | Description |
 |---------|-------------|
 | `make serena-up` | Start Serena MCP service |
-| `make serena-stop` | Stop Serena MCP service |
+| `make serena-down` | Down Serena MCP service (removes container) |
 | `make serena-logs` | View Serena logs |
 | `make serena-index` | Re-index the project workspace |
 | `make serena-health` | Health check |

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -15,7 +15,7 @@
  *   5. Exit cleanly
  *
  * Middleware stack (applied in order):
- *   cors → requestId → rateLimit(100/min) → cache injection → routes
+ *   cors → requestId → secureHeaders → rateLimit(100/min) → cache injection → routes
  */
 import { Hono } from 'hono';
 import * as path from 'jsr:@std/path';
@@ -24,6 +24,7 @@ import { corsMiddleware } from './middleware/cors.ts';
 import { requestIdMiddleware } from './middleware/requestId.ts';
 import { errorHandler } from './middleware/errorHandler.ts';
 import { rateLimitMiddleware } from './middleware/rateLimit.ts';
+import { secureHeaders } from 'hono/secure-headers';
 import { createCacheProvider } from './utils/cache/index.ts';
 import type { CacheProvider } from './utils/cache/index.ts';
 import { cacheProvider, setCacheProvider } from './utils/cache/singleton.ts';
@@ -44,6 +45,32 @@ const app = new Hono<{ Variables: Variables }>();
 
 app.use('*', corsMiddleware);
 app.use('*', requestIdMiddleware);
+app.use(
+  '*',
+  secureHeaders({
+    contentSecurityPolicy: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      imgSrc: ["'self'", 'data:', 'https:'],
+      connectSrc: ["'self'"],
+      fontSrc: ["'self'"],
+      objectSrc: ["'none'"],
+      frameAncestors: ["'none'"],
+      baseUri: ["'self'"],
+      formAction: ["'self'"],
+    },
+    strictTransportSecurity: 'max-age=63072000; includeSubDomains; preload',
+    xContentTypeOptions: 'nosniff',
+    xFrameOptions: 'DENY',
+    referrerPolicy: 'strict-origin-when-cross-origin',
+    permissionsPolicy: {
+      camera: [],
+      microphone: [],
+      geolocation: [],
+    },
+  }),
+);
 app.use('*', rateLimitMiddleware({ windowMs: 60_000, maxRequests: 100 }));
 app.use('*', async (c, next) => {
   c.set('cache', cacheProvider);

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,27 +1,26 @@
-/**
- * Authentication middleware for BrewForm API.
- *
- * - authMiddleware: Required auth. Rejects missing/invalid tokens, banned users,
- *   and soft-deleted users. Sets userId and user on Hono context.
- * - optionalAuthMiddleware: Inspects token if present but allows anonymous requests.
- *   Sets userId=null and user=null for unauthenticated requests. Used for endpoints
- *   like GET /recipes/:slug where private recipes are only visible to their author.
- * - adminMiddleware: Must be used AFTER authMiddleware. Rejects non-admin users (403).
- */
 import type { Context, Next } from 'hono';
+import { getCookie } from 'hono/cookie';
 import { verifyJwt } from '../modules/auth/jwt.ts';
 import { db } from '@brewform/db';
 import { users } from '@brewform/db/schema';
 import { and, eq, isNull } from 'drizzle-orm';
 import { forbidden, unauthorized } from '../utils/response/index.ts';
 
-export async function authMiddleware(c: Context, next: Next) {
+function extractAccessToken(c: Context): string | undefined {
   const authHeader = c.req.header('Authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    return authHeader.slice(7);
+  }
+  return getCookie(c, 'brewform_access_token');
+}
+
+export async function authMiddleware(c: Context, next: Next) {
+  const token = extractAccessToken(c);
+
+  if (!token) {
     return unauthorized(c, 'Missing or invalid Authorization header');
   }
 
-  const token = authHeader.slice(7);
   try {
     const payload = await verifyJwt(token);
     if (!payload.sub || payload.type !== 'access') {
@@ -49,15 +48,15 @@ export async function authMiddleware(c: Context, next: Next) {
 }
 
 export async function optionalAuthMiddleware(c: Context, next: Next) {
-  const authHeader = c.req.header('Authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+  const token = extractAccessToken(c);
+
+  if (!token) {
     c.set('userId', null);
     c.set('user', null);
     await next();
     return;
   }
 
-  const token = authHeader.slice(7);
   try {
     const payload = await verifyJwt(token);
     if (payload.sub && payload.type === 'access') {

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -1,7 +1,10 @@
 import type { Context, Next } from 'hono';
-import type { CacheProvider } from '../utils/cache/index.ts';
+import { cacheProvider } from '../utils/cache/singleton.ts';
 
-const loginAttempts = new Map<string, { count: number; resetAt: number }>();
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
 
 export function rateLimitMiddleware(options: {
   windowMs?: number;
@@ -15,14 +18,9 @@ export function rateLimitMiddleware(options: {
   return async (c: Context, next: Next) => {
     const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown';
     const key = `${keyPrefix}:${ip}`;
-
-    const cache = c.get('cache') as CacheProvider | undefined;
     const now = Date.now();
 
-    const entry = cache
-      ? await cache.get<{ count: number; resetAt: number }>(['ratelimit', key])
-      : null;
-
+    const entry = await cacheProvider.get<RateLimitEntry>(['ratelimit', key]);
     const current = entry || { count: 0, resetAt: now + windowMs };
 
     if (now > current.resetAt) {
@@ -32,9 +30,7 @@ export function rateLimitMiddleware(options: {
 
     current.count++;
 
-    if (cache) {
-      await cache.set(['ratelimit', key], current, { ttlMs: windowMs });
-    }
+    await cacheProvider.set(['ratelimit', key], current, { ttlMs: windowMs });
 
     c.header('X-RateLimit-Limit', String(maxRequests));
     c.header('X-RateLimit-Remaining', String(Math.max(0, maxRequests - current.count)));
@@ -54,22 +50,33 @@ export function rateLimitMiddleware(options: {
   };
 }
 
-export function authRateLimitMiddleware() {
-  const windowMs = 15 * 60_000;
-  const maxAttempts = 5;
+export function authRateLimitMiddleware(options: {
+  windowMs?: number;
+  maxAttempts?: number;
+} = {}) {
+  const windowMs = options.windowMs || 15 * 60_000;
+  const maxAttempts = options.maxAttempts || 5;
 
   return async (c: Context, next: Next) => {
     const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown';
-    const key = `auth:${ip}`;
+    const key = `auth-ratelimit:${ip}`;
     const now = Date.now();
 
-    const entry = loginAttempts.get(key);
-    if (entry && now > entry.resetAt) {
-      loginAttempts.delete(key);
+    const entry = await cacheProvider.get<RateLimitEntry>(['ratelimit', key]);
+    const current = entry || { count: 0, resetAt: now + windowMs };
+
+    if (now > current.resetAt) {
+      current.count = 0;
+      current.resetAt = now + windowMs;
     }
 
-    const current = loginAttempts.get(key) || { count: 0, resetAt: now + windowMs };
     current.count++;
+
+    await cacheProvider.set(['ratelimit', key], current, { ttlMs: windowMs });
+
+    c.header('X-RateLimit-Limit', String(maxAttempts));
+    c.header('X-RateLimit-Remaining', String(Math.max(0, maxAttempts - current.count)));
+    c.header('X-RateLimit-Reset', String(Math.ceil(current.resetAt / 1000)));
 
     if (current.count > maxAttempts) {
       return c.json({
@@ -81,7 +88,6 @@ export function authRateLimitMiddleware() {
       }, 429);
     }
 
-    loginAttempts.set(key, current);
     await next();
   };
 }

--- a/apps/api/src/modules/auth/email.ts
+++ b/apps/api/src/modules/auth/email.ts
@@ -2,6 +2,7 @@ import { config } from '../../config/index.ts';
 import { createLogger } from '../../utils/logger/index.ts';
 import { template as welcomeTemplate } from '../../templates/email/generated/welcome.ts';
 import { template as resetPasswordTemplate } from '../../templates/email/generated/reset-password.ts';
+import { template as verifyEmailTemplate } from '../../templates/email/generated/verify-email.ts';
 import nodemailer from 'npm:nodemailer';
 
 const logger = createLogger('email');
@@ -62,4 +63,16 @@ export async function sendPasswordResetEmail(to: string, token: string, username
     app_name: 'BrewForm',
   });
   await sendEmail(to, 'Reset your BrewForm password', html);
+}
+
+export async function sendVerificationEmail(to: string, token: string, username: string) {
+  const baseUrl = config.APP_ENV === 'production' ? 'https://brewform.cc' : 'http://localhost:5173';
+  const verifyUrl = `${baseUrl}/verify-email?token=${token}`;
+
+  const html = renderTemplate(verifyEmailTemplate, {
+    username,
+    verify_url: verifyUrl,
+    app_name: 'BrewForm',
+  });
+  await sendEmail(to, 'Verify your BrewForm email', html);
 }

--- a/apps/api/src/modules/auth/index.ts
+++ b/apps/api/src/modules/auth/index.ts
@@ -1,24 +1,75 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { describeRoute } from 'hono-openapi';
+import { deleteCookie, getCookie, setCookie } from 'hono/cookie';
+import type { Context } from 'hono';
 import {
   AuthLoginSchema,
-  AuthRefreshSchema,
   AuthRegisterSchema,
   PasswordResetConfirmSchema,
   PasswordResetSchema,
 } from '@brewform/shared/schemas';
+import { z } from 'zod';
 import * as authService from './service.ts';
 import { error, success } from '../../utils/response/index.ts';
 import { config } from '../../config/env.ts';
 import { createLogger } from '../../utils/logger/index.ts';
+import { authRateLimitMiddleware } from '../../middleware/rateLimit.ts';
+import { authMiddleware } from '../../middleware/auth.ts';
+import type { AppEnv } from '../../types/hono.ts';
 
 const log = createLogger('auth');
 
-const auth = new Hono();
+const auth = new Hono<AppEnv>();
+const authRateLimit = authRateLimitMiddleware({ windowMs: 15 * 60_000, maxAttempts: 5 });
+
+const CookieRefreshSchema = z.object({
+  refreshToken: z.string().optional(),
+  rememberMe: z.boolean().optional().default(false),
+});
+
+function setAuthCookies(
+  c: Context,
+  accessToken: string,
+  refreshToken: string,
+  rememberMe = false,
+) {
+  const isProduction = config.APP_ENV === 'production';
+
+  setCookie(c, 'brewform_access_token', accessToken, {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'Strict',
+    path: '/',
+    maxAge: 15 * 60,
+  });
+
+  setCookie(c, 'brewform_refresh_token', refreshToken, {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'Strict',
+    path: '/api/v1/auth',
+    maxAge: rememberMe ? 180 * 24 * 60 * 60 : 7 * 24 * 60 * 60,
+  });
+}
+
+function clearAuthCookies(c: Context) {
+  const isProduction = config.APP_ENV === 'production';
+
+  deleteCookie(c, 'brewform_access_token', {
+    path: '/',
+    secure: isProduction,
+  });
+
+  deleteCookie(c, 'brewform_refresh_token', {
+    path: '/api/v1/auth',
+    secure: isProduction,
+  });
+}
 
 auth.post(
   '/register',
+  authRateLimit,
   describeRoute({
     tags: ['Auth'],
     summary: 'Register a new account',
@@ -35,10 +86,9 @@ auth.post(
     const body = c.req.valid('json');
     try {
       const result = await authService.register(body);
+      setAuthCookies(c, result.accessToken, result.refreshToken);
       return success(c, {
         user: sanitizeUser(result.user),
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
       }, 201);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -67,6 +117,7 @@ auth.post(
 
 auth.post(
   '/login',
+  authRateLimit,
   describeRoute({
     tags: ['Auth'],
     summary: 'Log in with email and password',
@@ -83,10 +134,9 @@ auth.post(
     const body = c.req.valid('json');
     try {
       const result = await authService.login(body.email, body.password, body.rememberMe);
+      setAuthCookies(c, result.accessToken, result.refreshToken, body.rememberMe);
       return success(c, {
         user: sanitizeUser(result.user),
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
       });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -107,28 +157,30 @@ auth.post(
     tags: ['Auth'],
     summary: 'Exchange a refresh token for a new access token',
     description: 'Exchange a refresh token for a new access token. ' +
-      'Pass rememberMe: true to maintain the long-lived session.',
+      'The refresh token can be provided in the request body or via httpOnly cookie.',
     responses: {
       200: { description: 'New access + refresh tokens issued' },
       401: { description: 'Refresh token invalid or expired' },
     },
   }),
-  zValidator('json', AuthRefreshSchema),
+  zValidator('json', CookieRefreshSchema),
   async (c) => {
     const body = c.req.valid('json');
+    const refreshTokenValue = body.refreshToken || getCookie(c, 'brewform_refresh_token');
+    if (!refreshTokenValue) {
+      return error(c, 'INVALID_REFRESH_TOKEN', 'No refresh token provided', 401);
+    }
     try {
-      const result = await authService.refreshAccessToken(body.refreshToken, body.rememberMe);
+      const result = await authService.refreshAccessToken(refreshTokenValue, body.rememberMe);
+      setAuthCookies(c, result.accessToken, result.refreshToken, body.rememberMe);
       return success(c, {
         user: sanitizeUser(result.user),
-        accessToken: result.accessToken,
-        refreshToken: result.refreshToken,
       });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       if (['INVALID_TOKEN_TYPE', 'USER_NOT_FOUND'].includes(message)) {
         return error(c, 'INVALID_REFRESH_TOKEN', 'Invalid or expired refresh token', 401);
       }
-      // Catch JWT verification errors (expired, invalid signature, malformed)
       if (err instanceof Error && err.name.startsWith('Jwt')) {
         return error(c, 'INVALID_REFRESH_TOKEN', 'Invalid or expired refresh token', 401);
       }
@@ -139,6 +191,7 @@ auth.post(
 
 auth.post(
   '/forgot-password',
+  authRateLimit,
   describeRoute({
     tags: ['Auth'],
     summary: 'Request a password reset email',
@@ -204,6 +257,80 @@ auth.get(
   }),
   (c) => {
     return success(c, { enabled: config.ENABLE_REGISTRATION });
+  },
+);
+
+auth.post(
+  '/send-verification',
+  authMiddleware,
+  describeRoute({
+    tags: ['Auth'],
+    summary: 'Resend email verification link',
+    responses: {
+      200: { description: 'Verification email sent (if account is unverified)' },
+      401: { description: 'Authentication required' },
+    },
+  }),
+  async (c) => {
+    const user = c.get('user') as {
+      id: string;
+      email: string;
+      username: string;
+      emailVerifiedAt: Date | null;
+    };
+    if (user.emailVerifiedAt) {
+      return success(c, { message: 'Email is already verified' });
+    }
+    await authService.sendVerificationToken(user.id, user.email, user.username);
+    return success(c, { message: 'Verification email sent' });
+  },
+);
+
+auth.post(
+  '/verify-email',
+  describeRoute({
+    tags: ['Auth'],
+    summary: 'Verify email address with token',
+    responses: {
+      200: { description: 'Email verified' },
+      400: { description: 'Invalid or expired token' },
+    },
+  }),
+  zValidator('json', z.object({ token: z.string().min(1) })),
+  async (c) => {
+    const { token } = c.req.valid('json');
+    try {
+      await authService.verifyEmail(token);
+      return success(c, { message: 'Email verified successfully' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'INVALID_VERIFICATION_TOKEN') {
+        return error(c, 'INVALID_TOKEN', 'Invalid verification token', 400);
+      }
+      if (message === 'TOKEN_ALREADY_USED') {
+        return error(c, 'TOKEN_USED', 'This verification token has already been used', 400);
+      }
+      if (message === 'TOKEN_EXPIRED') {
+        return error(c, 'TOKEN_EXPIRED', 'This verification token has expired', 400);
+      }
+      throw err;
+    }
+  },
+);
+
+auth.post(
+  '/logout',
+  describeRoute({
+    tags: ['Auth'],
+    summary: 'Log out and clear auth cookies',
+    description: 'Clears the httpOnly auth cookies. No token required.',
+    responses: {
+      200: { description: 'Logged out' },
+    },
+  }),
+  (c) => {
+    clearAuthCookies(c);
+    return success(c, { message: 'Logged out successfully' });
   },
 );
 

--- a/apps/api/src/modules/auth/index.ts
+++ b/apps/api/src/modules/auth/index.ts
@@ -25,7 +25,6 @@ const authRateLimit = authRateLimitMiddleware({ windowMs: 15 * 60_000, maxAttemp
 
 const CookieRefreshSchema = z.object({
   refreshToken: z.string().optional(),
-  rememberMe: z.boolean().optional().default(false),
 });
 
 function setAuthCookies(
@@ -163,16 +162,24 @@ auth.post(
       401: { description: 'Refresh token invalid or expired' },
     },
   }),
-  zValidator('json', CookieRefreshSchema),
   async (c) => {
-    const body = c.req.valid('json');
-    const refreshTokenValue = body.refreshToken || getCookie(c, 'brewform_refresh_token');
+    let bodyToken: string | undefined;
+    try {
+      const contentType = c.req.header('content-type');
+      if (contentType?.includes('application/json')) {
+        const parsed = CookieRefreshSchema.parse(await c.req.json());
+        bodyToken = parsed.refreshToken;
+      }
+    } catch {
+      // Invalid or missing body — fall through to cookie
+    }
+    const refreshTokenValue = bodyToken || getCookie(c, 'brewform_refresh_token');
     if (!refreshTokenValue) {
       return error(c, 'INVALID_REFRESH_TOKEN', 'No refresh token provided', 401);
     }
     try {
-      const result = await authService.refreshAccessToken(refreshTokenValue, body.rememberMe);
-      setAuthCookies(c, result.accessToken, result.refreshToken, body.rememberMe);
+      const result = await authService.refreshAccessToken(refreshTokenValue);
+      setAuthCookies(c, result.accessToken, result.refreshToken, result.wasRememberMe);
       return success(c, {
         user: sanitizeUser(result.user),
       });

--- a/apps/api/src/modules/auth/jwt.ts
+++ b/apps/api/src/modules/auth/jwt.ts
@@ -79,6 +79,12 @@ export async function verifyJwt(token: string): Promise<JwtPayload> {
   return payload as unknown as JwtPayload;
 }
 
+export function isLongLivedRefreshToken(payload: RefreshPayload): boolean {
+  const originalLifetime = payload.exp - payload.iat;
+  const standardLifetime = parseExpiry(REFRESH_EXPIRY);
+  return originalLifetime > standardLifetime;
+}
+
 /** Decode a JWT without verification. Returns null on malformed input. */
 export function decodeJwt(
   token: string,

--- a/apps/api/src/modules/auth/model.ts
+++ b/apps/api/src/modules/auth/model.ts
@@ -1,5 +1,10 @@
 import { db } from '@brewform/db';
-import { passwordResets, userPreferences, users } from '@brewform/db/schema';
+import {
+  emailVerificationTokens,
+  passwordResets,
+  userPreferences,
+  users,
+} from '@brewform/db/schema';
 import { and, eq, isNull, ne } from 'drizzle-orm';
 import { compareSync, hashSync } from 'bcryptjs';
 
@@ -98,4 +103,33 @@ export async function isUsernameTaken(username: string, excludeId?: string) {
   if (excludeId) conditions.push(ne(users.id, excludeId));
   const [result] = await db.select({ id: users.id }).from(users).where(and(...conditions)).limit(1);
   return !!result;
+}
+
+export async function createEmailVerificationToken(
+  userId: string,
+  token: string,
+  expiresAt: Date,
+) {
+  const [result] = await db.insert(emailVerificationTokens).values({
+    userId,
+    token,
+    expiresAt,
+  }).returning();
+  return result;
+}
+
+export async function findEmailVerificationByToken(token: string) {
+  const result = await db.select().from(emailVerificationTokens)
+    .where(eq(emailVerificationTokens.token, token))
+    .limit(1);
+  return result[0] ?? null;
+}
+
+export async function markEmailVerified(userId: string, tokenId: string) {
+  await db.update(users)
+    .set({ emailVerifiedAt: new Date() })
+    .where(eq(users.id, userId));
+  await db.update(emailVerificationTokens)
+    .set({ usedAt: new Date() })
+    .where(eq(emailVerificationTokens.id, tokenId));
 }

--- a/apps/api/src/modules/auth/model.ts
+++ b/apps/api/src/modules/auth/model.ts
@@ -105,31 +105,44 @@ export async function isUsernameTaken(username: string, excludeId?: string) {
   return !!result;
 }
 
+async function hashToken(raw: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(raw));
+  return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
 export async function createEmailVerificationToken(
   userId: string,
   token: string,
   expiresAt: Date,
 ) {
+  const hashed = await hashToken(token);
   const [result] = await db.insert(emailVerificationTokens).values({
     userId,
-    token,
+    token: hashed,
     expiresAt,
   }).returning();
   return result;
 }
 
 export async function findEmailVerificationByToken(token: string) {
+  const hashed = await hashToken(token);
   const result = await db.select().from(emailVerificationTokens)
-    .where(eq(emailVerificationTokens.token, token))
+    .where(eq(emailVerificationTokens.token, hashed))
     .limit(1);
   return result[0] ?? null;
 }
 
 export async function markEmailVerified(userId: string, tokenId: string) {
-  await db.update(users)
-    .set({ emailVerifiedAt: new Date() })
-    .where(eq(users.id, userId));
-  await db.update(emailVerificationTokens)
-    .set({ usedAt: new Date() })
-    .where(eq(emailVerificationTokens.id, tokenId));
+  await db.transaction(async (tx) => {
+    const [consumed] = await tx.update(emailVerificationTokens)
+      .set({ usedAt: new Date() })
+      .where(and(eq(emailVerificationTokens.id, tokenId), isNull(emailVerificationTokens.usedAt)))
+      .returning({ id: emailVerificationTokens.id });
+    if (!consumed) {
+      throw new Error('TOKEN_ALREADY_USED');
+    }
+    await tx.update(users)
+      .set({ emailVerifiedAt: new Date() })
+      .where(eq(users.id, userId));
+  });
 }

--- a/apps/api/src/modules/auth/service.ts
+++ b/apps/api/src/modules/auth/service.ts
@@ -1,6 +1,6 @@
 import * as jwt from './jwt.ts';
 import * as model from './model.ts';
-import { sendPasswordResetEmail, sendWelcomeEmail } from './email.ts';
+import { sendPasswordResetEmail, sendVerificationEmail } from './email.ts';
 import { createLogger } from '../../utils/logger/index.ts';
 import { config } from '../../config/env.ts';
 // Standard dedup approach for future OAuth/social login:
@@ -61,9 +61,9 @@ export async function register(data: {
   const refreshToken = await jwt.signRefreshToken(user.id);
 
   try {
-    await sendWelcomeEmail(user.email, user.username);
+    await sendVerificationToken(user.id, user.email, user.username);
   } catch (err) {
-    logger.warn({ err }, 'Failed to send welcome email');
+    logger.warn({ err }, 'Failed to send verification email');
   }
 
   return { user, accessToken, refreshToken };
@@ -170,4 +170,27 @@ export async function getAuthenticatedUser(userId: string) {
     throw new Error('USER_NOT_FOUND');
   }
   return user;
+}
+
+export async function sendVerificationToken(userId: string, email: string, username: string) {
+  const token = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + 24 * 3600 * 1000);
+
+  await model.createEmailVerificationToken(userId, token, expiresAt);
+  await sendVerificationEmail(email, token, username);
+}
+
+export async function verifyEmail(token: string) {
+  const record = await model.findEmailVerificationByToken(token);
+  if (!record) {
+    throw new Error('INVALID_VERIFICATION_TOKEN');
+  }
+  if (record.usedAt) {
+    throw new Error('TOKEN_ALREADY_USED');
+  }
+  if (new Date(record.expiresAt) < new Date()) {
+    throw new Error('TOKEN_EXPIRED');
+  }
+
+  await model.markEmailVerified(record.userId, record.id);
 }

--- a/apps/api/src/modules/auth/service.ts
+++ b/apps/api/src/modules/auth/service.ts
@@ -98,7 +98,7 @@ export async function login(email: string, password: string, rememberMe = false)
   return { user, accessToken, refreshToken };
 }
 
-export async function refreshAccessToken(refreshToken: string, rememberMe = false) {
+export async function refreshAccessToken(refreshToken: string) {
   const payload = await jwt.verifyJwt(refreshToken);
   if (payload.type !== 'refresh') {
     throw new Error('INVALID_TOKEN_TYPE');
@@ -120,11 +120,12 @@ export async function refreshAccessToken(refreshToken: string, rememberMe = fals
     isAdmin: user.isAdmin,
   });
 
-  const newRefreshToken = rememberMe
+  const wasRememberMe = jwt.isLongLivedRefreshToken(payload);
+  const newRefreshToken = wasRememberMe
     ? await jwt.signRefreshToken(user.id, config.JWT_REMEMBER_ME_EXPIRY)
     : await jwt.signRefreshToken(user.id);
 
-  return { user, accessToken: newAccessToken, refreshToken: newRefreshToken };
+  return { user, accessToken: newAccessToken, refreshToken: newRefreshToken, wasRememberMe };
 }
 
 export async function requestPasswordReset(email: string) {

--- a/apps/api/src/modules/comment/index.ts
+++ b/apps/api/src/modules/comment/index.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import { CommentCreateSchema, PaginationSchema } from '@brewform/shared/schemas';
 import { authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
-import { error, paginated, success } from '../../utils/response/index.ts';
+import { error, isEmailVerified, paginated, success } from '../../utils/response/index.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
 const comment = new Hono<AppEnv>();
@@ -13,6 +13,9 @@ comment.post(
   authMiddleware,
   zValidator('json', CommentCreateSchema),
   async (c) => {
+    if (!isEmailVerified(c)) {
+      return error(c, 'EMAIL_NOT_VERIFIED', 'Please verify your email to perform this action', 403);
+    }
     const recipeId = c.req.param('recipeId')!;
     const userId = c.get('userId') as string;
     const user = c.get('user') as { isAdmin: boolean } | null;

--- a/apps/api/src/modules/recipe/index.ts
+++ b/apps/api/src/modules/recipe/index.ts
@@ -9,7 +9,13 @@ import {
 import { authMiddleware, optionalAuthMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import * as model from './model.ts';
-import { error, paginated, success, zodValidationHook } from '../../utils/response/index.ts';
+import {
+  error,
+  isEmailVerified,
+  paginated,
+  success,
+  zodValidationHook,
+} from '../../utils/response/index.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
 const recipe = new Hono<AppEnv>();
@@ -179,6 +185,9 @@ recipe.post(
   authMiddleware,
   zValidator('json', RecipeCreateSchema, zodValidationHook),
   async (c) => {
+    if (!isEmailVerified(c)) {
+      return error(c, 'EMAIL_NOT_VERIFIED', 'Please verify your email to perform this action', 403);
+    }
     const authorId = c.get('userId') as string;
     const body = c.req.valid('json');
     try {

--- a/apps/api/src/templates/email/generated/verify-email.ts
+++ b/apps/api/src/templates/email/generated/verify-email.ts
@@ -1,0 +1,187 @@
+// Auto-generated from verify-email.mjml
+// Do not edit manually. Run: deno run -A apps/api/scripts/build-email-templates.ts
+
+export const template = `<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+      <!--[if !mso]><!-->
+        <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+        <style type="text/css">
+          @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+        </style>
+      <!--<![endif]-->
+
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+    
+  
+    
+    
+    
+  </head>
+  
+      <body  style="word-spacing:normal;background-color:#F5F0EB;">
+        
+        <div
+           aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#F5F0EB;"
+        >
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div  style="margin:0px auto;max-width:600px;">
+        
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+        
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+          
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:24px;font-weight:bold;line-height:1;text-align:center;color:#3E2723;"
+      >☕ {{app_name}}</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:18px;line-height:1;text-align:center;color:#5D4037;"
+      >Hello {{username}},</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:center;color:#5D4037;"
+      >Please verify your email address by clicking the button below.</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tbody>
+          <tr>
+            <td
+               align="center" bgcolor="#6F4E37" role="presentation" style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;background:#6F4E37;" valign="middle"
+            >
+              <a
+                 href="{{verify_url}}" style="display:inline-block;background:#6F4E37;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank"
+              >
+                Verify Email
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td
+                   align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+                  
+      <div
+         style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:14px;line-height:1;text-align:center;color:#8D6E63;"
+      >This link expires in 24 hours. If you didn't create an account, you can safely ignore this email.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+      </body>
+    
+</html>
+  `;

--- a/apps/api/src/templates/email/verify-email.mjml
+++ b/apps/api/src/templates/email/verify-email.mjml
@@ -1,0 +1,29 @@
+<mjml>
+  <mj-head>
+    <mj-attributes>
+      <mj-text font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" />
+      <mj-button background-color="#6F4E37" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#F5F0EB">
+    <mj-section>
+      <mj-column>
+        <mj-text font-size="24px" font-weight="bold" color="#3E2723" align="center">
+          ☕ {{app_name}}
+        </mj-text>
+        <mj-text font-size="18px" color="#5D4037" align="center">
+          Hello {{username}},
+        </mj-text>
+        <mj-text font-size="16px" color="#5D4037" align="center">
+          Please verify your email address by clicking the button below.
+        </mj-text>
+        <mj-button href="{{verify_url}}" font-size="16px">
+          Verify Email
+        </mj-button>
+        <mj-text font-size="14px" color="#8D6E63" align="center">
+          This link expires in 24 hours. If you didn't create an account, you can safely ignore this email.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/apps/api/src/utils/response/index.ts
+++ b/apps/api/src/utils/response/index.ts
@@ -74,6 +74,11 @@ export function validationError(c: Context, details: Array<{ field: string; mess
   return error(c, 'VALIDATION_ERROR', 'Validation failed', 400, details);
 }
 
+export function isEmailVerified(c: Context): boolean {
+  const user = c.get('user') as { emailVerifiedAt: Date | null } | null;
+  return !!user?.emailVerifiedAt;
+}
+
 /**
  * Hook for @hono/zod-validator that formats Zod issues into our standard
  * { success: false, error: { code, message, details } } envelope instead of

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,7 +11,14 @@
       if (sessionStorage.redirect) {
         var redirect = sessionStorage.redirect;
         delete sessionStorage.redirect;
-        history.replaceState(null, '', redirect);
+        if (
+          typeof redirect === 'string' &&
+          redirect.charAt(0) === '/' &&
+          redirect.charAt(1) !== '/' &&
+          redirect.indexOf(':') === -1
+        ) {
+          history.replaceState(null, '', redirect);
+        }
       }
     </script>
     <div id="root"></div>

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,80 +1,32 @@
 const API_BASE = import.meta.env.VITE_API_URL || '/api/v1';
 
-let accessToken: string | null = null;
-
-export function setAccessToken(token: string | null) {
-  accessToken = token;
-  if (token) {
-    localStorage.setItem('brewform_access_token', token);
-  } else {
-    localStorage.removeItem('brewform_access_token');
-  }
-}
-
-export function getAccessToken(): string | null {
-  if (!accessToken) {
-    accessToken = localStorage.getItem('brewform_access_token');
-  }
-  return accessToken;
-}
-
-export function clearTokens() {
-  accessToken = null;
-  localStorage.removeItem('brewform_access_token');
-  localStorage.removeItem('brewform_refresh_token');
-  localStorage.removeItem('brewform_remember_me');
-}
-
-async function refreshAccessToken(): Promise<string | null> {
-  const refreshToken = localStorage.getItem('brewform_refresh_token');
-  if (!refreshToken) return null;
-
-  const rememberMe = localStorage.getItem('brewform_remember_me') === 'true';
-
-  try {
-    const response = await fetch(`${API_BASE}/auth/refresh`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refreshToken, rememberMe }),
-    });
-    const data = await response.json();
-    if (data.success) {
-      setAccessToken(data.data.accessToken);
-      localStorage.setItem('brewform_refresh_token', data.data.refreshToken);
-      return data.data.accessToken;
-    }
-  } catch {
-    clearTokens();
-  }
-  return null;
-}
-
 async function request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
-  const token = getAccessToken();
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     ...((options.headers as Record<string, string>) || {}),
   };
 
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-
   let response = await fetch(`${API_BASE}${endpoint}`, {
     ...options,
     headers,
+    credentials: 'include',
   });
 
-  if (response.status === 401 && token) {
-    const newToken = await refreshAccessToken();
-    if (newToken) {
-      headers['Authorization'] = `Bearer ${newToken}`;
+  if (response.status === 401) {
+    const refreshResponse = await fetch(`${API_BASE}/auth/refresh`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+      credentials: 'include',
+    });
+
+    if (refreshResponse.ok) {
       response = await fetch(`${API_BASE}${endpoint}`, {
         ...options,
         headers,
+        credentials: 'include',
       });
     } else {
-      clearTokens();
       globalThis.location.href = '/login';
       throw new Error('Session expired');
     }

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -12,7 +12,7 @@ async function request<T>(endpoint: string, options: RequestInit = {}): Promise<
     credentials: 'include',
   });
 
-  if (response.status === 401) {
+  if (response.status === 401 && !endpoint.startsWith('/auth/')) {
     const refreshResponse = await fetch(`${API_BASE}/auth/refresh`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -1,19 +1,21 @@
-import { api, ApiError, clearTokens, getAccessToken, setAccessToken } from './client.ts';
+import { api, ApiError } from './client.ts';
 
-export { api, ApiError, clearTokens, getAccessToken, setAccessToken };
+export { api, ApiError };
 
 export const authApi = {
   register: (data: { email: string; username: string; password: string; displayName?: string }) =>
-    api.post<{ user: AuthUser; accessToken: string; refreshToken: string }>('/auth/register', data),
+    api.post<{ user: AuthUser }>('/auth/register', data),
   login: (data: { email: string; password: string; rememberMe?: boolean }) =>
-    api.post<{ user: AuthUser; accessToken: string; refreshToken: string }>('/auth/login', data),
-  refresh: (data: { refreshToken: string; rememberMe?: boolean }) =>
-    api.post<{ user: AuthUser; accessToken: string; refreshToken: string }>('/auth/refresh', data),
+    api.post<{ user: AuthUser }>('/auth/login', data),
+  logout: () => api.post<{ message: string }>('/auth/logout', {}),
   forgotPassword: (data: { email: string }) =>
     api.post<{ message: string }>('/auth/forgot-password', data),
   resetPassword: (data: { token: string; newPassword: string }) =>
     api.post<{ message: string }>('/auth/reset-password', data),
   registrationStatus: () => api.get<{ enabled: boolean }>('/auth/registration-status'),
+  sendVerification: () => api.post<{ message: string }>('/auth/send-verification', {}),
+  verifyEmail: (data: { token: string }) =>
+    api.post<{ message: string }>('/auth/verify-email', data),
 };
 
 export const userApi = {
@@ -128,6 +130,7 @@ export const followApi = {
 interface AuthUser {
   id: string;
   email: string;
+  emailVerifiedAt: string | null;
   username: string;
   displayName: string | null;
   avatarUrl: string | null;

--- a/apps/web/src/components/EmailVerificationBanner.tsx
+++ b/apps/web/src/components/EmailVerificationBanner.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { authApi } from '../api/index';
+
+export function EmailVerificationBanner() {
+  const { user } = useAuth();
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  if (!user || user.emailVerifiedAt) return null;
+
+  const handleResend = async () => {
+    setSending(true);
+    try {
+      await authApi.sendVerification();
+      setSent(true);
+    } catch {
+      // Silently fail -- user can try again
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div
+      className='flex items-center justify-center gap-2 px-4 py-2 text-sm'
+      style={{ backgroundColor: 'var(--accent-primary)', color: 'white' }}
+    >
+      <span>Please verify your email address to unlock all features.</span>
+      <button
+        type='button'
+        onClick={handleResend}
+        disabled={sending || sent}
+        className='underline font-medium'
+      >
+        {sent ? 'Email sent!' : sending ? 'Sending...' : 'Resend verification email'}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import { isRouteErrorResponse, Link, useRouteError } from 'react-router';
+
+export function RootErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error)) {
+    return (
+      <div
+        className='flex min-h-screen flex-col items-center justify-center px-6 text-center'
+        style={{ backgroundColor: 'var(--bg-primary)', color: 'var(--text-primary)' }}
+      >
+        <h1 className='text-6xl font-bold' style={{ color: 'var(--accent-primary)' }}>
+          {error.status}
+        </h1>
+        <p className='mt-4 text-lg' style={{ color: 'var(--text-secondary)' }}>
+          {error.status === 404
+            ? "Looks like this cup is empty. The page you're looking for doesn't exist."
+            : error.statusText || 'Something went wrong.'}
+        </p>
+        <div className='mt-6 flex gap-4'>
+          <Link to='/' className='btn-primary'>
+            Go Home
+          </Link>
+          <button
+            type='button'
+            className='btn-primary'
+            onClick={() => globalThis.location.reload()}
+          >
+            Reload Page
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const message = error instanceof Error ? error.message : 'An unexpected error occurred.';
+
+  return (
+    <div
+      className='flex min-h-screen flex-col items-center justify-center px-6 text-center'
+      style={{ backgroundColor: 'var(--bg-primary)', color: 'var(--text-primary)' }}
+    >
+      <h1 className='text-6xl font-bold' style={{ color: 'var(--accent-primary)' }}>
+        Oops
+      </h1>
+      <p className='mt-4 text-lg' style={{ color: 'var(--text-secondary)' }}>
+        {message}
+      </p>
+      {import.meta.env.DEV && error instanceof Error && error.stack && (
+        <pre
+          className='mt-4 max-w-2xl overflow-auto rounded-lg p-4 text-left text-xs'
+          style={{ backgroundColor: 'var(--bg-tertiary)', color: 'var(--text-secondary)' }}
+        >
+          {error.stack}
+        </pre>
+      )}
+      <div className='mt-6 flex gap-4'>
+        <Link to='/' className='btn-primary'>
+          Go Home
+        </Link>
+        <button
+          type='button'
+          className='btn-primary'
+          onClick={() => globalThis.location.reload()}
+        >
+          Reload Page
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -2,10 +2,12 @@ import { Outlet } from 'react-router';
 import { Navbar } from './Navbar';
 import { Footer } from './Footer';
 import { CookieConsent } from '../CookieConsent';
+import { EmailVerificationBanner } from '../EmailVerificationBanner';
 
 export function Layout() {
   return (
     <div className='flex min-h-screen flex-col'>
+      <EmailVerificationBanner />
       <Navbar />
       <main className='flex-1'>
         <Outlet />

--- a/apps/web/src/components/layout/Navbar.pbt.test.tsx
+++ b/apps/web/src/components/layout/Navbar.pbt.test.tsx
@@ -374,7 +374,7 @@ describe('Navbar — Property 2: Mobile Menu Closes on Navigation', () => {
         fc.asyncProperty(
           fc.integer({ min: 0, max: MOBILE_NAV_ITEMS.length - 1 }),
           async (navItemIndex) => {
-            const user = userEvent.setup();
+            const user = userEvent.setup({ delay: null });
 
             const { unmount } = render(<Navbar />);
 
@@ -411,10 +411,9 @@ describe('Navbar — Property 2: Mobile Menu Closes on Navigation', () => {
             }
           },
         ),
-        { numRuns: 8 },
+        { numRuns: 100 },
       );
     },
-    15_000,
   );
 });
 

--- a/apps/web/src/components/layout/Navbar.pbt.test.tsx
+++ b/apps/web/src/components/layout/Navbar.pbt.test.tsx
@@ -411,9 +411,10 @@ describe('Navbar — Property 2: Mobile Menu Closes on Navigation', () => {
             }
           },
         ),
-        { numRuns: 100 },
+        { numRuns: 8 },
       );
     },
+    15_000,
   );
 });
 

--- a/apps/web/src/components/layout/Navbar.test.tsx
+++ b/apps/web/src/components/layout/Navbar.test.tsx
@@ -989,6 +989,7 @@ describe('Navbar — ThemeSwitcher PBT (task 6.2)', () => {
           fc.constantFrom('light', 'dark', 'coffee'),
           fc.constantFrom('en', 'tr'),
           async (theme, locale) => {
+            const user = userEvent.setup({ delay: null });
             const translations = allThemeTranslations[locale];
             const t = (key: string) => translations[key] ?? key;
 
@@ -1012,7 +1013,7 @@ describe('Navbar — ThemeSwitcher PBT (task 6.2)', () => {
               expect(triggers[0]).toHaveTextContent(expectedTriggerLabel);
 
               // Open the popup
-              await userEvent.click(triggers[0]);
+              await user.click(triggers[0]);
 
               // All options in popup should have translated names
               expect(await screen.findByRole('option', { name: translations['theme.light'] }))
@@ -1026,9 +1027,8 @@ describe('Navbar — ThemeSwitcher PBT (task 6.2)', () => {
             }
           },
         ),
-        { numRuns: 12 },
+        { numRuns: 100 },
       );
     },
-    15_000,
   );
 });

--- a/apps/web/src/components/layout/Navbar.test.tsx
+++ b/apps/web/src/components/layout/Navbar.test.tsx
@@ -71,11 +71,9 @@ vi.mock('../../api/index', () => ({
     code = '';
     status = 500;
   },
-  clearTokens: vi.fn(),
-  getAccessToken: vi.fn(() => null),
-  setAccessToken: vi.fn(),
   authApi: {
     registrationStatus: vi.fn().mockResolvedValue({ enabled: true }),
+    logout: vi.fn().mockResolvedValue({ message: 'Logged out successfully' }),
   },
 }));
 
@@ -1028,8 +1026,9 @@ describe('Navbar — ThemeSwitcher PBT (task 6.2)', () => {
             }
           },
         ),
-        { numRuns: 100 },
+        { numRuns: 12 },
       );
     },
+    15_000,
   );
 });

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -1,9 +1,10 @@
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
-import { authApi, clearTokens, getAccessToken, setAccessToken, userApi } from '../api/index';
+import { authApi, userApi } from '../api/index';
 
 interface AuthUser {
   id: string;
   email: string;
+  emailVerifiedAt: string | null;
   username: string;
   displayName: string | null;
   avatarUrl: string | null;
@@ -19,7 +20,7 @@ interface AuthContextType {
   register: (
     data: { email: string; username: string; password: string; displayName?: string },
   ) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   refreshUser: () => Promise<void>;
 }
 
@@ -34,7 +35,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const userData = await userApi.me();
       setUser(userData);
     } catch {
-      clearTokens();
       setUser(null);
     } finally {
       setIsLoading(false);
@@ -42,23 +42,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    const token = getAccessToken();
-    if (token) {
-      refreshUser();
-    } else {
-      setIsLoading(false);
-    }
+    refreshUser();
   }, [refreshUser]);
 
   async function login(email: string, password: string, rememberMe = false) {
-    if (rememberMe) {
-      localStorage.setItem('brewform_remember_me', 'true');
-    } else {
-      localStorage.removeItem('brewform_remember_me');
-    }
     const response = await authApi.login({ email, password, rememberMe });
-    setAccessToken(response.accessToken);
-    localStorage.setItem('brewform_refresh_token', response.refreshToken);
     setUser(response.user);
   }
 
@@ -66,13 +54,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     data: { email: string; username: string; password: string; displayName?: string },
   ) {
     const response = await authApi.register(data);
-    setAccessToken(response.accessToken);
-    localStorage.setItem('brewform_refresh_token', response.refreshToken);
     setUser(response.user);
   }
 
-  function logout() {
-    clearTokens();
+  async function logout() {
+    try {
+      await authApi.logout();
+    } catch {
+      // Server might be unreachable; clear local state anyway
+    }
     setUser(null);
   }
 

--- a/apps/web/src/pages/auth/LoginPage.test.tsx
+++ b/apps/web/src/pages/auth/LoginPage.test.tsx
@@ -10,13 +10,11 @@ vi.mock('../../api/index', () => ({
   authApi: {
     login: vi.fn(),
     registrationStatus: vi.fn().mockResolvedValue({ enabled: true }),
+    logout: vi.fn().mockResolvedValue({ message: 'Logged out successfully' }),
   },
   userApi: {
     me: vi.fn().mockRejectedValue(new Error('Not authenticated')),
   },
-  clearTokens: vi.fn(),
-  getAccessToken: vi.fn().mockReturnValue(null),
-  setAccessToken: vi.fn(),
   api: {
     get: vi.fn(),
     post: vi.fn(),
@@ -39,7 +37,7 @@ vi.mock('../../api/index', () => ({
 import { authApi } from '../../api/index';
 
 function renderLoginPage() {
-  return render(
+  render(
     <MemoryRouter>
       <I18nProvider>
         <AuthProvider>
@@ -50,15 +48,24 @@ function renderLoginPage() {
   );
 }
 
+async function renderLoginPageAndWait() {
+  renderLoginPage();
+  await waitFor(() => {
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+  });
+}
+
 describe('LoginPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
   });
 
-  it('should render the login form with email, password, and submit button', () => {
+  it('should render the login form with email, password, and submit button', async () => {
     renderLoginPage();
-    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    });
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
   });
@@ -108,11 +115,9 @@ describe('LoginPage', () => {
         isAdmin: false,
         onboardingCompleted: false,
       },
-      accessToken: 'access-token-xxx',
-      refreshToken: 'refresh-token-xxx',
     });
 
-    renderLoginPage();
+    await renderLoginPageAndWait();
     await userEvent.type(screen.getByLabelText(/email/i), 'test@test.com');
     await userEvent.type(screen.getByLabelText(/password/i), 'password123');
     await userEvent.click(screen.getByRole('checkbox', { name: /remember me/i }));
@@ -127,32 +132,6 @@ describe('LoginPage', () => {
     });
   });
 
-  it('should store brewform_remember_me in localStorage when rememberMe is true', async () => {
-    vi.mocked(authApi.login).mockResolvedValue({
-      user: {
-        id: '1',
-        email: 'test@test.com',
-        username: 'testuser',
-        displayName: null,
-        avatarUrl: null,
-        isAdmin: false,
-        onboardingCompleted: false,
-      },
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
-    });
-
-    renderLoginPage();
-    await userEvent.type(screen.getByLabelText(/email/i), 'test@test.com');
-    await userEvent.type(screen.getByLabelText(/password/i), 'password123');
-    await userEvent.click(screen.getByRole('checkbox', { name: /remember me/i }));
-    await userEvent.click(screen.getByRole('button', { name: /log in/i }));
-
-    await waitFor(() => {
-      expect(localStorage.getItem('brewform_remember_me')).toBe('true');
-    });
-  });
-
   it('should call login with rememberMe: false when checkbox is not checked', async () => {
     const loginMock = vi.mocked(authApi.login).mockResolvedValue({
       user: {
@@ -164,11 +143,9 @@ describe('LoginPage', () => {
         isAdmin: false,
         onboardingCompleted: false,
       },
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
     });
 
-    renderLoginPage();
+    await renderLoginPageAndWait();
     await userEvent.type(screen.getByLabelText(/email/i), 'other@test.com');
     await userEvent.type(screen.getByLabelText(/password/i), 'password456');
     await userEvent.click(screen.getByRole('button', { name: /log in/i }));
@@ -193,11 +170,9 @@ describe('LoginPage', () => {
         isAdmin: false,
         onboardingCompleted: false,
       },
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
     });
 
-    renderLoginPage();
+    await renderLoginPageAndWait();
     await userEvent.type(screen.getByLabelText(/email/i), 'other@test.com');
     await userEvent.type(screen.getByLabelText(/password/i), 'password456');
     await userEvent.click(screen.getByRole('button', { name: /log in/i }));
@@ -209,7 +184,7 @@ describe('LoginPage', () => {
 
   it('should display error message on login failure', async () => {
     vi.mocked(authApi.login).mockRejectedValue(new Error('Invalid email or password'));
-    renderLoginPage();
+    await renderLoginPageAndWait();
     await userEvent.type(screen.getByLabelText(/email/i), 'bad@test.com');
     await userEvent.type(screen.getByLabelText(/password/i), 'wrong');
     await userEvent.click(screen.getByRole('button', { name: /log in/i }));
@@ -225,7 +200,7 @@ describe('LoginPage', () => {
     });
     vi.mocked(authApi.login).mockReturnValue(loginPromise as Promise<unknown>);
 
-    renderLoginPage();
+    await renderLoginPageAndWait();
     await userEvent.type(screen.getByLabelText(/email/i), 'test@test.com');
     await userEvent.type(screen.getByLabelText(/password/i), 'password123');
     await userEvent.click(screen.getByRole('button', { name: /log in/i }));
@@ -242,18 +217,16 @@ describe('LoginPage', () => {
         isAdmin: false,
         onboardingCompleted: false,
       },
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
     });
   });
 
-  it('should require email field', () => {
-    renderLoginPage();
+  it('should require email field', async () => {
+    await renderLoginPageAndWait();
     expect(screen.getByLabelText(/email/i)).toBeRequired();
   });
 
-  it('should require password field', () => {
-    renderLoginPage();
+  it('should require password field', async () => {
+    await renderLoginPageAndWait();
     expect(screen.getByLabelText(/password/i)).toBeRequired();
   });
 });

--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -44,12 +44,14 @@ export function LoginPage() {
       <form onSubmit={handleSubmit} className='mt-6 flex flex-col gap-4'>
         <div>
           <label
+            htmlFor='email'
             className='mb-1 block text-sm font-medium'
             style={{ color: 'var(--text-secondary)' }}
           >
             {t('auth.email')}
           </label>
           <input
+            id='email'
             type='email'
             value={email}
             onChange={(e) => setEmail(e.target.value)}
@@ -60,12 +62,14 @@ export function LoginPage() {
         </div>
         <div>
           <label
+            htmlFor='password'
             className='mb-1 block text-sm font-medium'
             style={{ color: 'var(--text-secondary)' }}
           >
             {t('auth.password')}
           </label>
           <input
+            id='password'
             type='password'
             value={password}
             onChange={(e) => setPassword(e.target.value)}

--- a/apps/web/src/pages/auth/RegisterPage.test.tsx
+++ b/apps/web/src/pages/auth/RegisterPage.test.tsx
@@ -19,11 +19,9 @@ vi.mock('../../api/index', () => ({
     code = '';
     status = 500;
   },
-  clearTokens: vi.fn(),
-  getAccessToken: vi.fn(() => null),
-  setAccessToken: vi.fn(),
   authApi: {
     registrationStatus: vi.fn(),
+    logout: vi.fn().mockResolvedValue({ message: 'Logged out successfully' }),
   },
 }));
 

--- a/apps/web/src/pages/auth/VerifyEmailPage.tsx
+++ b/apps/web/src/pages/auth/VerifyEmailPage.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { Link, useSearchParams } from 'react-router';
+import { useAuth } from '../../contexts/AuthContext';
+import { authApi } from '../../api/index';
+
+export function VerifyEmailPage() {
+  const [searchParams] = useSearchParams();
+  const { refreshUser } = useAuth();
+  const token = searchParams.get('token');
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    if (!token) {
+      setStatus('error');
+      setErrorMessage('No verification token provided.');
+      return;
+    }
+
+    authApi
+      .verifyEmail({ token })
+      .then(async () => {
+        await refreshUser();
+        setStatus('success');
+      })
+      .catch((err) => {
+        setStatus('error');
+        setErrorMessage(err.message || 'Verification failed.');
+      });
+  }, [token, refreshUser]);
+
+  return (
+    <div className='flex min-h-[60vh] flex-col items-center justify-center px-6 text-center'>
+      {status === 'loading' && (
+        <p style={{ color: 'var(--text-secondary)' }}>Verifying your email...</p>
+      )}
+      {status === 'success' && (
+        <>
+          <h1 className='text-2xl font-bold' style={{ color: 'var(--accent-primary)' }}>
+            Email Verified!
+          </h1>
+          <p className='mt-4' style={{ color: 'var(--text-secondary)' }}>
+            Your email has been verified. You now have full access to all features.
+          </p>
+          <Link to='/' className='btn-primary mt-6'>
+            Go Home
+          </Link>
+        </>
+      )}
+      {status === 'error' && (
+        <>
+          <h1 className='text-2xl font-bold' style={{ color: 'var(--accent-primary)' }}>
+            Verification Failed
+          </h1>
+          <p className='mt-4' style={{ color: 'var(--text-secondary)' }}>
+            {errorMessage}
+          </p>
+          <Link to='/' className='btn-primary mt-6'>
+            Go Home
+          </Link>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -38,17 +38,21 @@ import { AdminCachePage } from './pages/admin/AdminCachePage';
 import { AdminUserCreatePage } from './pages/admin/AdminUserCreatePage';
 import { AdminUserEditPage } from './pages/admin/AdminUserEditPage';
 import { AdminUserDetailPage } from './pages/admin/AdminUserDetailPage';
+import { RootErrorBoundary } from './components/ErrorBoundary';
+import { VerifyEmailPage } from './pages/auth/VerifyEmailPage';
 
 export const router = createBrowserRouter([
   {
     path: '/',
     element: <Layout />,
+    errorElement: <RootErrorBoundary />,
     children: [
       { index: true, element: <HomePage /> },
       { path: 'login', element: <LoginPage /> },
       { path: 'register', element: <RegisterPage /> },
       { path: 'forgot-password', element: <ForgotPasswordPage /> },
       { path: 'reset-password', element: <ResetPasswordPage /> },
+      { path: 'verify-email', element: <VerifyEmailPage /> },
       { path: 'recipes', element: <RecipeListPage /> },
       {
         path: 'recipes/starred',
@@ -132,6 +136,7 @@ export const router = createBrowserRouter([
         <AdminLayout />
       </RequireAuth>
     ),
+    errorElement: <RootErrorBoundary />,
     children: [
       { index: true, element: <AdminDashboard /> },
       { path: 'users', element: <AdminUsersPage /> },

--- a/docs/serena-mcp.md
+++ b/docs/serena-mcp.md
@@ -189,7 +189,7 @@ Connect to the SSE endpoint at `http://localhost:10122/sse`.
 | Command | Description |
 |---------|-------------|
 | `make serena-up` | Start Serena MCP service (uses `--profile serena`) |
-| `make serena-stop` | Stop Serena MCP service |
+| `make serena-down` | Down Serena MCP service (removes container) |
 | `make serena-logs` | View Serena container logs |
 | `make serena-index` | Re-index the project workspace |
 | `make serena-health` | Health check — verifies SSE endpoint responds |

--- a/packages/db/drizzle/0005_wooden_owl.sql
+++ b/packages/db/drizzle/0005_wooden_owl.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "email_verification_token" (
+	"id" varchar(36) PRIMARY KEY NOT NULL,
+	"user_id" varchar(36) NOT NULL,
+	"token" varchar(255) NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"used_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "email_verification_token_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "email_verified_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "email_verification_token" ADD CONSTRAINT "email_verification_token_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "email_verification_token_token_idx" ON "email_verification_token" USING btree ("token");--> statement-breakpoint
+CREATE INDEX "email_verification_token_user_id_idx" ON "email_verification_token" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "email_verification_token_expires_at_idx" ON "email_verification_token" USING btree ("expires_at");

--- a/packages/db/drizzle/meta/0005_snapshot.json
+++ b/packages/db/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,3684 @@
+{
+  "id": "fe566ec4-00ab-485d-8720-ac964673651a",
+  "prevId": "d8f12969-8296-4ca6-bba4-c159ee83f34b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity": {
+          "name": "entity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_admin_id_idx": {
+          "name": "audit_log_admin_id_idx",
+          "columns": [
+            {
+              "expression": "admin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_admin_id_user_id_fk": {
+          "name": "audit_log_admin_id_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "admin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badge": {
+      "name": "badge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule": {
+          "name": "rule",
+          "type": "badge_rule",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "badge_rule_idx": {
+          "name": "badge_rule_idx",
+          "columns": [
+            {
+              "expression": "rule",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "badge_rule_unique": {
+          "name": "badge_rule_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "rule"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bean": {
+      "name": "bean",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roaster": {
+          "name": "roaster",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roast_level": {
+          "name": "roast_level",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing": {
+          "name": "processing",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bean_user_id_idx": {
+          "name": "bean_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bean_deleted_at_idx": {
+          "name": "bean_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bean_vendor_id_vendor_id_fk": {
+          "name": "bean_vendor_id_vendor_id_fk",
+          "tableFrom": "bean",
+          "tableTo": "vendor",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bean_user_id_user_id_fk": {
+          "name": "bean_user_id_user_id_fk",
+          "tableFrom": "bean",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brew_method_equipment_rule": {
+      "name": "brew_method_equipment_rule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "brew_method": {
+          "name": "brew_method",
+          "type": "brew_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "equipment_type": {
+          "name": "equipment_type",
+          "type": "equipment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compatible": {
+          "name": "compatible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brew_method_equipment_rule_brew_method_idx": {
+          "name": "brew_method_equipment_rule_brew_method_idx",
+          "columns": [
+            {
+              "expression": "brew_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brew_method_equipment_rule_equipment_type_idx": {
+          "name": "brew_method_equipment_rule_equipment_type_idx",
+          "columns": [
+            {
+              "expression": "equipment_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "brew_method_equipment_rule_brew_method_equipment_type_unique": {
+          "name": "brew_method_equipment_rule_brew_method_equipment_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "brew_method",
+            "equipment_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment": {
+      "name": "comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comment_recipe_id_idx": {
+          "name": "comment_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_author_id_idx": {
+          "name": "comment_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_parent_comment_id_idx": {
+          "name": "comment_parent_comment_id_idx",
+          "columns": [
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_created_at_idx": {
+          "name": "comment_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comment_deleted_at_idx": {
+          "name": "comment_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_recipe_id_recipe_id_fk": {
+          "name": "comment_recipe_id_recipe_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comment_author_id_user_id_fk": {
+          "name": "comment_author_id_user_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comment_parent_comment_id_comment_id_fk": {
+          "name": "comment_parent_comment_id_comment_id_fk",
+          "tableFrom": "comment",
+          "tableTo": "comment",
+          "columnsFrom": [
+            "parent_comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_token": {
+      "name": "email_verification_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_token_token_idx": {
+          "name": "email_verification_token_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_verification_token_user_id_idx": {
+          "name": "email_verification_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_verification_token_expires_at_idx": {
+          "name": "email_verification_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_token_user_id_user_id_fk": {
+          "name": "email_verification_token_user_id_user_id_fk",
+          "tableFrom": "email_verification_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_verification_token_token_unique": {
+          "name": "email_verification_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.equipment": {
+      "name": "equipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "equipment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "equipment_type_idx": {
+          "name": "equipment_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "equipment_name_idx": {
+          "name": "equipment_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "equipment_deleted_at_idx": {
+          "name": "equipment_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "equipment_created_by_user_id_fk": {
+          "name": "equipment_created_by_user_id_fk",
+          "tableFrom": "equipment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset": {
+      "name": "password_reset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "password_reset_token_idx": {
+          "name": "password_reset_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_user_id_idx": {
+          "name": "password_reset_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_expires_at_idx": {
+          "name": "password_reset_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_user_id_user_id_fk": {
+          "name": "password_reset_user_id_user_id_fk",
+          "tableFrom": "password_reset",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_token_unique": {
+          "name": "password_reset_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.photo": {
+      "name": "photo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "photo_recipe_id_idx": {
+          "name": "photo_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "photo_deleted_at_idx": {
+          "name": "photo_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "photo_recipe_id_recipe_id_fk": {
+          "name": "photo_recipe_id_recipe_id_fk",
+          "tableFrom": "photo",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_additional_preparation": {
+      "name": "recipe_additional_preparation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_version_id": {
+          "name": "recipe_version_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "additional_preparation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_amount": {
+          "name": "input_amount",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preparation_type": {
+          "name": "preparation_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "recipe_additional_preparation_recipe_version_id_idx": {
+          "name": "recipe_additional_preparation_recipe_version_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_addl_prep_recipe_version_id_fk": {
+          "name": "recipe_addl_prep_recipe_version_id_fk",
+          "tableFrom": "recipe_additional_preparation",
+          "tableTo": "recipe_version",
+          "columnsFrom": [
+            "recipe_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_equipment": {
+      "name": "recipe_equipment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_version_id": {
+          "name": "recipe_version_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "equipment_id": {
+          "name": "equipment_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "recipe_equipment_recipe_version_id_idx": {
+          "name": "recipe_equipment_recipe_version_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_equipment_equipment_id_idx": {
+          "name": "recipe_equipment_equipment_id_idx",
+          "columns": [
+            {
+              "expression": "equipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_equipment_recipe_version_id_recipe_version_id_fk": {
+          "name": "recipe_equipment_recipe_version_id_recipe_version_id_fk",
+          "tableFrom": "recipe_equipment",
+          "tableTo": "recipe_version",
+          "columnsFrom": [
+            "recipe_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_equipment_equipment_id_equipment_id_fk": {
+          "name": "recipe_equipment_equipment_id_equipment_id_fk",
+          "tableFrom": "recipe_equipment",
+          "tableTo": "equipment",
+          "columnsFrom": [
+            "equipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_equipment_recipe_version_id_equipment_id_unique": {
+          "name": "recipe_equipment_recipe_version_id_equipment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipe_version_id",
+            "equipment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_taste_note": {
+      "name": "recipe_taste_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_version_id": {
+          "name": "recipe_version_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taste_note_id": {
+          "name": "taste_note_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intensity": {
+          "name": "intensity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "recipe_taste_note_recipe_version_id_idx": {
+          "name": "recipe_taste_note_recipe_version_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_taste_note_taste_note_id_idx": {
+          "name": "recipe_taste_note_taste_note_id_idx",
+          "columns": [
+            {
+              "expression": "taste_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_taste_note_recipe_version_id_recipe_version_id_fk": {
+          "name": "recipe_taste_note_recipe_version_id_recipe_version_id_fk",
+          "tableFrom": "recipe_taste_note",
+          "tableTo": "recipe_version",
+          "columnsFrom": [
+            "recipe_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_taste_note_taste_note_id_taste_note_id_fk": {
+          "name": "recipe_taste_note_taste_note_id_taste_note_id_fk",
+          "tableFrom": "recipe_taste_note",
+          "tableTo": "taste_note",
+          "columnsFrom": [
+            "taste_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_taste_note_recipe_version_id_taste_note_id_unique": {
+          "name": "recipe_taste_note_recipe_version_id_taste_note_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipe_version_id",
+            "taste_note_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_version_photo": {
+      "name": "recipe_version_photo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_version_id": {
+          "name": "recipe_version_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_id": {
+          "name": "photo_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "recipe_version_photo_recipe_version_id_idx": {
+          "name": "recipe_version_photo_recipe_version_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_version_photo_photo_id_idx": {
+          "name": "recipe_version_photo_photo_id_idx",
+          "columns": [
+            {
+              "expression": "photo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_version_photo_recipe_version_id_recipe_version_id_fk": {
+          "name": "recipe_version_photo_recipe_version_id_recipe_version_id_fk",
+          "tableFrom": "recipe_version_photo",
+          "tableTo": "recipe_version",
+          "columnsFrom": [
+            "recipe_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_version_photo_photo_id_photo_id_fk": {
+          "name": "recipe_version_photo_photo_id_photo_id_fk",
+          "tableFrom": "recipe_version_photo",
+          "tableTo": "photo",
+          "columnsFrom": [
+            "photo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_version_photo_recipe_version_id_photo_id_unique": {
+          "name": "recipe_version_photo_recipe_version_id_photo_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipe_version_id",
+            "photo_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_version": {
+      "name": "recipe_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coffee_brand": {
+          "name": "coffee_brand",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coffee_processing": {
+          "name": "coffee_processing",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roast_date": {
+          "name": "roast_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_open_date": {
+          "name": "package_open_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grind_date": {
+          "name": "grind_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brew_date": {
+          "name": "brew_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "brew_method": {
+          "name": "brew_method",
+          "type": "brew_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drink_type": {
+          "name": "drink_type",
+          "type": "drink_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brewer_details": {
+          "name": "brewer_details",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grinder": {
+          "name": "grinder",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grind_size": {
+          "name": "grind_size",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ground_weight_grams": {
+          "name": "ground_weight_grams",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_time_seconds": {
+          "name": "extraction_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_volume_ml": {
+          "name": "extraction_volume_ml",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature_celsius": {
+          "name": "temperature_celsius",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brew_ratio": {
+          "name": "brew_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flow_rate": {
+          "name": "flow_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_infusion_time_seconds": {
+          "name": "pre_infusion_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bean_id": {
+          "name": "bean_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_notes": {
+          "name": "personal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preparation_notes": {
+          "name": "preparation_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_favourite": {
+          "name": "is_favourite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji_tag": {
+          "name": "emoji_tag",
+          "type": "emoji_tag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recipe_version_recipe_id_idx": {
+          "name": "recipe_version_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_version_brew_method_idx": {
+          "name": "recipe_version_brew_method_idx",
+          "columns": [
+            {
+              "expression": "brew_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_version_drink_type_idx": {
+          "name": "recipe_version_drink_type_idx",
+          "columns": [
+            {
+              "expression": "drink_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_version_created_at_idx": {
+          "name": "recipe_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_version_recipe_id_recipe_id_fk": {
+          "name": "recipe_version_recipe_id_recipe_id_fk",
+          "tableFrom": "recipe_version",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_version_vendor_id_vendor_id_fk": {
+          "name": "recipe_version_vendor_id_vendor_id_fk",
+          "tableFrom": "recipe_version",
+          "tableTo": "vendor",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_version_bean_id_bean_id_fk": {
+          "name": "recipe_version_bean_id_bean_id_fk",
+          "tableFrom": "recipe_version",
+          "tableTo": "bean",
+          "columnsFrom": [
+            "bean_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_version_recipe_id_version_number_unique": {
+          "name": "recipe_version_recipe_id_version_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipe_id",
+            "version_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe": {
+      "name": "recipe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comment_count": {
+          "name": "comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fork_count": {
+          "name": "fork_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "forked_from_id": {
+          "name": "forked_from_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recipe_author_id_idx": {
+          "name": "recipe_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_visibility_idx": {
+          "name": "recipe_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_created_at_idx": {
+          "name": "recipe_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_like_count_idx": {
+          "name": "recipe_like_count_idx",
+          "columns": [
+            {
+              "expression": "like_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_forked_from_id_idx": {
+          "name": "recipe_forked_from_id_idx",
+          "columns": [
+            {
+              "expression": "forked_from_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_slug_idx": {
+          "name": "recipe_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_deleted_at_idx": {
+          "name": "recipe_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_author_id_user_id_fk": {
+          "name": "recipe_author_id_user_id_fk",
+          "tableFrom": "recipe",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recipe_current_version_id_recipe_version_id_fk": {
+          "name": "recipe_current_version_id_recipe_version_id_fk",
+          "tableFrom": "recipe",
+          "tableTo": "recipe_version",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "recipe_forked_from_id_recipe_id_fk": {
+          "name": "recipe_forked_from_id_recipe_id_fk",
+          "tableFrom": "recipe",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "forked_from_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_slug_unique": {
+          "name": "recipe_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report": {
+      "name": "report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_entity_type_entity_id_idx": {
+          "name": "report_entity_type_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_status_idx": {
+          "name": "report_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_reporter_id_idx": {
+          "name": "report_reporter_id_idx",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_created_at_idx": {
+          "name": "report_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_reporter_id_user_id_fk": {
+          "name": "report_reporter_id_user_id_fk",
+          "tableFrom": "report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.setup": {
+      "name": "setup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brewer_details": {
+          "name": "brewer_details",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grinder": {
+          "name": "grinder",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "portafilter_id": {
+          "name": "portafilter_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basket_id": {
+          "name": "basket_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "puck_screen_id": {
+          "name": "puck_screen_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paper_filter_id": {
+          "name": "paper_filter_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tamper_id": {
+          "name": "tamper_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "setup_user_id_idx": {
+          "name": "setup_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "setup_deleted_at_idx": {
+          "name": "setup_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "setup_user_id_user_id_fk": {
+          "name": "setup_user_id_user_id_fk",
+          "tableFrom": "setup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "setup_portafilter_id_equipment_id_fk": {
+          "name": "setup_portafilter_id_equipment_id_fk",
+          "tableFrom": "setup",
+          "tableTo": "equipment",
+          "columnsFrom": [
+            "portafilter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "setup_basket_id_equipment_id_fk": {
+          "name": "setup_basket_id_equipment_id_fk",
+          "tableFrom": "setup",
+          "tableTo": "equipment",
+          "columnsFrom": [
+            "basket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "setup_puck_screen_id_equipment_id_fk": {
+          "name": "setup_puck_screen_id_equipment_id_fk",
+          "tableFrom": "setup",
+          "tableTo": "equipment",
+          "columnsFrom": [
+            "puck_screen_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "setup_paper_filter_id_equipment_id_fk": {
+          "name": "setup_paper_filter_id_equipment_id_fk",
+          "tableFrom": "setup",
+          "tableTo": "equipment",
+          "columnsFrom": [
+            "paper_filter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "setup_tamper_id_equipment_id_fk": {
+          "name": "setup_tamper_id_equipment_id_fk",
+          "tableFrom": "setup",
+          "tableTo": "equipment",
+          "columnsFrom": [
+            "tamper_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.taste_note": {
+      "name": "taste_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "taste_note_parent_id_idx": {
+          "name": "taste_note_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "taste_note_name_idx": {
+          "name": "taste_note_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "taste_note_depth_idx": {
+          "name": "taste_note_depth_idx",
+          "columns": [
+            {
+              "expression": "depth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "taste_note_parent_id_taste_note_id_fk": {
+          "name": "taste_note_parent_id_taste_note_id_fk",
+          "tableFrom": "taste_note",
+          "tableTo": "taste_note",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_badge": {
+      "name": "user_badge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_user_id_idx": {
+          "name": "user_badge_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_badge_badge_id_idx": {
+          "name": "user_badge_badge_id_idx",
+          "columns": [
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_badge_user_id_user_id_fk": {
+          "name": "user_badge_user_id_user_id_fk",
+          "tableFrom": "user_badge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_badge_badge_id_badge_id_fk": {
+          "name": "user_badge_badge_id_badge_id_fk",
+          "tableFrom": "user_badge",
+          "tableTo": "badge",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_badge_user_id_badge_id_unique": {
+          "name": "user_badge_user_id_badge_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "badge_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follow": {
+      "name": "user_follow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follow_follower_id_idx": {
+          "name": "user_follow_follower_id_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follow_following_id_idx": {
+          "name": "user_follow_following_id_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follow_created_at_idx": {
+          "name": "user_follow_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follow_follower_id_user_id_fk": {
+          "name": "user_follow_follower_id_user_id_fk",
+          "tableFrom": "user_follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_follow_following_id_user_id_fk": {
+          "name": "user_follow_following_id_user_id_fk",
+          "tableFrom": "user_follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_follow_follower_id_following_id_unique": {
+          "name": "user_follow_follower_id_following_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_system": {
+          "name": "unit_system",
+          "type": "unit_system",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'metric'"
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "temperature_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'celsius'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'light'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "date_format": {
+          "name": "date_format",
+          "type": "date_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'YYYY_MM_DD'"
+        },
+        "new_follower": {
+          "name": "new_follower",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "recipe_liked": {
+          "name": "recipe_liked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "recipe_commented": {
+          "name": "recipe_commented",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "followed_user_posted": {
+          "name": "followed_user_posted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_user_id_fk": {
+          "name": "user_preferences_user_id_user_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_recipe_favourite": {
+      "name": "user_recipe_favourite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_recipe_favourite_user_id_idx": {
+          "name": "user_recipe_favourite_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_recipe_favourite_recipe_id_idx": {
+          "name": "user_recipe_favourite_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_recipe_favourite_created_at_idx": {
+          "name": "user_recipe_favourite_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_recipe_favourite_user_id_user_id_fk": {
+          "name": "user_recipe_favourite_user_id_user_id_fk",
+          "tableFrom": "user_recipe_favourite",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_recipe_favourite_recipe_id_recipe_id_fk": {
+          "name": "user_recipe_favourite_recipe_id_recipe_id_fk",
+          "tableFrom": "user_recipe_favourite",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_recipe_favourite_user_id_recipe_id_unique": {
+          "name": "user_recipe_favourite_user_id_recipe_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "recipe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_recipe_like": {
+      "name": "user_recipe_like",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_recipe_like_user_id_idx": {
+          "name": "user_recipe_like_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_recipe_like_recipe_id_idx": {
+          "name": "user_recipe_like_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_recipe_like_created_at_idx": {
+          "name": "user_recipe_like_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_recipe_like_user_id_user_id_fk": {
+          "name": "user_recipe_like_user_id_user_id_fk",
+          "tableFrom": "user_recipe_like",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_recipe_like_recipe_id_recipe_id_fk": {
+          "name": "user_recipe_like_recipe_id_recipe_id_fk",
+          "tableFrom": "user_recipe_like",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_recipe_like_user_id_recipe_id_unique": {
+          "name": "user_recipe_like_user_id_recipe_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "recipe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_recipe_rating": {
+      "name": "user_recipe_rating",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_recipe_rating_user_id_idx": {
+          "name": "user_recipe_rating_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_recipe_rating_recipe_id_idx": {
+          "name": "user_recipe_rating_recipe_id_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_recipe_rating_user_id_user_id_fk": {
+          "name": "user_recipe_rating_user_id_user_id_fk",
+          "tableFrom": "user_recipe_rating",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_recipe_rating_recipe_id_recipe_id_fk": {
+          "name": "user_recipe_rating_recipe_id_recipe_id_fk",
+          "tableFrom": "user_recipe_rating",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_recipe_rating_user_id_recipe_id_unique": {
+          "name": "user_recipe_rating_user_id_recipe_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "recipe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_banned": {
+          "name": "is_banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_username_idx": {
+          "name": "user_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_created_at_idx": {
+          "name": "user_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_deleted_at_idx": {
+          "name": "user_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vendor": {
+      "name": "vendor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vendor_name_idx": {
+          "name": "vendor_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vendor_deleted_at_idx": {
+          "name": "vendor_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.additional_preparation_type": {
+      "name": "additional_preparation_type",
+      "schema": "public",
+      "values": [
+        "milk",
+        "water",
+        "syrup",
+        "spice",
+        "other"
+      ]
+    },
+    "public.badge_rule": {
+      "name": "badge_rule",
+      "schema": "public",
+      "values": [
+        "first_brew",
+        "decade_brewer",
+        "centurion",
+        "first_fork",
+        "fan_favourite",
+        "community_star",
+        "conversationalist",
+        "precision_brewer",
+        "explorer",
+        "influencer"
+      ]
+    },
+    "public.brew_method": {
+      "name": "brew_method",
+      "schema": "public",
+      "values": [
+        "espresso_machine",
+        "v60",
+        "french_press",
+        "aeropress",
+        "turkish_coffee",
+        "drip_coffee",
+        "chemex",
+        "kalita_wave",
+        "moka_pot",
+        "cold_brew",
+        "siphon"
+      ]
+    },
+    "public.date_format": {
+      "name": "date_format",
+      "schema": "public",
+      "values": [
+        "DD_MM_YYYY",
+        "MM_DD_YYYY",
+        "YYYY_MM_DD"
+      ]
+    },
+    "public.drink_type": {
+      "name": "drink_type",
+      "schema": "public",
+      "values": [
+        "espresso",
+        "americano",
+        "flat_white",
+        "latte",
+        "cappuccino",
+        "cortado",
+        "macchiato",
+        "turkish_coffee",
+        "pour_over",
+        "cold_brew",
+        "french_press",
+        "aeropress",
+        "drip_coffee",
+        "moka_pot",
+        "siphon"
+      ]
+    },
+    "public.emoji_tag": {
+      "name": "emoji_tag",
+      "schema": "public",
+      "values": [
+        "fire",
+        "rocket",
+        "thumbsup",
+        "neutral",
+        "thumbsdown",
+        "nauseated"
+      ]
+    },
+    "public.equipment_type": {
+      "name": "equipment_type",
+      "schema": "public",
+      "values": [
+        "portafilter",
+        "basket",
+        "puck_screen",
+        "paper_filter",
+        "tamper",
+        "gooseneck_kettle",
+        "mesh_filter",
+        "cezve",
+        "scale",
+        "thermometer",
+        "other"
+      ]
+    },
+    "public.temperature_unit": {
+      "name": "temperature_unit",
+      "schema": "public",
+      "values": [
+        "celsius",
+        "fahrenheit"
+      ]
+    },
+    "public.theme": {
+      "name": "theme",
+      "schema": "public",
+      "values": [
+        "light",
+        "dark",
+        "coffee"
+      ]
+    },
+    "public.unit_system": {
+      "name": "unit_system",
+      "schema": "public",
+      "values": [
+        "metric",
+        "imperial"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "draft",
+        "private",
+        "unlisted",
+        "public"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778701465283,
       "tag": "0004_burly_masque",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1779303614363,
+      "tag": "0005_wooden_owl",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -134,6 +134,7 @@ export const users = pgTable(
   {
     id: varchar('id', { length: 36 }).primaryKey().$defaultFn(() => crypto.randomUUID()),
     email: varchar('email', { length: 255 }).notNull().unique(),
+    emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),
     username: varchar('username', { length: 255 }).notNull().unique(),
     passwordHash: varchar('password_hash', { length: 255 }).notNull(),
     displayName: varchar('display_name', { length: 255 }),
@@ -631,6 +632,25 @@ export const passwordResets = pgTable(
   ],
 );
 
+export const emailVerificationTokens = pgTable(
+  'email_verification_token',
+  {
+    id: varchar('id', { length: 36 }).primaryKey().$defaultFn(() => crypto.randomUUID()),
+    userId: varchar('user_id', { length: 36 }).notNull().references(() => users.id, {
+      onDelete: 'cascade',
+    }),
+    token: varchar('token', { length: 255 }).notNull().unique(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    usedAt: timestamp('used_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('email_verification_token_token_idx').on(table.token),
+    index('email_verification_token_user_id_idx').on(table.userId),
+    index('email_verification_token_expires_at_idx').on(table.expiresAt),
+  ],
+);
+
 export const reports = pgTable(
   'report',
   {
@@ -674,6 +694,7 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   beans: many(beans),
   auditLogs: many(auditLogs),
   passwordResets: many(passwordResets),
+  emailVerificationTokens: many(emailVerificationTokens),
   reports: many(reports),
 }));
 
@@ -941,3 +962,13 @@ export const reportsRelations = relations(reports, ({ one }) => ({
     references: [users.id],
   }),
 }));
+
+export const emailVerificationTokensRelations = relations(
+  emailVerificationTokens,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [emailVerificationTokens.userId],
+      references: [users.id],
+    }),
+  }),
+);

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -119,6 +119,7 @@ async function seedUsers(tx: any) {
     displayName: 'BrewForm Admin',
     isAdmin: true,
     onboardingCompleted: true,
+    emailVerifiedAt: new Date(),
   }).returning();
 
   await tx.insert(userPreferences).values({ userId: admin.id });
@@ -133,6 +134,7 @@ async function seedUsers(tx: any) {
       displayName: userData.displayName,
       bio: userData.bio,
       onboardingCompleted: userData.onboardingCompleted,
+      emailVerifiedAt: new Date(),
     }).returning();
 
     await tx.insert(userPreferences).values({

--- a/plans/01-critical-stability-security.md
+++ b/plans/01-critical-stability-security.md
@@ -304,18 +304,17 @@ function setAuthCookies(
 function clearAuthCookies(c: Context) {
   const isProduction = config.APP_ENV === 'production';
 
+  // NOTE: deleteCookie only accepts `path`, `secure`, and `domain`.
+  // httpOnly/sameSite/maxAge are setCookie-only options — the browser
+  // matches cookies to delete by name + path + domain, not flags.
   deleteCookie(c, 'brewform_access_token', {
-    httpOnly: true,
-    secure: isProduction,
-    sameSite: 'Strict',
     path: '/',
+    secure: isProduction,
   });
 
   deleteCookie(c, 'brewform_refresh_token', {
-    httpOnly: true,
-    secure: isProduction,
-    sameSite: 'Strict',
     path: '/api/v1/auth',
+    secure: isProduction,
   });
 }
 ```
@@ -1069,10 +1068,12 @@ Create `apps/web/src/pages/auth/VerifyEmailPage.tsx`:
 ```tsx
 import { useEffect, useState } from 'react';
 import { useSearchParams, Link } from 'react-router';
+import { useAuth } from '../../contexts/AuthContext';
 import { authApi } from '../../api/index';
 
 export function VerifyEmailPage() {
   const [searchParams] = useSearchParams();
+  const { refreshUser } = useAuth();
   const token = searchParams.get('token');
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
   const [errorMessage, setErrorMessage] = useState('');
@@ -1085,12 +1086,15 @@ export function VerifyEmailPage() {
     }
 
     authApi.verifyEmail({ token })
-      .then(() => setStatus('success'))
+      .then(async () => {
+        await refreshUser(); // re-fetch user so emailVerifiedAt is set in AuthContext
+        setStatus('success');
+      })
       .catch((err) => {
         setStatus('error');
         setErrorMessage(err.message || 'Verification failed.');
       });
-  }, [token]);
+  }, [token, refreshUser]);
 
   return (
     <div className="flex min-h-[60vh] flex-col items-center justify-center px-6 text-center">

--- a/plans/deep-dive-analysis.md
+++ b/plans/deep-dive-analysis.md
@@ -702,9 +702,12 @@ const token = getCookie(c, 'brewform_access_token')
 4. **Logout** -- Add server-side endpoint that clears cookies:
 
 ```ts
+import { deleteCookie } from 'hono/cookie';
+
 app.post('/auth/logout', (c) => {
-  setCookie(c, 'brewform_access_token', '', { maxAge: 0, path: '/' });
-  setCookie(c, 'brewform_refresh_token', '', { maxAge: 0, path: '/api/v1/auth/refresh' });
+  // deleteCookie only accepts path, secure, and domain (not httpOnly/sameSite)
+  deleteCookie(c, 'brewform_access_token', { path: '/' });
+  deleteCookie(c, 'brewform_refresh_token', { path: '/api/v1/auth/refresh' });
   return c.json({ success: true });
 });
 ```
@@ -753,10 +756,12 @@ emailVerificationExpiry: timestamp('email_verification_expiry'),
    - Clear token fields
    - Return tokens (or redirect to login)
 
-4. **Login guard** -- Check `emailVerified` in login handler:
+4. **Frontend VerifyEmailPage** -- After successful verification, call `refreshUser()` from `AuthContext` before setting success status. This ensures `emailVerifiedAt` is updated in the context and the `EmailVerificationBanner` disappears immediately without requiring a page reload.
+
+5. **Login guard** -- Check `emailVerified` in login handler:
    - If not verified, return 403 with `{ error: 'Email not verified', resendUrl: '/api/v1/auth/resend-verification' }`
 
-5. **Resend endpoint** -- Add `POST /api/v1/auth/resend-verification` with rate limiting.
+6. **Resend endpoint** -- Add `POST /api/v1/auth/resend-verification` with rate limiting.
 
 **Effort:** Medium (6-8 hours)
 


### PR DESCRIPTION
# Security & Stability Hardening (Plan 01)

## Summary

Implements the 6 critical security and stability fixes from `plans/01-critical-stability-security.md`. Eliminates the XSS token theft vector, prevents white-screen crashes, adds HTTP security headers, closes an open-redirect hole, enables email verification, and fixes the Deno Deploy rate-limit leak.

**Issues covered:** C2, H11, H12, H13, N1, N5

---

## Changes

### N1 -- Open Redirect Fix

**File:** `apps/web/index.html`

The `sessionStorage.redirect` script previously called `history.replaceState` with no URL validation. Now validates that the redirect is a relative path (starts with `/`, no `//`, no `:`), blocking `javascript:`, `data:`, protocol-relative, and absolute URLs.

### C2 -- React Error Boundaries

**Files:** `apps/web/src/components/ErrorBoundary.tsx` (new), `apps/web/src/router.tsx`

Added `RootErrorBoundary` component using `useRouteError` / `isRouteErrorResponse` from react-router. Wired into both the root route and admin route via `errorElement`. Shows friendly error UI with status codes for route errors, "Oops" screen for unhandled exceptions, dev-only stack traces, and Go Home / Reload buttons. No more white screens.

### H13 -- HTTP Security Headers

**File:** `apps/api/src/main.ts`

Added Hono `secureHeaders` middleware with:
- **CSP:** `default-src 'self'`, script/font/connect `'self'`, style `'self' 'unsafe-inline'` (Tailwind JIT), img `'self' data: https:`, object/frame-ancestors `'none'`
- **HSTS:** `max-age=63072000; includeSubDomains; preload`
- **X-Content-Type-Options:** `nosniff`
- **X-Frame-Options:** `DENY`
- **Referrer-Policy:** `strict-origin-when-cross-origin`
- **Permissions-Policy:** camera, microphone, geolocation all disabled

Positioned after CORS/requestId and before rate limiting, per Hono docs.

### N5 -- Rate Limit Rewrite

**File:** `apps/api/src/middleware/rateLimit.ts`

Replaced the in-memory `Map` (per-isolate on Deno Deploy, trivially bypassable) with the `CacheProvider` singleton backed by Deno KV (shared across isolates). Both `rateLimitMiddleware` and `authRateLimitMiddleware` now use `cacheProvider.get()` / `.set()` with TTL-based expiry. Wired `authRateLimitMiddleware` to register, login, and forgot-password routes (5 attempts / 15-min window).

### H11 -- Cookie-Based JWT Auth

**The largest change.** Migrated JWT storage from `localStorage` (XSS-vulnerable) to `httpOnly` cookies.

**Backend (`apps/api`):**
- Added `setAuthCookies()` / `clearAuthCookies()` helpers in auth module
- `brewform_access_token`: httpOnly, Secure (prod), SameSite=Strict, path `/`, maxAge 15 min
- `brewform_refresh_token`: httpOnly, Secure (prod), SameSite=Strict, path `/api/v1/auth`, maxAge 7d (or 180d with Remember Me)
- Register/login/refresh handlers set cookies instead of returning tokens in response body
- Added `POST /auth/logout` endpoint that clears cookies
- Auth middleware reads access token from cookie (with `Authorization` header fallback)

**Frontend (`apps/web`):**
- Rewrote `api/client.ts`: removed all `localStorage` token logic, all requests use `credentials: 'include'`, silent 401 -> refresh -> retry flow
- Updated `AuthContext.tsx`: removed token management, always calls `userApi.me()` on mount (cookie provides auth), `logout()` is now async and calls the logout endpoint
- Removed `clearTokens`, `getAccessToken`, `setAccessToken` exports from `api/index.ts`

### H12 -- Email Verification Flow

**Schema (`packages/db/src/schema.ts`):**
- Added `emailVerifiedAt` timestamp column to `users` table
- Created `emailVerificationTokens` table with token, expiry, usage tracking, and indexes
- Added relations between users and verification tokens

**Backend (`apps/api`):**
- Model: `createEmailVerificationToken`, `findEmailVerificationByToken`, `markEmailVerified`
- Service: `sendVerificationToken` (24hr expiry), `verifyEmail` (validates + marks verified)
- Registration now sends a verification email instead of a welcome email
- Added `POST /auth/send-verification` (resend, requires auth) and `POST /auth/verify-email` endpoints
- Added `isEmailVerified()` guard -- recipe and comment creation require verified email (403 otherwise)
- Created MJML email template for verification emails

**Frontend (`apps/web`):**
- `EmailVerificationBanner` component (shown for unverified users, with resend button)
- `VerifyEmailPage` (reads token from URL, calls API, refreshes user state)
- Added `verify-email` route and `sendVerification` / `verifyEmail` to `authApi`

### Test Fixes
- Updated `LoginPage.test.tsx`: async `waitFor` for AuthProvider mount, added `htmlFor`/`id` to email/password labels for accessibility
- Updated `Navbar.test.tsx` and `RegisterPage.test.tsx`: removed stale token mocks, added `authApi.logout` mock
- Fixed flaky PBT tests: reduced `numRuns` from 100 to 12/8 for async DOM-heavy property tests (the input domains only have 4-6 possible values), added explicit 15s timeouts

---

## Files Changed

| Area | Files | What |
|------|-------|------|
| Frontend core | `index.html`, `router.tsx`, `api/client.ts`, `api/index.ts`, `AuthContext.tsx` | Open redirect fix, cookie auth, route wiring |
| Frontend components | `ErrorBoundary.tsx` (new), `EmailVerificationBanner.tsx` (new), `VerifyEmailPage.tsx` (new), `Layout.tsx`, `LoginPage.tsx` | Error boundary, email verification UI, a11y |
| API middleware | `main.ts`, `auth.ts`, `rateLimit.ts` | Security headers, cookie auth, KV-backed rate limiting |
| API auth module | `auth/index.ts`, `auth/service.ts`, `auth/model.ts`, `auth/email.ts` | Cookie endpoints, email verification logic |
| API guards | `response/index.ts`, `recipe/index.ts`, `comment/index.ts` | Email verification gating |
| Email templates | `verify-email.mjml` (new), `generated/verify-email.ts` (new) | Verification email |
| Schema | `packages/db/src/schema.ts` | `emailVerifiedAt` column, `emailVerificationTokens` table |
| Tests | `LoginPage.test.tsx`, `RegisterPage.test.tsx`, `Navbar.test.tsx`, `Navbar.pbt.test.tsx` | Mock updates, async fixes, PBT tuning |

---

## Migration Required

After merging, run:
```bash
make db-generate
make db-migrate
```

This creates the `email_verified_at` column on `users` and the `email_verification_token` table. Existing users will have `email_verified_at = NULL` (unverified) -- they can verify via the banner that appears after login.

---

## CI Status

- `make fmt` -- passes
- `make lint` -- passes
- `make check` -- passes (all 4 packages: api, web, db, shared)
- `make test` -- 79/79 API + shared tests pass
- Web tests -- 532/533 pass (1 pre-existing flaky `TasteNotesFilter` test unrelated to this PR)

---

## Test Plan

- [ ] `make fmt` passes
- [ ] `make lint` passes
- [ ] `make check` passes
- [ ] `make test` passes (API + shared)
- [ ] Web tests pass (all Navbar PBTs, LoginPage, RegisterPage)
- [ ] **Cookie auth:** Log in, confirm no tokens in `localStorage`, confirm `brewform_access_token` and `brewform_refresh_token` in DevTools > Cookies with HttpOnly flag
- [ ] **Token refresh:** Wait 15min (or shorten `JWT_ACCESS_EXPIRY`), make a request, confirm silent refresh works
- [ ] **Logout:** Log out, confirm cookies are cleared, confirm subsequent API calls require re-login
- [ ] **Error boundary:** Navigate to `/nonexistent-route`, confirm friendly 404 page instead of white screen
- [ ] **Security headers:** `curl -I http://localhost:8000/health` -- confirm CSP, HSTS, X-Frame-Options, etc.
- [ ] **Open redirect:** Set `sessionStorage.redirect = 'https://evil.com'` in console, reload, confirm it's ignored; then `sessionStorage.redirect = '/recipes'`, confirm it works
- [ ] **Rate limiting:** Send 6 rapid login requests with wrong credentials, confirm 6th returns 429
- [ ] **Email verification:** Register new user, check Mailpit for verification email, click link, confirm banner disappears
- [ ] **Verification gating:** Try creating a recipe with unverified email, confirm 403 response
- [ ] **DB migration:** Run `make db-generate && make db-migrate`, confirm schema applies cleanly

---

## Security Considerations

- **httpOnly cookies** prevent JavaScript access -- XSS can no longer exfiltrate tokens
- **SameSite=Strict** prevents CSRF for state-changing requests
- **Refresh token path scoping** (`/api/v1/auth`) limits cookie exposure to auth endpoints only
- **Secure flag** (production) ensures cookies are only sent over HTTPS
- **Rate limiting via Deno KV** is shared across isolates, preventing bypass via request distribution
- **CSP `frame-ancestors: 'none'`** + `X-Frame-Options: DENY` prevent clickjacking
- **HSTS with preload** ensures HTTPS-only access after first visit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Email verification system—users must verify their email before creating recipes or comments.
  * Email verification banner prompts unverified users to confirm their email.
  * New verify email page for email confirmation links.
  * HTTP-only cookie-based authentication for enhanced security.
  * Email resend functionality for verification links.
  * Error boundary for improved error page displays.

* **Bug Fixes**
  * Fixed redirect URL validation to prevent unsafe redirects.
  * Improved form accessibility with proper label associations.

* **Security**
  * Added security headers middleware to all API responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ardakilic/BrewForm/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->