### PR TITLE
feat: loading skeleton on main page

### DIFF
--- a/apps/web/src/pages/HomePage.test.tsx
+++ b/apps/web/src/pages/HomePage.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { HomePage } from './HomePage.tsx';
 import type { RecipeListItem } from '../api/types.ts';
 
@@ -224,5 +224,40 @@ describe('HomePage — i18n', () => {
     expect(screen.getByText('Latest Recipes')).toBeInTheDocument();
     expect(screen.getByText('Popular Recipes')).toBeInTheDocument();
     expect(screen.queryByText(/❤️/)).not.toBeInTheDocument();
+  });
+
+  it('shows recipe card skeleton placeholders while loading', async () => {
+    const { recipeApi } = await import('../api/index.ts');
+    let resolvePromise!: (value: any) => void;
+    const deferred = new Promise<any>((resolve) => {
+      resolvePromise = resolve;
+    });
+    vi.mocked(recipeApi.list).mockReturnValue(deferred);
+
+    render(<HomePage />);
+
+    const skeletons = document.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+
+    resolvePromise({
+      data: [
+        {
+          id: '1',
+          slug: 'test',
+          title: 'Loaded Recipe',
+          likeCount: 0,
+          commentCount: 0,
+          forkCount: 0,
+          author: null,
+        } as RecipeListItem,
+      ],
+      meta: { pagination: { page: 1, perPage: 6, total: 1, totalPages: 1 } },
+    });
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.animate-pulse').length).toBe(0);
+    });
+
+    expect(await screen.findAllByText('Loaded Recipe')).toHaveLength(2);
   });
 });

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -4,19 +4,26 @@ import { recipeApi } from '../api/index.ts';
 import type { RecipeListItem } from '../api/types.ts';
 import { useTranslation } from '../contexts/I18nContext.tsx';
 import { SEOHead } from '../components/seo/SEOHead.tsx';
+import { RecipeCardSkeletonGrid } from '../components/ui/Skeleton.tsx';
 
 export function HomePage() {
+  const [loading, setLoading] = useState(true);
   const [latestRecipes, setLatestRecipes] = useState<RecipeListItem[]>([]);
   const [popularRecipes, setPopularRecipes] = useState<RecipeListItem[]>([]);
   const { t } = useTranslation();
 
   useEffect(() => {
-    recipeApi.list({ perPage: '6', sortBy: 'createdAt' }).then((response) => {
-      setLatestRecipes(response.data ?? []);
-    }).catch(() => {});
-    recipeApi.list({ perPage: '6', sortBy: 'likeCount' }).then((response) => {
-      setPopularRecipes(response.data ?? []);
-    }).catch(() => {});
+    setLoading(true);
+    Promise.all([
+      recipeApi.list({ perPage: '6', sortBy: 'createdAt' }).then((response) => {
+        setLatestRecipes(response.data ?? []);
+      }),
+      recipeApi.list({ perPage: '6', sortBy: 'likeCount' }).then((response) => {
+        setPopularRecipes(response.data ?? []);
+      }),
+    ]).catch(() => {}).finally(() => {
+      setLoading(false);
+    });
   }, []);
 
   return (
@@ -39,18 +46,26 @@ export function HomePage() {
         <h2 className='mb-4 text-2xl font-bold' style={{ color: 'var(--text-primary)' }}>
           {t('home.latestRecipes')}
         </h2>
-        <div className='grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3'>
-          {latestRecipes.map((r) => <RecipeCard key={r.id} recipe={r} />)}
-        </div>
+        {loading
+          ? <RecipeCardSkeletonGrid count={6} />
+          : (
+            <div className='grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3'>
+              {latestRecipes.map((r) => <RecipeCard key={r.id} recipe={r} />)}
+            </div>
+          )}
       </section>
 
       <section className='mx-auto max-w-6xl px-6 py-8'>
         <h2 className='mb-4 text-2xl font-bold' style={{ color: 'var(--text-primary)' }}>
           {t('home.popularRecipes')}
         </h2>
-        <div className='grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3'>
-          {popularRecipes.map((r) => <RecipeCard key={r.id} recipe={r} />)}
-        </div>
+        {loading
+          ? <RecipeCardSkeletonGrid count={6} />
+          : (
+            <div className='grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3'>
+              {popularRecipes.map((r) => <RecipeCard key={r.id} recipe={r} />)}
+            </div>
+          )}
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary

Add loading skeleton placeholders to the HomePage's "Latest Recipes" and "Popular Recipes" sections, matching the behavior already present on the recipes, coffee varieties, and equipment list pages.

## Problem

On the recipes, varieties, and equipments pages, a skeleton placeholder is shown while content loads. However, on the main page (HomePage), the "Latest Recipes" and "Popular Recipes" sections have no loading indicator — they simply render empty until the API responses arrive, creating the impression that the page is broken or that no recipes exist.

## Solution

- Added a `loading` state to `HomePage` that is `true` initially and set to `false` once both API calls resolve
- Wrapped both API calls in `Promise.all` to track a single loading state for both sections
- Imported and used the existing `RecipeCardSkeletonGrid` component from `@/components/ui/Skeleton.tsx` (same component used by `RecipeListPage`)
- While loading, each section displays a `RecipeCardSkeletonGrid` with 6 skeleton cards; after loading, the actual recipe cards are shown

## Changes

| File | Change |
|------|--------|
| `apps/web/src/pages/HomePage.tsx` | Added `loading` state, `Promise.all` for coordinated loading, conditional rendering of `RecipeCardSkeletonGrid` vs actual recipe grid |
| `apps/web/src/pages/HomePage.test.tsx` | Added test verifying skeleton placeholders are shown while loading and replaced with content after API resolves |

## Testing

- Added a new test: "shows recipe card skeleton placeholders while loading"
  - Verifies `.animate-pulse` elements are present during loading
  - Verifies skeletons are removed after API resolves
  - Verifies actual recipe content appears after loading
- All 808 existing tests continue to pass (`make test`)
- `make fmt` and `make lint` pass cleanly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loading skeleton placeholders now display in both "Latest" and "Popular" recipe sections while recipes are being fetched, providing visual feedback during data loading.

* **Tests**
  * Added test coverage for loading state behavior to ensure skeleton placeholders appear during fetch operations and disappear once recipes load successfully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ardakilic/BrewForm/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->