### PR TITLE
feat: Flush Contents Commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,17 @@ db-seed: ## Seed the database
 db-studio: ## Open Drizzle Studio
 	docker compose run --rm -p 5555:5555 app sh -c "cd packages/db && deno run -A $(DRIZZLE_KIT) studio --host=0.0.0.0 --port=5555"
 
-db-reset: ## Instructions to reset database
-	docker compose run --rm app bash -c "echo 'Drop and recreate database manually, then run db-migrate and db-seed'"
+flush-db: ## Truncate all database tables
+	docker compose run --rm app deno run --allow-env --allow-net apps/api/scripts/flush-db.ts
+
+flush-cache: ## Clear Deno KV cache
+	docker compose run --rm app deno run --allow-env --allow-read --allow-write apps/api/scripts/flush-cache.ts
+
+flush-contents: flush-db flush-cache ## Truncate all database tables and clear Deno KV cache
+
+db-reset: flush-contents ## Full reset: truncate tables, clear cache, run migrations, re-seed
+	$(MAKE) db-migrate
+	$(MAKE) db-seed
 
 # --- Admin Setup ---
 
@@ -192,4 +201,4 @@ serena-index: ## Index project with Serena
 serena-health: ## Check Serena health
 	@curl -sf --max-time 5 --connect-timeout 2 http://localhost:10122/sse > /dev/null 2>&1 && echo "✓ Serena is healthy" || echo "✗ Serena is not responding"
 
-.PHONY: help up down build logs restart install email-build lint fmt fmt-check check check-tests test test-coverage test-api test-shared test-web test-specific db-migrate db-generate db-push db-seed db-studio db-reset setup dev dev-api web-dev web-build preview ci generate-icons serena-up serena-down serena-logs serena-index serena-health
+.PHONY: help up down build logs restart install email-build lint fmt fmt-check check check-tests test test-coverage test-api test-shared test-web test-specific db-migrate db-generate db-push db-seed db-studio flush-db flush-cache flush-contents db-reset setup dev dev-api web-dev web-build preview ci generate-icons serena-up serena-down serena-logs serena-index serena-health

--- a/README.md
+++ b/README.md
@@ -168,11 +168,14 @@ See [docs/serena-mcp.md](docs/serena-mcp.md) for detailed setup, architecture, a
 ## Database
 
 ```bash
-make db-generate   # Generate Drizzle migration SQL
-make db-migrate    # Apply pending migrations
-make db-seed       # Seed sample data
-make db-studio     # Open Drizzle Studio (GUI)
-make db-reset      # Reset database (destroys all data)
+make db-generate     # Generate Drizzle migration SQL
+make db-migrate      # Apply pending migrations
+make db-seed         # Seed sample data
+make db-studio       # Open Drizzle Studio (GUI)
+make flush-db        # Truncate all database tables
+make flush-cache     # Clear Deno KV cache
+make flush-contents  # Truncate all tables + clear Deno KV cache
+make db-reset        # Full reset: flush-db, flush-cache, migrate, re-seed
 ```
 
 ## Architecture

--- a/apps/api/scripts/flush-cache.ts
+++ b/apps/api/scripts/flush-cache.ts
@@ -6,24 +6,23 @@
  *   make flush-cache
  */
 
-let count = 0;
-
 try {
   const kv = await Deno.openKv();
   console.log('Clearing Deno KV cache...');
+  let count = 0;
   const entries = kv.list({ prefix: [] });
   for await (const entry of entries) {
     await kv.delete(entry.key);
     count++;
   }
   kv.close();
-  console.log(`Cleared ${count} KV entries successfully.`);
+  if (count === 0) {
+    console.log('No KV entries found to clear.');
+  } else {
+    console.log(`Cleared ${count} KV entries successfully.`);
+  }
 } catch (error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   console.warn(`Could not clear Deno KV: ${message}`);
   console.warn('This is expected if KV is not initialized or the data directory is not mounted.');
-}
-
-if (count === 0) {
-  console.log('No KV entries found to clear.');
 }

--- a/apps/api/scripts/flush-cache.ts
+++ b/apps/api/scripts/flush-cache.ts
@@ -1,0 +1,29 @@
+/**
+ * Clear all Deno KV cache entries.
+ *
+ * Usage:
+ *   deno run --allow-env --allow-read --allow-write apps/api/scripts/flush-cache.ts
+ *   make flush-cache
+ */
+
+let count = 0;
+
+try {
+  const kv = await Deno.openKv();
+  console.log('Clearing Deno KV cache...');
+  const entries = kv.list({ prefix: [] });
+  for await (const entry of entries) {
+    await kv.delete(entry.key);
+    count++;
+  }
+  kv.close();
+  console.log(`Cleared ${count} KV entries successfully.`);
+} catch (error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`Could not clear Deno KV: ${message}`);
+  console.warn('This is expected if KV is not initialized or the data directory is not mounted.');
+}
+
+if (count === 0) {
+  console.log('No KV entries found to clear.');
+}

--- a/apps/api/scripts/flush-db.ts
+++ b/apps/api/scripts/flush-db.ts
@@ -6,39 +6,35 @@
  *   make flush-db
  */
 
-import { client } from '@brewform/db';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import * as schema from '@brewform/db/schema';
 
-const TABLE_NAMES = [
-  'recipe_version_photo',
-  'recipe_taste_note',
-  'recipe_equipment',
-  'recipe_additional_preparation',
-  'user_recipe_favourite',
-  'user_recipe_like',
-  'user_recipe_rating',
-  'user_follow',
-  'user_badge',
-  'comment',
-  'report',
-  'password_reset',
-  'email_verification_token',
-  'audit_log',
-  'recipe_version',
-  'setup',
-  'recipe',
-  'photo',
-  'equipment',
-  'bean',
-  'vendor',
-  'taste_note',
-  'badge',
-  'brew_method_equipment_rule',
-  'user_preferences',
-  'user',
-];
+if (!Deno.env.get('DATABASE_URL')) {
+  console.error('DATABASE_URL environment variable is required.');
+  Deno.exit(1);
+}
 
-console.log('Truncating all database tables...');
-await client.unsafe(`TRUNCATE TABLE ${TABLE_NAMES.join(', ')} RESTART IDENTITY CASCADE`);
-console.log(`Truncated ${TABLE_NAMES.length} tables successfully.`);
+const { client } = await import('@brewform/db');
 
-await client.end();
+const TABLE_NAMES: string[] = [];
+for (const value of Object.values(schema)) {
+  try {
+    TABLE_NAMES.push(getTableConfig(value as never).name);
+  } catch {
+    // skip non-table exports (enums, relations, etc.)
+  }
+}
+
+console.log(`Truncating ${TABLE_NAMES.length} database tables...`);
+try {
+  await client.unsafe(
+    `TRUNCATE TABLE ${TABLE_NAMES.join(', ')} RESTART IDENTITY CASCADE`,
+  );
+  console.log(`Truncated ${TABLE_NAMES.length} tables successfully.`);
+} catch (error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Failed to truncate tables: ${message}`);
+  Deno.exit(1);
+} finally {
+  await client.end();
+}

--- a/apps/api/scripts/flush-db.ts
+++ b/apps/api/scripts/flush-db.ts
@@ -1,0 +1,44 @@
+/**
+ * Truncate all database tables.
+ *
+ * Usage:
+ *   deno run --allow-env --allow-net apps/api/scripts/flush-db.ts
+ *   make flush-db
+ */
+
+import { client } from '@brewform/db';
+
+const TABLE_NAMES = [
+  'recipe_version_photo',
+  'recipe_taste_note',
+  'recipe_equipment',
+  'recipe_additional_preparation',
+  'user_recipe_favourite',
+  'user_recipe_like',
+  'user_recipe_rating',
+  'user_follow',
+  'user_badge',
+  'comment',
+  'report',
+  'password_reset',
+  'email_verification_token',
+  'audit_log',
+  'recipe_version',
+  'setup',
+  'recipe',
+  'photo',
+  'equipment',
+  'bean',
+  'vendor',
+  'taste_note',
+  'badge',
+  'brew_method_equipment_rule',
+  'user_preferences',
+  'user',
+];
+
+console.log('Truncating all database tables...');
+await client.unsafe(`TRUNCATE TABLE ${TABLE_NAMES.join(', ')} RESTART IDENTITY CASCADE`);
+console.log(`Truncated ${TABLE_NAMES.length} tables successfully.`);
+
+await client.end();

--- a/apps/web/src/components/recipe/TasteNotesFilter.tsx
+++ b/apps/web/src/components/recipe/TasteNotesFilter.tsx
@@ -193,7 +193,11 @@ export function TasteNotesFilter({
                   'placeholder:text-[color:var(--text-tertiary)]',
                   'focus:outline-none focus:border-[color:var(--accent-primary)]',
                 ].join(' ')}
-                onKeyDown={(e) => e.stopPropagation()}
+                onKeyDown={(e) => {
+                  if (e.key !== 'Escape') {
+                    e.stopPropagation();
+                  }
+                }}
               />
             </div>
 


### PR DESCRIPTION
# Flush Contents Commands

Adds flush utilities to wipe application data (database tables + KV cache) during development, composable into the `db-reset` workflow.

## Summary

Two new scripts under `apps/api/scripts/`:
- **`flush-db.ts`** — truncates all 26 Drizzle-managed database tables via `TRUNCATE ... RESTART IDENTITY CASCADE`
- **`flush-cache.ts`** — clears all Deno KV entries

Three new Makefile targets that compose into each other:
- `make flush-db` — runs `flush-db.ts`
- `make flush-cache` — runs `flush-cache.ts`
- `make flush-contents` — runs both `flush-db` + `flush-cache`

The existing `make db-reset` is updated to chain `flush-contents` → `db-migrate` → `db-seed` for a complete seed-to-reset cycle.

## How to Use

| Command | Behaviour |
|---------|-----------|
| `make flush-db` | Truncates all 26 DB tables |
| `make flush-cache` | Clears all Deno KV cache entries |
| `make flush-contents` | `flush-db` + `flush-cache` (both) |
| `make db-reset` | `flush-contents` → `db-migrate` → `db-seed` |

Run inside Docker (all `make` targets proxy through the app container automatically).

## Files Changed

| File | Change |
|------|--------|
| `apps/api/scripts/flush-db.ts` | **New** — truncates all 26 database tables |
| `apps/api/scripts/flush-cache.ts` | **New** — clears all Deno KV entries |
| `scripts/flush-contents.ts` | **Removed** — split into the two scripts above |
| `Makefile` | Added `flush-db`, `flush-cache`, `flush-contents` targets; updated `db-reset` |
| `README.md` | Updated database section with new commands |

## Prerequisites

- `DATABASE_URL` must be set (used by the Drizzle client in `flush-db.ts`)
- The Deno KV data directory must be writable for `flush-cache.ts` (default `./data/kv/`)

## How to Verify

```bash
# 1. Seed the database
make db-seed

# 2. Test individual commands
make flush-db       # Tables empty
make flush-cache    # KV entries cleared

# 3. Full reset cycle
make db-reset
```

After `make db-reset`, the database contains fresh seed data and the KV store is empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new database maintenance commands for clearing database tables and cache data.
  * Automated database reset workflow for streamlined development setup.

* **Documentation**
  * Updated documentation with new database maintenance commands and reset procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ardakilic/BrewForm/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->