### PR TITLE
feat: SEO Head info for equipments, bean variants and detail pages

### DIFF
--- a/apps/web/src/pages/coffee-varieties/CoffeeVarietyDetailPage.tsx
+++ b/apps/web/src/pages/coffee-varieties/CoffeeVarietyDetailPage.tsx
@@ -124,7 +124,13 @@ export function CoffeeVarietyDetailPage() {
 
   return (
     <div className='mx-auto max-w-4xl px-6 py-8'>
-      <SEOHead title={variety.name} />
+      <SEOHead
+        title={variety.name}
+        description={variety.cupProfile ||
+          [variety.species, variety.origin].filter(Boolean).join(' from ') ||
+          undefined}
+        canonical={`${globalThis.location.origin}/coffee-varieties/${variety.id}`}
+      />
 
       {/* Breadcrumb */}
       <nav aria-label='Breadcrumb' className='mb-4'>

--- a/apps/web/src/pages/coffee-varieties/CoffeeVarietyDetailPage.tsx
+++ b/apps/web/src/pages/coffee-varieties/CoffeeVarietyDetailPage.tsx
@@ -39,6 +39,7 @@ interface RecipeEntry {
   commentCount: number;
 }
 
+/** Displays a single coffee variety's details, properties, and associated recipes. */
 export function CoffeeVarietyDetailPage() {
   const { id } = useParams<{ id: string }>();
   const [variety, setVariety] = useState<VarietyDetail | null>(null);

--- a/apps/web/src/pages/coffee-varieties/__tests__/CoffeeVarietiesPage.test.tsx
+++ b/apps/web/src/pages/coffee-varieties/__tests__/CoffeeVarietiesPage.test.tsx
@@ -22,16 +22,18 @@ vi.mock('../../../hooks/useDebounce.ts', () => ({
 }));
 
 vi.mock('../../../components/seo/SEOHead.tsx', () => ({
-  SEOHead: () => null,
+  SEOHead: vi.fn(() => null),
 }));
 
 import { useSearchParams } from 'react-router';
 import { useTranslation } from '../../../contexts/I18nContext.tsx';
 import { api } from '../../../api/client.ts';
+import { SEOHead } from '../../../components/seo/SEOHead.tsx';
 
 const mockUseSearchParams = vi.mocked(useSearchParams);
 const mockUseTranslation = vi.mocked(useTranslation);
 const mockApiGetWithMeta = vi.mocked(api.getWithMeta);
+const mockSEOHead = vi.mocked(SEOHead);
 
 const enT = (key: string) => {
   const map: Record<string, string> = {
@@ -513,5 +515,28 @@ describe('CoffeeVarietiesPage', () => {
 
     expect(screen.getByText('No varieties found')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Clear search' })).toBeInTheDocument();
+  });
+
+  it('passes translated title to SEOHead', async () => {
+    mockApiGetWithMeta.mockResolvedValue(makePaginatedResponse([], 0));
+    render(<CoffeeVarietiesPage />);
+
+    await waitFor(() => expect(document.querySelector('.animate-pulse')).toBeFalsy());
+
+    const calls = mockSEOHead.mock.calls;
+    const lastProps = calls[calls.length - 1][0] as { title?: string };
+    expect(lastProps.title).toBe('Coffee Varieties');
+  });
+
+  it('passes translated title to SEOHead — Turkish', async () => {
+    mockUseTranslation.mockReturnValue({ ...defaultTranslation, locale: 'tr', t: trT });
+    mockApiGetWithMeta.mockResolvedValue(makePaginatedResponse([], 0));
+    render(<CoffeeVarietiesPage />);
+
+    await waitFor(() => expect(document.querySelector('.animate-pulse')).toBeFalsy());
+
+    const calls = mockSEOHead.mock.calls;
+    const lastProps = calls[calls.length - 1][0] as { title?: string };
+    expect(lastProps.title).toBe('Kahve Çeşitleri');
   });
 });

--- a/apps/web/src/pages/coffee-varieties/__tests__/CoffeeVarietiesPage.test.tsx
+++ b/apps/web/src/pages/coffee-varieties/__tests__/CoffeeVarietiesPage.test.tsx
@@ -120,6 +120,7 @@ beforeEach(() => {
   mockApiGetWithMeta.mockResolvedValue(makePaginatedResponse([], 0));
 });
 
+/** Tests for CoffeeVarietiesPage — rendering, category tabs, search, pagination, SEO, and i18n. */
 describe('CoffeeVarietiesPage', () => {
   it('renders page title and subtitle — English', async () => {
     render(<CoffeeVarietiesPage />);

--- a/apps/web/src/pages/coffee-varieties/__tests__/CoffeeVarietyDetailPage.test.tsx
+++ b/apps/web/src/pages/coffee-varieties/__tests__/CoffeeVarietyDetailPage.test.tsx
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { CoffeeVarietyDetailPage } from '../CoffeeVarietyDetailPage.tsx';
+
+vi.mock('react-router', () => ({
+  Link: (
+    { to, children, ...props }: { to: string; children: React.ReactNode; [key: string]: unknown },
+  ) => <a href={to} {...props}>{children}</a>,
+  useParams: vi.fn(),
+}));
+
+vi.mock('../../../contexts/I18nContext.tsx', () => ({
+  useTranslation: vi.fn(),
+}));
+
+vi.mock('../../../api/client.ts', () => ({
+  api: { get: vi.fn() },
+}));
+
+vi.mock('../../../components/seo/SEOHead.tsx', () => ({
+  SEOHead: vi.fn(() => null),
+}));
+
+import { useParams } from 'react-router';
+import { useTranslation } from '../../../contexts/I18nContext.tsx';
+import { api } from '../../../api/client.ts';
+import { SEOHead } from '../../../components/seo/SEOHead.tsx';
+
+const mockUseParams = vi.mocked(useParams);
+const mockUseTranslation = vi.mocked(useTranslation);
+const mockApiGet = vi.mocked(api.get);
+const mockSEOHead = vi.mocked(SEOHead);
+
+const enT = (key: string) => {
+  const map: Record<string, string> = {
+    'coffeeVarieties.title': 'Coffee Varieties',
+    'coffeeVarieties.error.notFound': 'Variety not found',
+    'coffeeVarieties.backToList': 'Back to varieties',
+    'coffeeVarieties.category.varietyDetail': 'Variety Details',
+    'coffeeVarieties.category.processingDetail': 'Processing Method Details',
+    'coffeeVarieties.category.marketNameDetail': 'Market Name Details',
+    'coffeeVarieties.fields.origin': 'Origin',
+    'coffeeVarieties.fields.species': 'Species',
+    'coffeeVarieties.fields.altitude': 'Altitude',
+    'coffeeVarieties.fields.cupProfile': 'Cup Profile',
+    'coffeeVarieties.fields.body': 'Body',
+    'coffeeVarieties.fields.acidity': 'Acidity',
+    'coffeeVarieties.fields.caffeine': 'Caffeine',
+    'coffeeVarieties.fields.diseaseResistance': 'Disease Resistance',
+    'coffeeVarieties.fields.yield': 'Yield',
+    'coffeeVarieties.fields.plantSize': 'Plant Size',
+    'coffeeVarieties.fields.spread': 'Spread',
+    'coffeeVarieties.fields.notes': 'Notes',
+    'coffeeVarieties.fields.fermentation': 'Fermentation',
+    'coffeeVarieties.fields.dryingTime': 'Drying Time',
+    'coffeeVarieties.fields.processingCompatibility': 'Processing Compatibility',
+    'coffeeVarieties.fields.subVarieties': 'Sub-Varieties',
+    'coffeeVarieties.recipesUsing': 'Recipes using {name}',
+    'coffeeVarieties.noRecipes': 'No recipes use this variety yet.',
+    'recipe.focusMode.by': 'by',
+  };
+  return map[key] ?? key;
+};
+
+const trT = (key: string) => {
+  const map: Record<string, string> = {
+    'coffeeVarieties.title': 'Kahve Çeşitleri',
+    'coffeeVarieties.error.notFound': 'Çeşit bulunamadı',
+    'coffeeVarieties.backToList': 'Çeşitlere dön',
+    'coffeeVarieties.category.varietyDetail': 'Çeşit Detayları',
+    'coffeeVarieties.category.processingDetail': 'İşleme Yöntemi Detayları',
+    'coffeeVarieties.category.marketNameDetail': 'Pazar Adı Detayları',
+    'coffeeVarieties.fields.origin': 'Menşei',
+    'coffeeVarieties.fields.species': 'Tür',
+    'coffeeVarieties.fields.altitude': 'Rakım',
+    'coffeeVarieties.fields.cupProfile': 'Fincan Profili',
+    'coffeeVarieties.fields.body': 'Gövde',
+    'coffeeVarieties.fields.acidity': 'Asidite',
+    'coffeeVarieties.fields.caffeine': 'Kafein',
+    'coffeeVarieties.fields.diseaseResistance': 'Hastalık Direnci',
+    'coffeeVarieties.fields.yield': 'Verim',
+    'coffeeVarieties.fields.plantSize': 'Bitki Boyutu',
+    'coffeeVarieties.fields.spread': 'Yayılım',
+    'coffeeVarieties.fields.notes': 'Notlar',
+    'coffeeVarieties.fields.fermentation': 'Fermantasyon',
+    'coffeeVarieties.fields.dryingTime': 'Kurutma Süresi',
+    'coffeeVarieties.fields.processingCompatibility': 'İşleme Uyumluluğu',
+    'coffeeVarieties.fields.subVarieties': 'Alt Çeşitler',
+    'coffeeVarieties.recipesUsing': '{name} kullanan tarifler',
+    'coffeeVarieties.noRecipes': 'Bu çeşidi kullanan tarif henüz yok.',
+    'recipe.focusMode.by': 'tarafından',
+  };
+  return map[key] ?? key;
+};
+
+const defaultTranslation = {
+  locale: 'en' as const,
+  setLocale: vi.fn(),
+  t: enT,
+  availableLocales: ['en', 'tr'],
+};
+
+const mockVariety = {
+  id: 'var-1',
+  name: 'Bourbon',
+  species: 'Arabica',
+  category: 'variety',
+  origin: 'Ethiopia',
+  altitude: '1500-2000m',
+  cupProfile: 'Sweet, fruity with chocolate notes',
+  body: 'Full',
+  acidity: 'Bright',
+  caffeine: 'Moderate',
+  diseaseResistance: null,
+  yield: null,
+  plantSize: null,
+  spread: null,
+  notes: null,
+  fermentation: null,
+  dryingTime: null,
+  processingCompatibility: null,
+  subVarieties: null,
+  slug: 'bourbon',
+};
+
+const mockRecipes = {
+  data: [
+    {
+      id: 'r1',
+      slug: 'my-espresso',
+      title: 'My Espresso',
+      author: { username: 'coffeelover', displayName: 'Coffee Lover' },
+      currentVersion: { brewMethod: 'espresso', drinkType: 'espresso', rating: 4 },
+      likeCount: 5,
+      commentCount: 2,
+    },
+    {
+      id: 'r2',
+      slug: 'pour-over',
+      title: 'Morning Pour Over',
+      author: { username: 'barista', displayName: null },
+      currentVersion: { brewMethod: 'v60', drinkType: 'filter', rating: null },
+      likeCount: 3,
+      commentCount: 1,
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseParams.mockReturnValue({ id: 'var-1' });
+  mockUseTranslation.mockReturnValue(defaultTranslation);
+  (mockApiGet as ReturnType<typeof vi.fn>)
+    .mockResolvedValueOnce(mockVariety)
+    .mockResolvedValueOnce(mockRecipes);
+});
+
+describe('CoffeeVarietyDetailPage', () => {
+  it('shows loading skeleton while fetching', () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    render(<CoffeeVarietyDetailPage />);
+
+    const skeletons = document.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('renders variety details when data loads — English', async () => {
+    render(<CoffeeVarietyDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Bourbon' })).toBeInTheDocument()
+    );
+
+    expect(screen.getByText('Arabica')).toBeInTheDocument();
+    expect(screen.getByText('Origin')).toBeInTheDocument();
+    expect(screen.getByText('Ethiopia')).toBeInTheDocument();
+    expect(screen.getByText('Cup Profile')).toBeInTheDocument();
+    expect(screen.getByText('Sweet, fruity with chocolate notes')).toBeInTheDocument();
+    expect(screen.getByText('Variety Details')).toBeInTheDocument();
+  });
+
+  it('renders processing category badge', async () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ...mockVariety, category: 'processing' })
+      .mockResolvedValueOnce(mockRecipes);
+    render(<CoffeeVarietyDetailPage />);
+
+    await waitFor(() => expect(screen.getByText('Processing Method Details')).toBeInTheDocument());
+  });
+
+  it('renders market_name category badge', async () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ...mockVariety, category: 'market_name' })
+      .mockResolvedValueOnce(mockRecipes);
+    render(<CoffeeVarietyDetailPage />);
+
+    await waitFor(() => expect(screen.getByText('Market Name Details')).toBeInTheDocument());
+  });
+
+  it('shows error state when API fails', async () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+    render(<CoffeeVarietyDetailPage />);
+
+    await waitFor(() => expect(screen.getByText('Variety not found')).toBeInTheDocument());
+    expect(screen.getByRole('link', { name: 'Back to varieties' })).toBeInTheDocument();
+  });
+
+  it('shows error state in Turkish', async () => {
+    mockUseTranslation.mockReturnValue({ ...defaultTranslation, locale: 'tr', t: trT });
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+    render(<CoffeeVarietyDetailPage />);
+
+    await waitFor(() => expect(screen.getByText('Çeşit bulunamadı')).toBeInTheDocument());
+    expect(screen.getByRole('link', { name: 'Çeşitlere dön' })).toBeInTheDocument();
+  });
+
+  it('renders recipes section', async () => {
+    render(<CoffeeVarietyDetailPage />);
+
+    await waitFor(() => expect(screen.getByText('Recipes using Bourbon')).toBeInTheDocument());
+    expect(screen.getByText('My Espresso')).toBeInTheDocument();
+    expect(screen.getByText('Morning Pour Over')).toBeInTheDocument();
+  });
+
+  it('shows empty recipes message when no recipes', async () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(mockVariety)
+      .mockResolvedValueOnce({ data: [] });
+    render(<CoffeeVarietyDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText('No recipes use this variety yet.')).toBeInTheDocument()
+    );
+  });
+
+  it('passes title with description to SEOHead', async () => {
+    render(<CoffeeVarietyDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Bourbon' })).toBeInTheDocument()
+    );
+
+    const calls = mockSEOHead.mock.calls;
+    const lastProps = calls[calls.length - 1][0] as {
+      title?: string;
+      description?: string;
+      canonical?: string;
+    };
+    expect(lastProps.title).toBe('Bourbon');
+    expect(lastProps.description).toBe('Sweet, fruity with chocolate notes');
+  });
+
+  it('passes canonical URL to SEOHead', async () => {
+    render(<CoffeeVarietyDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Bourbon' })).toBeInTheDocument()
+    );
+
+    const calls = mockSEOHead.mock.calls;
+    const lastProps = calls[calls.length - 1][0] as { canonical?: string };
+    expect(lastProps.canonical).toContain('/coffee-varieties/var-1');
+  });
+
+  it('falls back to species+origin description when no cupProfile', async () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ...mockVariety, cupProfile: null })
+      .mockResolvedValueOnce(mockRecipes);
+    render(<CoffeeVarietyDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Bourbon' })).toBeInTheDocument()
+    );
+
+    const calls = mockSEOHead.mock.calls;
+    const lastProps = calls[calls.length - 1][0] as { description?: string };
+    expect(lastProps.description).toBe('Arabica from Ethiopia');
+  });
+
+  it('renders breadcrumb with link to list', async () => {
+    render(<CoffeeVarietyDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Bourbon' })).toBeInTheDocument()
+    );
+
+    expect(screen.getByRole('link', { name: 'Coffee Varieties' })).toHaveAttribute(
+      'href',
+      '/coffee-varieties',
+    );
+  });
+});

--- a/apps/web/src/pages/coffee-varieties/__tests__/CoffeeVarietyDetailPage.test.tsx
+++ b/apps/web/src/pages/coffee-varieties/__tests__/CoffeeVarietyDetailPage.test.tsx
@@ -155,6 +155,7 @@ beforeEach(() => {
     .mockResolvedValueOnce(mockRecipes);
 });
 
+/** Tests for CoffeeVarietyDetailPage — loading, error, detail fields, recipes, breadcrumb, SEO props, and i18n. */
 describe('CoffeeVarietyDetailPage', () => {
   it('shows loading skeleton while fetching', () => {
     (mockApiGet as ReturnType<typeof vi.fn>).mockReset();

--- a/apps/web/src/pages/equipment/EquipmentCatalogPage.test.tsx
+++ b/apps/web/src/pages/equipment/EquipmentCatalogPage.test.tsx
@@ -132,6 +132,7 @@ beforeEach(() => {
 
 // ── Tests ──────────────────────────────────────────────────────────────────
 
+/** Tests for EquipmentCatalogPage — rendering, category filters, search, pagination, SEO, and i18n. */
 describe('EquipmentCatalogPage', () => {
   it('renders page title and subtitle — English', async () => {
     mockApiGetWithMeta.mockResolvedValue(makePaginatedResponse([], 0));

--- a/apps/web/src/pages/equipment/EquipmentCatalogPage.test.tsx
+++ b/apps/web/src/pages/equipment/EquipmentCatalogPage.test.tsx
@@ -20,7 +20,7 @@ vi.mock('../../api/client.ts', () => ({
 }));
 
 vi.mock('../../components/seo/SEOHead.tsx', () => ({
-  SEOHead: () => null,
+  SEOHead: vi.fn(() => null),
 }));
 
 vi.mock('../../hooks/useDebounce.ts', () => ({
@@ -32,10 +32,12 @@ vi.mock('../../hooks/useDebounce.ts', () => ({
 import { useSearchParams } from 'react-router';
 import { useTranslation } from '../../contexts/I18nContext.tsx';
 import { api } from '../../api/client.ts';
+import { SEOHead } from '../../components/seo/SEOHead.tsx';
 
 const mockUseSearchParams = vi.mocked(useSearchParams);
 const mockUseTranslation = vi.mocked(useTranslation);
 const mockApiGetWithMeta = vi.mocked(api.getWithMeta);
+const mockSEOHead = vi.mocked(SEOHead);
 
 // ── Translation helpers ────────────────────────────────────────────────────
 
@@ -461,5 +463,28 @@ describe('EquipmentCatalogPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
 
     await waitFor(() => expect(mockApiGetWithMeta).toHaveBeenCalledTimes(2));
+  });
+
+  it('passes translated title to SEOHead', async () => {
+    mockApiGetWithMeta.mockResolvedValue(makePaginatedResponse([], 0));
+    render(<EquipmentCatalogPage />);
+
+    await waitFor(() => expect(document.querySelector('.animate-pulse')).toBeFalsy());
+
+    const calls = mockSEOHead.mock.calls;
+    const lastProps = calls[calls.length - 1][0] as { title?: string };
+    expect(lastProps.title).toBe('Coffee Equipment');
+  });
+
+  it('passes translated title to SEOHead — Turkish', async () => {
+    mockUseTranslation.mockReturnValue({ ...defaultTranslation, locale: 'tr', t: trT });
+    mockApiGetWithMeta.mockResolvedValue(makePaginatedResponse([], 0));
+    render(<EquipmentCatalogPage />);
+
+    await waitFor(() => expect(document.querySelector('.animate-pulse')).toBeFalsy());
+
+    const calls = mockSEOHead.mock.calls;
+    const lastProps = calls[calls.length - 1][0] as { title?: string };
+    expect(lastProps.title).toBe('Kahve Ekipmanları');
   });
 });

--- a/apps/web/src/pages/equipment/EquipmentDetailPage.test.tsx
+++ b/apps/web/src/pages/equipment/EquipmentDetailPage.test.tsx
@@ -94,6 +94,7 @@ beforeEach(() => {
     .mockResolvedValueOnce(mockRecipes);
 });
 
+/** Tests for EquipmentDetailPage — loading, error, brand/model, description, recipes, breadcrumb, SEO props, and i18n. */
 describe('EquipmentDetailPage', () => {
   it('shows loading skeleton while fetching', () => {
     (mockApiGet as ReturnType<typeof vi.fn>).mockReset();

--- a/apps/web/src/pages/equipment/EquipmentDetailPage.test.tsx
+++ b/apps/web/src/pages/equipment/EquipmentDetailPage.test.tsx
@@ -1,0 +1,281 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { EquipmentDetailPage } from './EquipmentDetailPage.tsx';
+
+vi.mock('react-router', () => ({
+  Link: (
+    { to, children, ...props }: { to: string; children: React.ReactNode; [key: string]: unknown },
+  ) => <a href={to} {...props}>{children}</a>,
+  useParams: vi.fn(),
+}));
+
+vi.mock('../../contexts/I18nContext.tsx', () => ({
+  useTranslation: vi.fn(),
+}));
+
+vi.mock('../../api/client.ts', () => ({
+  api: { get: vi.fn() },
+}));
+
+vi.mock('../../components/seo/SEOHead.tsx', () => ({
+  SEOHead: vi.fn(() => null),
+}));
+
+import { useParams } from 'react-router';
+import { useTranslation } from '../../contexts/I18nContext.tsx';
+import { api } from '../../api/client.ts';
+import { SEOHead } from '../../components/seo/SEOHead.tsx';
+
+const mockUseParams = vi.mocked(useParams);
+const mockUseTranslation = vi.mocked(useTranslation);
+const mockApiGet = vi.mocked(api.get);
+const mockSEOHead = vi.mocked(SEOHead);
+
+const enT = (key: string) => {
+  const map: Record<string, string> = {
+    'equipment.error.notFound': 'Equipment not found',
+    'equipment.backToList': 'Back to equipment list',
+    'equipment.recipesUsing': 'Recipes using this equipment',
+    'equipment.noRecipes': 'No recipes use this equipment yet.',
+    'equipment.catalog.title': 'Coffee Equipment',
+    'recipe.focusMode.by': 'by',
+  };
+  return map[key] ?? key;
+};
+
+const trT = (key: string) => {
+  const map: Record<string, string> = {
+    'equipment.error.notFound': 'Ekipman bulunamadı',
+    'equipment.backToList': 'Ekipman listesine dön',
+    'equipment.recipesUsing': 'Bu ekipmanı kullanan tarifler',
+    'equipment.noRecipes': 'Bu ekipmanı kullanan tarif henüz yok.',
+    'equipment.catalog.title': 'Kahve Ekipmanları',
+    'recipe.focusMode.by': 'tarafından',
+  };
+  return map[key] ?? key;
+};
+
+const defaultTranslation = {
+  locale: 'en' as const,
+  setLocale: vi.fn(),
+  t: enT,
+  availableLocales: ['en', 'tr'],
+};
+
+const mockEquipment = {
+  id: 'eq-1',
+  name: 'Stagg EKG',
+  brand: 'Fellow',
+  model: 'Stagg EKG',
+  type: 'kettle',
+  description: 'Electric pour-over kettle with temperature control',
+};
+
+const mockRecipes = {
+  data: [
+    {
+      id: 'r1',
+      slug: 'my-espresso',
+      title: 'My Espresso',
+      author: { username: 'coffeelover', displayName: 'Coffee Lover' },
+      currentVersion: { brewMethod: 'espresso', drinkType: 'espresso', rating: 4 },
+      likeCount: 5,
+      commentCount: 2,
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseParams.mockReturnValue({ id: 'eq-1' });
+  mockUseTranslation.mockReturnValue(defaultTranslation);
+  (mockApiGet as ReturnType<typeof vi.fn>)
+    .mockResolvedValueOnce(mockEquipment)
+    .mockResolvedValueOnce(mockRecipes);
+});
+
+describe('EquipmentDetailPage', () => {
+  it('shows loading skeleton while fetching', () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    render(<EquipmentDetailPage />);
+
+    const skeletons = document.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('renders equipment details when data loads — English', async () => {
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Stagg EKG' })).toBeInTheDocument()
+    );
+
+    expect(screen.getAllByText('Fellow').length).toBe(2);
+    expect(screen.getByText('Electric pour-over kettle with temperature control'))
+      .toBeInTheDocument();
+    expect(screen.getByText('kettle')).toBeInTheDocument();
+  });
+
+  it('renders brand and model as title', async () => {
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Stagg EKG' })).toBeInTheDocument()
+    );
+
+    expect(screen.getAllByText('Fellow').length).toBeGreaterThan(0);
+  });
+
+  it('uses name when brand is null', async () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ...mockEquipment, brand: null, model: null })
+      .mockResolvedValueOnce(mockRecipes);
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Stagg EKG' })).toBeInTheDocument()
+    );
+  });
+
+  it('renders type badge', async () => {
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() => expect(screen.getByText('kettle')).toBeInTheDocument());
+  });
+
+  it('converts underscores in type badge to spaces', async () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ...mockEquipment, type: 'pour_over_brewer' })
+      .mockResolvedValueOnce(mockRecipes);
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() => expect(screen.getByText('pour over brewer')).toBeInTheDocument());
+  });
+
+  it('shows error state when API fails', async () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() => expect(screen.getByText('Equipment not found')).toBeInTheDocument());
+    expect(screen.getByRole('link', { name: 'Back to equipment list' })).toBeInTheDocument();
+  });
+
+  it('shows error state in Turkish', async () => {
+    mockUseTranslation.mockReturnValue({ ...defaultTranslation, locale: 'tr', t: trT });
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() => expect(screen.getByText('Ekipman bulunamadı')).toBeInTheDocument());
+    expect(screen.getByRole('link', { name: 'Ekipman listesine dön' })).toBeInTheDocument();
+  });
+
+  it('renders recipes section', async () => {
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Recipes using this equipment')).toBeInTheDocument()
+    );
+    expect(screen.getByText('My Espresso')).toBeInTheDocument();
+  });
+
+  it('shows empty recipes message when no recipes', async () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(mockEquipment)
+      .mockResolvedValueOnce({ data: [] });
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText('No recipes use this equipment yet.')).toBeInTheDocument()
+    );
+  });
+
+  it('passes title to SEOHead', async () => {
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Stagg EKG' })).toBeInTheDocument()
+    );
+
+    const calls = mockSEOHead.mock.calls;
+    const lastProps = calls[calls.length - 1][0] as {
+      title?: string;
+      description?: string;
+      canonical?: string;
+    };
+    expect(lastProps.title).toBe('Fellow Stagg EKG');
+  });
+
+  it('passes description to SEOHead from equipment.description', async () => {
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Stagg EKG' })).toBeInTheDocument()
+    );
+
+    const calls = mockSEOHead.mock.calls;
+    const lastProps = calls[calls.length - 1][0] as { description?: string };
+    expect(lastProps.description).toBe('Electric pour-over kettle with temperature control');
+  });
+
+  it('passes canonical URL to SEOHead', async () => {
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Stagg EKG' })).toBeInTheDocument()
+    );
+
+    const calls = mockSEOHead.mock.calls;
+    const lastProps = calls[calls.length - 1][0] as { canonical?: string };
+    expect(lastProps.canonical).toContain('/equipment/eq-1');
+  });
+
+  it('falls back to brand+type description when no description', async () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ...mockEquipment, description: null })
+      .mockResolvedValueOnce(mockRecipes);
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Stagg EKG' })).toBeInTheDocument()
+    );
+
+    const calls = mockSEOHead.mock.calls;
+    const lastProps = calls[calls.length - 1][0] as { description?: string };
+    expect(lastProps.description).toBe('Fellow kettle');
+  });
+
+  it('renders breadcrumb with link to catalog', async () => {
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Stagg EKG' })).toBeInTheDocument()
+    );
+
+    expect(screen.getByRole('link', { name: 'Coffee Equipment' })).toHaveAttribute(
+      'href',
+      '/equipments',
+    );
+  });
+
+  it('hides description section when no description', async () => {
+    (mockApiGet as ReturnType<typeof vi.fn>).mockReset();
+    (mockApiGet as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ...mockEquipment, description: null })
+      .mockResolvedValueOnce(mockRecipes);
+    render(<EquipmentDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Stagg EKG' })).toBeInTheDocument()
+    );
+
+    expect(screen.queryByText('Electric pour-over kettle with temperature control')).not
+      .toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/equipment/EquipmentDetailPage.tsx
+++ b/apps/web/src/pages/equipment/EquipmentDetailPage.tsx
@@ -25,6 +25,7 @@ interface RecipeEntry {
   commentCount: number;
 }
 
+/** Displays a single equipment item's details, description, and associated recipes. */
 export function EquipmentDetailPage() {
   const { id } = useParams<{ id: string }>();
   const [equipment, setEquipment] = useState<EquipmentDetail | null>(null);

--- a/apps/web/src/pages/equipment/EquipmentDetailPage.tsx
+++ b/apps/web/src/pages/equipment/EquipmentDetailPage.tsx
@@ -89,7 +89,14 @@ export function EquipmentDetailPage() {
 
   return (
     <div className='mx-auto max-w-4xl px-6 py-8'>
-      <SEOHead title={displayTitle} />
+      <SEOHead
+        title={displayTitle}
+        description={equipment.description ||
+          [equipment.brand, equipment.type ? equipment.type.replace(/_/g, ' ') : '']
+            .filter(Boolean).join(' ') ||
+          undefined}
+        canonical={`${globalThis.location.origin}/equipment/${equipment.id}`}
+      />
 
       {/* Breadcrumb */}
       <nav aria-label='Breadcrumb' className='mb-4'>


### PR DESCRIPTION
## Summary

Adds missing SEO metadata (Open Graph description and canonical URL) to Coffee Variety and Equipment detail pages, and adds comprehensive test coverage for SEO props across all recently-added public pages.

## Motivation

The recently added pages — Coffee Varieties list/detail and Equipment catalog/detail — were shipping with only a basic `<title>` tag via `SEOHead`. Detail pages were missing:
- **`description`** — used for `og:description` and `meta[name="description"]` (visible in search snippets and social previews)
- **`canonical`** — tells search engines the preferred URL, preventing duplicate content issues

Additionally, SEO assertions were absent from existing page tests, and CoffeeVarietyDetailPage and EquipmentDetailPage had no test files at all.

## Changes

### Page changes (SEO improvements)

| File | Change |
|------|--------|
| `apps/web/src/pages/coffee-varieties/CoffeeVarietyDetailPage.tsx` | Added `description` (falls back: cupProfile → "species from origin" → none) and `canonical` URL to `<SEOHead>` |
| `apps/web/src/pages/equipment/EquipmentDetailPage.tsx` | Added `description` (falls back: equipment.description → "brand type" → none) and `canonical` URL to `<SEOHead>` |

### Test changes

| File | Change |
|------|--------|
| `apps/web/src/pages/coffee-varieties/__tests__/CoffeeVarietiesPage.test.tsx` | Added `SEOHead` mock assertions — verifies translated title is passed (English + Turkish) |
| `apps/web/src/pages/equipment/EquipmentCatalogPage.test.tsx` | Added `SEOHead` mock assertions — verifies translated title is passed (English + Turkish) |
| `apps/web/src/pages/coffee-varieties/__tests__/CoffeeVarietyDetailPage.test.tsx` | **New file** — 12 tests covering: loading skeleton, detail rendering, category badges, error states (EN/TR), recipes section, SEO props (title, description fallback, canonical), breadcrumb |
| `apps/web/src/pages/equipment/EquipmentDetailPage.test.tsx` | **New file** — 16 tests covering: loading skeleton, brand/model rendering, type badge with underscore conversion, error states (EN/TR), recipes, SEO props (title, description fallback, canonical), breadcrumb |

## How to test

```bash
make check-web    # type-check + lint (all pass)
make test-web     # 685 tests, all pass across 45 files
```

## SEO behavior

Both detail pages now produce the following in `<head>`:

```
<title>{entity name} | BrewForm</title>
<meta name="description" content="{dynamic description}">
<meta property="og:title" content="{entity name}">
<meta property="og:description" content="{dynamic description}">
<meta property="og:url" content="https://brewform.app/{path}/{id}">
<meta property="og:type" content="website">
<meta property="og:image" content="/og-default.png">
<meta property="twitter:card" content="summary_large_image">
<link rel="canonical" href="https://brewform.app/{path}/{id}">
```

Description fallback logic:

- **Coffee varieties**: uses `cupProfile` → `"Arabica from Ethiopia"` → no description
- **Equipment**: uses `description` → `"Fellow kettle"` → no description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced SEO metadata for coffee variety and equipment detail pages, now including page descriptions (derived from product attributes with intelligent fallbacks) and canonical URLs for improved search engine optimization.

* **Tests**
  * Added comprehensive test suites verifying correct rendering of page content, error states, and proper SEO metadata configuration across English and Turkish localizations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ardakilic/BrewForm/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->