### PR TITLE
feat: d07

### DIFF
--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -223,9 +223,9 @@ export function SettingsPage() {
                   onChange={(e) => setPrefs({ ...prefs, dateFormat: e.target.value })}
                   className='input-field w-auto'
                 >
-                  <option value='YYYY-MM-DD'>YYYY-MM-DD</option>
-                  <option value='DD/MM/YYYY'>DD/MM/YYYY</option>
-                  <option value='MM/DD/YYYY'>MM/DD/YYYY</option>
+                  <option value='YYYY_MM_DD'>YYYY-MM-DD</option>
+                  <option value='DD_MM_YYYY'>DD/MM/YYYY</option>
+                  <option value='MM_DD_YYYY'>MM/DD/YYYY</option>
                 </select>
               </div>
               <button

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -18,122 +18,44 @@ import {
   varchar,
 } from 'drizzle-orm/pg-core';
 
+import {
+  ADDITIONAL_PREPARATION_TYPE_VALUES,
+  BADGE_RULE_VALUES,
+  BREW_METHOD_VALUES,
+  COFFEE_VARIETY_CATEGORY_VALUES,
+  DATE_FORMAT_VALUES,
+  DRINK_TYPE_VALUES,
+  EMOJI_TAG_VALUES,
+  EQUIPMENT_DELETE_REQUEST_STATUS_VALUES,
+  EQUIPMENT_TYPE_VALUES,
+  TEMPERATURE_UNIT_VALUES,
+  THEME_VALUES,
+  UNIT_SYSTEM_VALUES,
+  VISIBILITY_VALUES,
+} from '@brewform/shared/constants';
+
 // ============================================================
-// Enums
+// Enums — values imported from @brewform/shared/constants
+// (single source of truth across DB, Zod, and TypeScript)
 // ============================================================
 
-export const visibilityEnum = pgEnum('visibility', [
-  'draft',
-  'private',
-  'unlisted',
-  'public',
-]);
+export const visibilityEnum = pgEnum('visibility', [...VISIBILITY_VALUES]);
 
 export type RecipeVisibility = typeof visibilityEnum.enumValues[number];
 
-export const brewMethodEnum = pgEnum('brew_method', [
-  'espresso_machine',
-  'v60',
-  'french_press',
-  'aeropress',
-  'turkish_coffee',
-  'drip_coffee',
-  'chemex',
-  'kalita_wave',
-  'moka_pot',
-  'cold_brew',
-  'siphon',
-]);
-
-export const drinkTypeEnum = pgEnum('drink_type', [
-  'espresso',
-  'americano',
-  'flat_white',
-  'latte',
-  'cappuccino',
-  'cortado',
-  'macchiato',
-  'turkish_coffee',
-  'pour_over',
-  'cold_brew',
-  'french_press',
-  'aeropress',
-  'drip_coffee',
-  'moka_pot',
-  'siphon',
-]);
-
-export const equipmentTypeEnum = pgEnum('equipment_type', [
-  'espresso_machine',
-  'grinder',
-  'pour_over_brewer',
-  'immersion_brewer',
-  'kettle',
-  'milk_tool',
-  'scale_accessory',
-  'roaster',
-  'portafilter',
-  'basket',
-  'puck_screen',
-  'paper_filter',
-  'tamper',
-  'mesh_filter',
-  'cezve',
-  'thermometer',
-  'other',
-]);
-
-export const emojiTagEnum = pgEnum('emoji_tag', [
-  'fire',
-  'rocket',
-  'thumbsup',
-  'neutral',
-  'thumbsdown',
-  'nauseated',
-]);
-
-export const badgeRuleEnum = pgEnum('badge_rule', [
-  'first_brew',
-  'decade_brewer',
-  'centurion',
-  'first_fork',
-  'fan_favourite',
-  'community_star',
-  'conversationalist',
-  'precision_brewer',
-  'explorer',
-  'influencer',
-]);
-
-export const unitSystemEnum = pgEnum('unit_system', [
-  'metric',
-  'imperial',
-]);
-
-export const temperatureUnitEnum = pgEnum('temperature_unit', [
-  'celsius',
-  'fahrenheit',
-]);
-
-export const themeEnum = pgEnum('theme', [
-  'light',
-  'dark',
-  'coffee',
-]);
-
-export const dateFormatEnum = pgEnum('date_format', [
-  'DD_MM_YYYY',
-  'MM_DD_YYYY',
-  'YYYY_MM_DD',
-]);
-
-export const additionalPreparationTypeEnum = pgEnum('additional_preparation_type', [
-  'milk',
-  'water',
-  'syrup',
-  'spice',
-  'other',
-]);
+export const brewMethodEnum = pgEnum('brew_method', [...BREW_METHOD_VALUES]);
+export const drinkTypeEnum = pgEnum('drink_type', [...DRINK_TYPE_VALUES]);
+export const equipmentTypeEnum = pgEnum('equipment_type', [...EQUIPMENT_TYPE_VALUES]);
+export const emojiTagEnum = pgEnum('emoji_tag', [...EMOJI_TAG_VALUES]);
+export const badgeRuleEnum = pgEnum('badge_rule', [...BADGE_RULE_VALUES]);
+export const unitSystemEnum = pgEnum('unit_system', [...UNIT_SYSTEM_VALUES]);
+export const temperatureUnitEnum = pgEnum('temperature_unit', [...TEMPERATURE_UNIT_VALUES]);
+export const themeEnum = pgEnum('theme', [...THEME_VALUES]);
+export const dateFormatEnum = pgEnum('date_format', [...DATE_FORMAT_VALUES]);
+export const additionalPreparationTypeEnum = pgEnum(
+  'additional_preparation_type',
+  [...ADDITIONAL_PREPARATION_TYPE_VALUES],
+);
 
 // ============================================================
 // Tables
@@ -414,11 +336,10 @@ export const beans = pgTable(
   ],
 );
 
-export const coffeeVarietyCategoryEnum = pgEnum('coffee_variety_category', [
-  'variety',
-  'processing',
-  'market_name',
-]);
+export const coffeeVarietyCategoryEnum = pgEnum(
+  'coffee_variety_category',
+  [...COFFEE_VARIETY_CATEGORY_VALUES],
+);
 
 export const coffeeVarieties = pgTable('coffee_variety', {
   id: varchar('id', { length: 36 }).primaryKey().$defaultFn(() => crypto.randomUUID()),
@@ -662,11 +583,10 @@ export const brewMethodEquipmentRules = pgTable(
   ],
 );
 
-export const equipmentDeleteRequestStatusEnum = pgEnum('equipment_delete_request_status', [
-  'pending',
-  'approved',
-  'rejected',
-]);
+export const equipmentDeleteRequestStatusEnum = pgEnum(
+  'equipment_delete_request_status',
+  [...EQUIPMENT_DELETE_REQUEST_STATUS_VALUES],
+);
 
 export const equipmentDeleteRequests = pgTable('equipment_delete_request', {
   id: varchar('id', { length: 36 }).primaryKey().$defaultFn(() => crypto.randomUUID()),

--- a/packages/shared/src/constants/additional-preparation-types.ts
+++ b/packages/shared/src/constants/additional-preparation-types.ts
@@ -1,0 +1,28 @@
+/**
+ * Additional preparation category enum — single source of truth.
+ *
+ * Consumed by:
+ * - `packages/db/src/schema.ts` — Drizzle `pgEnum('additional_preparation_type', …)`
+ * - `packages/shared/src/schemas/recipe.ts` — Zod `z.enum(…)`
+ * - `packages/shared/src/types/recipe.ts` — `AdditionalPreparationCategory` type
+ *
+ * The database enum and Zod schema use the word `type` but the TypeScript
+ * convention (preserved for backward compatibility) is `Category`, since this
+ * enum is used on the `type` field of an `AdditionalPreparation`.
+ */
+export const ADDITIONAL_PREPARATION_TYPE_VALUES = [
+  'milk',
+  'water',
+  'syrup',
+  'spice',
+  'other',
+] as const;
+
+/**
+ * Category of an additional preparation step (e.g. milk, syrup, spice).
+ *
+ * Note: named with the suffix `Category` (not `Type`) to match the existing
+ * TypeScript convention in `types/recipe.ts` and to avoid shadowing the
+ * built-in `Type` global.
+ */
+export type AdditionalPreparationCategory = (typeof ADDITIONAL_PREPARATION_TYPE_VALUES)[number];

--- a/packages/shared/src/constants/badges.ts
+++ b/packages/shared/src/constants/badges.ts
@@ -70,3 +70,21 @@ export const BADGE_RULES = [
     threshold: 25,
   },
 ] as const;
+
+/**
+ * Machine-readable identifier for a badge rule.
+ *
+ * Derived from the `rule` field of {@link BADGE_RULES} so the union cannot
+ * drift from the rule definitions. Consumed by Drizzle's `pgEnum()` and by
+ * Zod `z.enum()` to keep the database enum, runtime validation, and
+ * TypeScript union synchronised.
+ */
+export type BadgeRule = (typeof BADGE_RULES)[number]['rule'];
+
+/**
+ * Pure-values tuple of every {@link BadgeRule}.
+ *
+ * Derived from {@link BADGE_RULES} via `.map()` (the source field is `rule`,
+ * not `value`). Consumed by Drizzle's `pgEnum()` and by Zod `z.enum()`.
+ */
+export const BADGE_RULE_VALUES = BADGE_RULES.map((b) => b.rule) as [BadgeRule, ...BadgeRule[]];

--- a/packages/shared/src/constants/brew-method-rules.test.ts
+++ b/packages/shared/src/constants/brew-method-rules.test.ts
@@ -1,11 +1,8 @@
 import { describe, it } from 'jsr:@std/testing/bdd';
 import { expect } from 'jsr:@std/expect';
-import {
-  BREW_METHOD_EQUIPMENT_RULES,
-  EQUIPMENT_TYPE_LABELS,
-  EQUIPMENT_TYPES,
-} from './brew-method-rules.ts';
+import { BREW_METHOD_EQUIPMENT_RULES } from './brew-method-rules.ts';
 import { BREW_METHODS } from './brew-methods.ts';
+import { EQUIPMENT_TYPE_LABELS, EQUIPMENT_TYPES } from './equipment-types.ts';
 
 const VALID_BREW_METHODS = new Set(BREW_METHODS.map((m) => m.value));
 

--- a/packages/shared/src/constants/brew-method-rules.ts
+++ b/packages/shared/src/constants/brew-method-rules.ts
@@ -1,51 +1,18 @@
-import type { BrewMethod } from '../types/recipe.ts';
-import type { EquipmentType } from '../types/equipment.ts';
+/**
+ * Brew method × equipment compatibility matrix.
+ *
+ * Each rule records whether a given brew method can be performed with a given
+ * piece of equipment. The shape mirrors the database `brew_method_equipment`
+ * table (one row per method/equipment combination).
+ */
+import type { EquipmentType } from './equipment-types.ts';
+import type { BrewMethodValue } from './brew-methods.ts';
 
 export interface BrewMethodEquipmentRuleDef {
-  brewMethod: BrewMethod;
+  brewMethod: BrewMethodValue;
   equipmentType: EquipmentType;
   compatible: boolean;
 }
-
-export const EQUIPMENT_TYPES: EquipmentType[] = [
-  'espresso_machine',
-  'grinder',
-  'pour_over_brewer',
-  'immersion_brewer',
-  'kettle',
-  'milk_tool',
-  'scale_accessory',
-  'roaster',
-  'portafilter',
-  'basket',
-  'puck_screen',
-  'paper_filter',
-  'tamper',
-  'mesh_filter',
-  'cezve',
-  'thermometer',
-  'other',
-];
-
-export const EQUIPMENT_TYPE_LABELS: Record<EquipmentType, string> = {
-  espresso_machine: 'Espresso Machine',
-  grinder: 'Grinder',
-  pour_over_brewer: 'Pour-Over & Filter Brewer',
-  immersion_brewer: 'Immersion & Pressure Brewer',
-  kettle: 'Kettle',
-  milk_tool: 'Milk Tool',
-  scale_accessory: 'Scale & Accessory',
-  roaster: 'Roaster',
-  portafilter: 'Portafilter',
-  basket: 'Basket',
-  puck_screen: 'Puck Screen',
-  paper_filter: 'Paper Filter',
-  tamper: 'Tamper',
-  mesh_filter: 'Mesh Filter',
-  cezve: 'Cezve',
-  thermometer: 'Thermometer',
-  other: 'Other',
-};
 
 export const BREW_METHOD_EQUIPMENT_RULES: BrewMethodEquipmentRuleDef[] = [
   { brewMethod: 'espresso_machine', equipmentType: 'espresso_machine', compatible: true },

--- a/packages/shared/src/constants/brew-methods.ts
+++ b/packages/shared/src/constants/brew-methods.ts
@@ -74,3 +74,16 @@ export type BrewMethodOption = {
 
 /** Mutable copy for use in .map()/.filter() in React components */
 export const BREW_METHODS_LIST: BrewMethodOption[] = [...BREW_METHODS];
+
+/**
+ * Pure-values tuple of every {@link BrewMethodValue}.
+ *
+ * Derived from {@link BREW_METHODS} via `.map()` so the tuple cannot drift
+ * from the rich-object source. Consumed by Drizzle's `pgEnum()` and by Zod
+ * `z.enum()` to keep the database enum, runtime validation, and TypeScript
+ * union synchronised.
+ */
+export const BREW_METHOD_VALUES = BREW_METHODS.map((m) => m.value) as [
+  BrewMethodValue,
+  ...BrewMethodValue[],
+];

--- a/packages/shared/src/constants/coffee-variety.ts
+++ b/packages/shared/src/constants/coffee-variety.ts
@@ -1,0 +1,16 @@
+/**
+ * Coffee variety category enum — single source of truth.
+ *
+ * Consumed by:
+ * - `packages/db/src/schema.ts` — Drizzle `pgEnum('coffee_variety_category', …)`
+ * - `packages/shared/src/schemas/coffee-variety.ts` — Zod `z.enum(…)`
+ * - `packages/shared/src/types/coffee-variety.ts` — `CoffeeVarietyCategory` type
+ */
+export const COFFEE_VARIETY_CATEGORY_VALUES = [
+  'variety',
+  'processing',
+  'market_name',
+] as const;
+
+/** Classification of a {@link CoffeeVariety} entry. */
+export type CoffeeVarietyCategory = (typeof COFFEE_VARIETY_CATEGORY_VALUES)[number];

--- a/packages/shared/src/constants/drink-types.ts
+++ b/packages/shared/src/constants/drink-types.ts
@@ -25,3 +25,16 @@ export type DrinkTypeOption = {
 };
 
 export const DRINK_TYPES_LIST: DrinkTypeOption[] = [...DRINK_TYPES];
+
+/**
+ * Pure-values tuple of every {@link DrinkTypeValue}.
+ *
+ * Derived from {@link DRINK_TYPES} via `.map()` so the tuple cannot drift
+ * from the rich-object source. Consumed by Drizzle's `pgEnum()` and by Zod
+ * `z.enum()` to keep the database enum, runtime validation, and TypeScript
+ * union synchronised.
+ */
+export const DRINK_TYPE_VALUES = DRINK_TYPES.map((d) => d.value) as [
+  DrinkTypeValue,
+  ...DrinkTypeValue[],
+];

--- a/packages/shared/src/constants/emoji-tags.ts
+++ b/packages/shared/src/constants/emoji-tags.ts
@@ -21,3 +21,12 @@ export const EMOJI_TAGS_LIST: EmojiTagOption[] = EMOJI_TAGS.map((t) => ({
   emoji: t.emoji,
   label: t.label,
 }));
+
+/**
+ * Pure-values tuple of every {@link EmojiTagKey}.
+ *
+ * Derived from {@link EMOJI_TAGS} via `.map()` (the source field is `key`,
+ * not `value`). Consumed by Drizzle's `pgEnum()` and by Zod `z.enum()` to keep
+ * the database enum, runtime validation, and TypeScript union synchronised.
+ */
+export const EMOJI_TAG_VALUES = EMOJI_TAGS.map((t) => t.key) as [EmojiTagKey, ...EmojiTagKey[]];

--- a/packages/shared/src/constants/enums.test.ts
+++ b/packages/shared/src/constants/enums.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Enum single-source-of-truth tests.
+ *
+ * Verifies that every `_VALUES` tuple in `packages/shared/src/constants/`
+ * matches the underlying rich-object definition. These are the runtime guard
+ * for the contract that the database enum, the Zod schema, and the
+ * TypeScript union all derive from the same source of truth.
+ *
+ * If a future refactor adds a new value to e.g. `BREW_METHODS` but forgets
+ * to also add it to a `_VALUES` tuple, this test fails immediately.
+ */
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { BADGE_RULE_VALUES, BADGE_RULES } from './badges.ts';
+import { BREW_METHOD_VALUES, BREW_METHODS } from './brew-methods.ts';
+import { DRINK_TYPE_VALUES, DRINK_TYPES } from './drink-types.ts';
+import { EMOJI_TAG_VALUES, EMOJI_TAGS } from './emoji-tags.ts';
+import {
+  ADDITIONAL_PREPARATION_TYPE_VALUES,
+  type AdditionalPreparationCategory,
+} from './additional-preparation-types.ts';
+import { COFFEE_VARIETY_CATEGORY_VALUES, type CoffeeVarietyCategory } from './coffee-variety.ts';
+import {
+  EQUIPMENT_DELETE_REQUEST_STATUS_VALUES,
+  type EquipmentDeleteRequestStatus,
+} from './equipment-delete-request.ts';
+import {
+  EQUIPMENT_TYPE_LABELS,
+  EQUIPMENT_TYPE_VALUES,
+  EQUIPMENT_TYPES,
+  type EquipmentType,
+} from './equipment-types.ts';
+import {
+  DATE_FORMAT_DISPLAY,
+  DATE_FORMAT_VALUES,
+  TEMPERATURE_UNIT_VALUES,
+  THEME_VALUES,
+  UNIT_SYSTEM_VALUES,
+} from './user-preferences.ts';
+import { VISIBILITY_STATES, VISIBILITY_VALUES } from './visibility.ts';
+
+describe('Enum single-source-of-truth: _VALUES tuples match rich objects', () => {
+  it('VISIBILITY_VALUES matches VISIBILITY_STATES', () => {
+    expect([...VISIBILITY_VALUES].sort())
+      .toEqual(VISIBILITY_STATES.map((s) => s.value).sort());
+  });
+
+  it('BREW_METHOD_VALUES matches BREW_METHODS', () => {
+    expect([...BREW_METHOD_VALUES].sort())
+      .toEqual(BREW_METHODS.map((m) => m.value).sort());
+  });
+
+  it('DRINK_TYPE_VALUES matches DRINK_TYPES', () => {
+    expect([...DRINK_TYPE_VALUES].sort())
+      .toEqual(DRINK_TYPES.map((d) => d.value).sort());
+  });
+
+  it('EMOJI_TAG_VALUES matches EMOJI_TAGS keys', () => {
+    expect([...EMOJI_TAG_VALUES].sort())
+      .toEqual(EMOJI_TAGS.map((t) => t.key).sort());
+  });
+
+  it('BADGE_RULE_VALUES matches BADGE_RULES rules', () => {
+    expect([...BADGE_RULE_VALUES].sort())
+      .toEqual(BADGE_RULES.map((b) => b.rule).sort());
+  });
+});
+
+describe('Standalone enum constants: types derived from values', () => {
+  it('EquipmentType covers every value in EQUIPMENT_TYPE_VALUES', () => {
+    const typeSet: Set<EquipmentType> = new Set(EQUIPMENT_TYPE_VALUES);
+    expect(typeSet.size).toBe(EQUIPMENT_TYPE_VALUES.length);
+    for (const value of EQUIPMENT_TYPE_VALUES) {
+      expect(typeSet.has(value)).toBe(true);
+    }
+  });
+
+  it('EQUIPMENT_TYPES is a mutable copy of EQUIPMENT_TYPE_VALUES', () => {
+    expect(EQUIPMENT_TYPES.length).toBe(EQUIPMENT_TYPE_VALUES.length);
+    expect([...EQUIPMENT_TYPES].sort()).toEqual([...EQUIPMENT_TYPE_VALUES].sort());
+  });
+
+  it('EQUIPMENT_TYPE_LABELS has an entry for every EquipmentType', () => {
+    for (const type of EQUIPMENT_TYPE_VALUES) {
+      const label = EQUIPMENT_TYPE_LABELS[type];
+      expect(label).toBeDefined();
+      expect(typeof label).toBe('string');
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('AdditionalPreparationCategory covers ADDITIONAL_PREPARATION_TYPE_VALUES', () => {
+    const set: Set<AdditionalPreparationCategory> = new Set(
+      ADDITIONAL_PREPARATION_TYPE_VALUES,
+    );
+    expect(set.size).toBe(ADDITIONAL_PREPARATION_TYPE_VALUES.length);
+  });
+
+  it('CoffeeVarietyCategory covers COFFEE_VARIETY_CATEGORY_VALUES', () => {
+    const set: Set<CoffeeVarietyCategory> = new Set(COFFEE_VARIETY_CATEGORY_VALUES);
+    expect(set.size).toBe(COFFEE_VARIETY_CATEGORY_VALUES.length);
+  });
+
+  it('EquipmentDeleteRequestStatus covers its values', () => {
+    const set: Set<EquipmentDeleteRequestStatus> = new Set(
+      EQUIPMENT_DELETE_REQUEST_STATUS_VALUES,
+    );
+    expect(set.size).toBe(EQUIPMENT_DELETE_REQUEST_STATUS_VALUES.length);
+  });
+});
+
+describe('User preference constants', () => {
+  it('DATE_FORMAT_VALUES uses underscores (matches PostgreSQL enum)', () => {
+    for (const value of DATE_FORMAT_VALUES) {
+      expect(value).not.toContain('/');
+      expect(value).toMatch(/^[A-Z_]+$/);
+    }
+  });
+
+  it('DATE_FORMAT_DISPLAY covers every DATE_FORMAT_VALUES entry', () => {
+    for (const value of DATE_FORMAT_VALUES) {
+      const display = DATE_FORMAT_DISPLAY[value];
+      expect(display).toBeDefined();
+      expect(display).not.toBe(value);
+    }
+  });
+
+  it('UNIT_SYSTEM_VALUES contains metric and imperial', () => {
+    expect(new Set(UNIT_SYSTEM_VALUES)).toEqual(new Set(['metric', 'imperial']));
+  });
+
+  it('TEMPERATURE_UNIT_VALUES contains celsius and fahrenheit', () => {
+    expect(new Set(TEMPERATURE_UNIT_VALUES)).toEqual(new Set(['celsius', 'fahrenheit']));
+  });
+
+  it('THEME_VALUES contains light, dark, coffee', () => {
+    expect(new Set(THEME_VALUES)).toEqual(new Set(['light', 'dark', 'coffee']));
+  });
+});

--- a/packages/shared/src/constants/enums.test.ts
+++ b/packages/shared/src/constants/enums.test.ts
@@ -75,7 +75,7 @@ describe('Standalone enum constants: types derived from values', () => {
     }
   });
 
-  it('EQUIPMENT_TYPES is a mutable copy of EQUIPMENT_TYPE_VALUES', () => {
+  it('EQUIPMENT_TYPES is a readonly copy of EQUIPMENT_TYPE_VALUES', () => {
     expect(EQUIPMENT_TYPES.length).toBe(EQUIPMENT_TYPE_VALUES.length);
     expect([...EQUIPMENT_TYPES].sort()).toEqual([...EQUIPMENT_TYPE_VALUES].sort());
   });

--- a/packages/shared/src/constants/equipment-delete-request.ts
+++ b/packages/shared/src/constants/equipment-delete-request.ts
@@ -1,0 +1,18 @@
+/**
+ * Equipment deletion request status enum — single source of truth.
+ *
+ * Consumed by:
+ * - `packages/db/src/schema.ts` — Drizzle `pgEnum('equipment_delete_request_status', …)`
+ *
+ * No Zod schema or public-facing TypeScript type currently uses this enum
+ * directly, but it is exported through the constants barrel for downstream
+ * consumers (admin tooling, future status filters, etc.).
+ */
+export const EQUIPMENT_DELETE_REQUEST_STATUS_VALUES = [
+  'pending',
+  'approved',
+  'rejected',
+] as const;
+
+/** Lifecycle status of an equipment deletion request submitted by a user. */
+export type EquipmentDeleteRequestStatus = typeof EQUIPMENT_DELETE_REQUEST_STATUS_VALUES[number];

--- a/packages/shared/src/constants/equipment-types.ts
+++ b/packages/shared/src/constants/equipment-types.ts
@@ -55,5 +55,5 @@ export const EQUIPMENT_TYPE_LABELS: Record<EquipmentType, string> = {
   other: 'Other',
 };
 
-/** Mutable copy of {@link EQUIPMENT_TYPE_VALUES} for use in `.map()`/`.filter()`. */
-export const EQUIPMENT_TYPES: EquipmentType[] = [...EQUIPMENT_TYPE_VALUES];
+/** Readonly copy of {@link EQUIPMENT_TYPE_VALUES} for use in `.map()`/`.filter()`. */
+export const EQUIPMENT_TYPES: readonly EquipmentType[] = [...EQUIPMENT_TYPE_VALUES];

--- a/packages/shared/src/constants/equipment-types.ts
+++ b/packages/shared/src/constants/equipment-types.ts
@@ -1,0 +1,59 @@
+/**
+ * Equipment category enum — single source of truth.
+ *
+ * Consumed by:
+ * - `packages/db/src/schema.ts` — Drizzle `pgEnum('equipment_type', …)`
+ * - `packages/shared/src/schemas/equipment.ts` — Zod `z.enum(…)`
+ * - `packages/shared/src/types/equipment.ts` — `EquipmentType` type
+ *
+ * Adding or removing a value here is automatically picked up by the database
+ * enum, the runtime validator, and the TypeScript union. The Drizzle schema
+ * uses the spread form `[...EQUIPMENT_TYPE_VALUES]` because Drizzle 0.45's
+ * `pgEnum` expects a mutable tuple.
+ */
+export const EQUIPMENT_TYPE_VALUES = [
+  'espresso_machine',
+  'grinder',
+  'pour_over_brewer',
+  'immersion_brewer',
+  'kettle',
+  'milk_tool',
+  'scale_accessory',
+  'roaster',
+  'portafilter',
+  'basket',
+  'puck_screen',
+  'paper_filter',
+  'tamper',
+  'mesh_filter',
+  'cezve',
+  'thermometer',
+  'other',
+] as const;
+
+/** Union of every equipment category stored in the database. */
+export type EquipmentType = (typeof EQUIPMENT_TYPE_VALUES)[number];
+
+/** Human-readable labels keyed by {@link EquipmentType}. */
+export const EQUIPMENT_TYPE_LABELS: Record<EquipmentType, string> = {
+  espresso_machine: 'Espresso Machine',
+  grinder: 'Grinder',
+  pour_over_brewer: 'Pour-Over & Filter Brewer',
+  immersion_brewer: 'Immersion & Pressure Brewer',
+  kettle: 'Kettle',
+  milk_tool: 'Milk Tool',
+  scale_accessory: 'Scale & Accessory',
+  roaster: 'Roaster',
+  portafilter: 'Portafilter',
+  basket: 'Basket',
+  puck_screen: 'Puck Screen',
+  paper_filter: 'Paper Filter',
+  tamper: 'Tamper',
+  mesh_filter: 'Mesh Filter',
+  cezve: 'Cezve',
+  thermometer: 'Thermometer',
+  other: 'Other',
+};
+
+/** Mutable copy of {@link EQUIPMENT_TYPE_VALUES} for use in `.map()`/`.filter()`. */
+export const EQUIPMENT_TYPES: EquipmentType[] = [...EQUIPMENT_TYPE_VALUES];

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,7 +1,48 @@
+/**
+ * Public barrel for `@brewform/shared/constants`.
+ *
+ * Re-exports every rich-object enum definition (option lists for the UI)
+ * and every pure-value tuple (the `_VALUES` arrays) that the rest of the
+ * monorepo consumes for Drizzle `pgEnum()` and Zod `z.enum()` calls.
+ *
+ * The TypeScript type aliases that derive from these tuples (e.g.
+ * `BrewMethodValue`, `EquipmentType`) are intentionally re-exported only
+ * from `@brewform/shared/types` to avoid name collisions at the package
+ * root. The types are still defined inside the `constants/` directory as
+ * the canonical single source of truth, and `types/*.ts` files import
+ * from here.
+ */
+
+// ── Rich-object enum exports (option lists for the UI) ───────────────────────
 export { BREW_METHODS, BREW_METHODS_LIST, type BrewMethodOption } from './brew-methods.ts';
 export { DRINK_TYPES, DRINK_TYPES_LIST, type DrinkTypeOption } from './drink-types.ts';
 export { EMOJI_TAGS, EMOJI_TAGS_LIST, type EmojiTagOption } from './emoji-tags.ts';
-export { CANONICAL_UNITS, UNIT_CONVERSIONS } from './units.ts';
 export { VISIBILITY_STATES, VISIBILITY_STATES_LIST, type VisibilityOption } from './visibility.ts';
 export { BADGE_RULES } from './badges.ts';
-export { BREW_METHOD_EQUIPMENT_RULES } from './brew-method-rules.ts';
+export {
+  BREW_METHOD_EQUIPMENT_RULES,
+  type BrewMethodEquipmentRuleDef,
+} from './brew-method-rules.ts';
+export { CANONICAL_UNITS, UNIT_CONVERSIONS } from './units.ts';
+
+// ── Pure-value tuples (DB / Zod single source of truth) ──────────────────────
+export { BREW_METHOD_VALUES } from './brew-methods.ts';
+export { DRINK_TYPE_VALUES } from './drink-types.ts';
+export { EMOJI_TAG_VALUES } from './emoji-tags.ts';
+export { VISIBILITY_VALUES } from './visibility.ts';
+export { BADGE_RULE_VALUES } from './badges.ts';
+export {
+  EQUIPMENT_TYPE_LABELS,
+  EQUIPMENT_TYPE_VALUES,
+  EQUIPMENT_TYPES,
+} from './equipment-types.ts';
+export { ADDITIONAL_PREPARATION_TYPE_VALUES } from './additional-preparation-types.ts';
+export {
+  DATE_FORMAT_DISPLAY,
+  DATE_FORMAT_VALUES,
+  TEMPERATURE_UNIT_VALUES,
+  THEME_VALUES,
+  UNIT_SYSTEM_VALUES,
+} from './user-preferences.ts';
+export { COFFEE_VARIETY_CATEGORY_VALUES } from './coffee-variety.ts';
+export { EQUIPMENT_DELETE_REQUEST_STATUS_VALUES } from './equipment-delete-request.ts';

--- a/packages/shared/src/constants/user-preferences.ts
+++ b/packages/shared/src/constants/user-preferences.ts
@@ -1,0 +1,52 @@
+/**
+ * User preference enums — single source of truth.
+ *
+ * All four enums (UnitSystem, TemperatureUnit, Theme, DateFormat) feed the
+ * `user_preferences` table's JSON column on the API side and the user-facing
+ * settings page on the web side. The Postgres-side preference storage uses
+ * `DateFormat` with underscore-separated values (`DD_MM_YYYY`) to stay
+ * compatible with the underlying enum, while display strings
+ * (`DD/MM/YYYY`) are produced via {@link DATE_FORMAT_DISPLAY}.
+ */
+export const UNIT_SYSTEM_VALUES = ['metric', 'imperial'] as const;
+/** Measurement system for weight and volume display. */
+export type UnitSystem = (typeof UNIT_SYSTEM_VALUES)[number];
+
+export const TEMPERATURE_UNIT_VALUES = ['celsius', 'fahrenheit'] as const;
+/**
+ * Temperature unit for display.
+ *
+ * Was previously defined inline as a string-union on the `UserPreferences`
+ * interface; promoted to a named type here to match the rest of the
+ * preference enums.
+ */
+export type TemperatureUnit = (typeof TEMPERATURE_UNIT_VALUES)[number];
+
+export const THEME_VALUES = ['light', 'dark', 'coffee'] as const;
+/** UI colour theme. */
+export type Theme = (typeof THEME_VALUES)[number];
+
+/**
+ * Stored date display format.
+ *
+ * Values use underscore separators (`DD_MM_YYYY`) to match the PostgreSQL
+ * `date_format` enum exactly. Display strings with slashes/dashes
+ * (`DD/MM/YYYY`) must NOT be used as stored values — use
+ * {@link DATE_FORMAT_DISPLAY} when rendering the format to users.
+ */
+export const DATE_FORMAT_VALUES = ['DD_MM_YYYY', 'MM_DD_YYYY', 'YYYY_MM_DD'] as const;
+/** See {@link DATE_FORMAT_VALUES} for storage details. */
+export type DateFormat = (typeof DATE_FORMAT_VALUES)[number];
+
+/**
+ * Map from stored `DateFormat` value to its human-readable display string.
+ *
+ * The UI should look up display labels through this map rather than string-
+ * formatting the stored value directly, so that the database representation
+ * (underscores) can stay decoupled from the user-facing representation.
+ */
+export const DATE_FORMAT_DISPLAY: Record<DateFormat, string> = {
+  DD_MM_YYYY: 'DD/MM/YYYY',
+  MM_DD_YYYY: 'MM/DD/YYYY',
+  YYYY_MM_DD: 'YYYY-MM-DD',
+};

--- a/packages/shared/src/constants/visibility.ts
+++ b/packages/shared/src/constants/visibility.ts
@@ -14,3 +14,16 @@ export type VisibilityOption = {
 };
 
 export const VISIBILITY_STATES_LIST: VisibilityOption[] = [...VISIBILITY_STATES];
+
+/**
+ * Pure-values tuple of every {@link VisibilityValue}.
+ *
+ * Derived from {@link VISIBILITY_STATES} via `.map()` so the two cannot drift
+ * apart. Consumed by Drizzle's `pgEnum()` and by Zod `z.enum()` so the runtime
+ * validation set, the database enum, and the TypeScript union share one source
+ * of truth.
+ */
+export const VISIBILITY_VALUES = VISIBILITY_STATES.map((s) => s.value) as [
+  VisibilityValue,
+  ...VisibilityValue[],
+];

--- a/packages/shared/src/schemas/badge.test.ts
+++ b/packages/shared/src/schemas/badge.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the badge schemas (`BadgeCreateSchema` / `BadgeUpdateSchema`).
+ *
+ * Covers: every rule value from {@link BADGE_RULE_VALUES}, missing-field
+ * rejection, non-positive threshold rejection, empty/partial update
+ * acceptance, and rejection of unknown rules.
+ */
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { BADGE_RULE_VALUES } from '../constants/badges.ts';
+import { BadgeCreateSchema, BadgeUpdateSchema } from './badge.ts';
+
+const validBadge = {
+  name: 'First Brew',
+  icon: '\u2615',
+  description: 'Logged your first recipe',
+  rule: 'first_brew',
+  threshold: 1,
+};
+
+/** Validates the full create surface, iterating the canonical rule tuple. */
+describe('BadgeCreateSchema', () => {
+  it('should accept a valid badge', () => {
+    const result = BadgeCreateSchema.safeParse(validBadge);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept every BADGE_RULE_VALUES value', () => {
+    for (const rule of BADGE_RULE_VALUES) {
+      const result = BadgeCreateSchema.safeParse({ ...validBadge, rule });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.rule).toBe(rule);
+    }
+  });
+
+  it('should reject missing name', () => {
+    const { name: _name, ...rest } = validBadge;
+    const result = BadgeCreateSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('name'))).toBe(true);
+    }
+  });
+
+  it('should reject missing rule', () => {
+    const { rule: _rule, ...rest } = validBadge;
+    const result = BadgeCreateSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('rule'))).toBe(true);
+    }
+  });
+
+  it('should reject missing threshold', () => {
+    const { threshold: _threshold, ...rest } = validBadge;
+    const result = BadgeCreateSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('threshold'))).toBe(true);
+    }
+  });
+
+  it('should reject negative threshold', () => {
+    const result = BadgeCreateSchema.safeParse({ ...validBadge, threshold: -1 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('threshold'))).toBe(true);
+    }
+  });
+
+  it('should reject zero threshold', () => {
+    const result = BadgeCreateSchema.safeParse({ ...validBadge, threshold: 0 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('threshold'))).toBe(true);
+    }
+  });
+
+  it('should reject invalid rule', () => {
+    const result = BadgeCreateSchema.safeParse({ ...validBadge, rule: 'not_a_rule' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('rule'))).toBe(true);
+    }
+  });
+});
+
+/** Validates the partial update surface (every field is optional). */
+describe('BadgeUpdateSchema', () => {
+  it('should accept empty object', () => {
+    const result = BadgeUpdateSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept a partial update with one field', () => {
+    const result = BadgeUpdateSchema.safeParse({ name: 'Renamed Badge' });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/shared/src/schemas/badge.ts
+++ b/packages/shared/src/schemas/badge.ts
@@ -1,17 +1,7 @@
 import { z } from 'zod';
+import { BADGE_RULE_VALUES } from '../constants/index.ts';
 
-const BadgeRuleEnum = z.enum([
-  'first_brew',
-  'decade_brewer',
-  'centurion',
-  'first_fork',
-  'fan_favourite',
-  'community_star',
-  'conversationalist',
-  'precision_brewer',
-  'explorer',
-  'influencer',
-]);
+const BadgeRuleEnum = z.enum(BADGE_RULE_VALUES);
 
 export const BadgeCreateSchema = z.object({
   name: z.string().min(1).max(100),

--- a/packages/shared/src/schemas/coffee-variety.test.ts
+++ b/packages/shared/src/schemas/coffee-variety.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'jsr:@std/testing/bdd';
 import { expect } from 'jsr:@std/expect';
+import { COFFEE_VARIETY_CATEGORY_VALUES } from '../constants/coffee-variety.ts';
 import {
   CoffeeVarietyCreateSchema,
   CoffeeVarietyFilterSchema,
@@ -32,8 +33,7 @@ describe('CoffeeVarietyCreateSchema', () => {
   });
 
   it('should accept all valid categories', () => {
-    const categories = ['variety', 'processing', 'market_name'];
-    for (const category of categories) {
+    for (const category of COFFEE_VARIETY_CATEGORY_VALUES) {
       const result = CoffeeVarietyCreateSchema.safeParse({
         name: `Test ${category}`,
         category,

--- a/packages/shared/src/schemas/coffee-variety.ts
+++ b/packages/shared/src/schemas/coffee-variety.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
+import { COFFEE_VARIETY_CATEGORY_VALUES } from '../constants/index.ts';
 
-export const CoffeeVarietyCategoryEnum = z.enum(['variety', 'processing', 'market_name']);
+export const CoffeeVarietyCategoryEnum = z.enum(COFFEE_VARIETY_CATEGORY_VALUES);
 
 export const CoffeeVarietyCreateSchema = z.object({
   name: z.string().min(1).max(255),

--- a/packages/shared/src/schemas/equipment.test.ts
+++ b/packages/shared/src/schemas/equipment.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'jsr:@std/testing/bdd';
 import { expect } from 'jsr:@std/expect';
+import { EQUIPMENT_TYPE_VALUES } from '../constants/equipment-types.ts';
 import {
   EquipmentCreateSchema,
   EquipmentDeleteRequestSchema,
@@ -32,26 +33,7 @@ describe('EquipmentCreateSchema', () => {
   });
 
   it('should accept all valid equipment types', () => {
-    const types = [
-      'espresso_machine',
-      'grinder',
-      'pour_over_brewer',
-      'immersion_brewer',
-      'kettle',
-      'milk_tool',
-      'scale_accessory',
-      'roaster',
-      'portafilter',
-      'basket',
-      'puck_screen',
-      'paper_filter',
-      'tamper',
-      'mesh_filter',
-      'cezve',
-      'thermometer',
-      'other',
-    ];
-    for (const type of types) {
+    for (const type of EQUIPMENT_TYPE_VALUES) {
       const result = EquipmentCreateSchema.safeParse({
         name: `Test ${type}`,
         type,

--- a/packages/shared/src/schemas/equipment.ts
+++ b/packages/shared/src/schemas/equipment.ts
@@ -1,24 +1,7 @@
 import { z } from 'zod';
+import { EQUIPMENT_TYPE_VALUES } from '../constants/index.ts';
 
-const EquipmentTypeEnum = z.enum([
-  'espresso_machine',
-  'grinder',
-  'pour_over_brewer',
-  'immersion_brewer',
-  'kettle',
-  'milk_tool',
-  'scale_accessory',
-  'roaster',
-  'portafilter',
-  'basket',
-  'puck_screen',
-  'paper_filter',
-  'tamper',
-  'mesh_filter',
-  'cezve',
-  'thermometer',
-  'other',
-]);
+const EquipmentTypeEnum = z.enum(EQUIPMENT_TYPE_VALUES);
 
 export const EquipmentCreateSchema = z.object({
   name: z.string().min(1).max(200),

--- a/packages/shared/src/schemas/recipe.test.ts
+++ b/packages/shared/src/schemas/recipe.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from 'jsr:@std/testing/bdd';
 import { expect } from 'jsr:@std/expect';
 import fc from 'npm:fast-check';
+import { EMOJI_TAG_VALUES } from '../constants/emoji-tags.ts';
+import { VISIBILITY_VALUES } from '../constants/visibility.ts';
 import {
   RecipeCreateObjectSchema,
   RecipeCreateSchema,
@@ -49,7 +51,7 @@ describe('RecipeCreateSchema', () => {
   });
 
   it('should accept valid visibility values', () => {
-    for (const visibility of ['draft', 'private', 'unlisted', 'public'] as const) {
+    for (const visibility of VISIBILITY_VALUES) {
       const result = RecipeCreateSchema.safeParse({
         title: 'Test',
         brewMethod: 'espresso_machine',
@@ -140,6 +142,20 @@ describe('RecipeCreateSchema', () => {
       preparationNotes: 'Test notes',
     });
     expect(result.success).toBe(true);
+  });
+
+  it('should accept every emoji tag value from EMOJI_TAG_VALUES', () => {
+    for (const emojiTag of EMOJI_TAG_VALUES) {
+      const result = RecipeCreateSchema.safeParse({
+        title: 'Tagged',
+        brewMethod: 'espresso_machine',
+        drinkType: 'espresso',
+        emojiTag,
+        preparationNotes: 'Test notes',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.emojiTag).toBe(emojiTag);
+    }
   });
 
   it('should reject invalid emoji tags', () => {

--- a/packages/shared/src/schemas/recipe.ts
+++ b/packages/shared/src/schemas/recipe.ts
@@ -1,41 +1,17 @@
 import { z } from 'zod';
+import {
+  ADDITIONAL_PREPARATION_TYPE_VALUES,
+  BREW_METHOD_VALUES,
+  DRINK_TYPE_VALUES,
+  EMOJI_TAG_VALUES,
+  VISIBILITY_VALUES,
+} from '../constants/index.ts';
 
-const BrewMethodEnum = z.enum([
-  'espresso_machine',
-  'v60',
-  'french_press',
-  'aeropress',
-  'turkish_coffee',
-  'drip_coffee',
-  'chemex',
-  'kalita_wave',
-  'moka_pot',
-  'cold_brew',
-  'siphon',
-]);
-
-const DrinkTypeEnum = z.enum([
-  'espresso',
-  'americano',
-  'flat_white',
-  'latte',
-  'cappuccino',
-  'cortado',
-  'macchiato',
-  'turkish_coffee',
-  'pour_over',
-  'cold_brew',
-  'french_press',
-  'aeropress',
-  'drip_coffee',
-  'moka_pot',
-  'siphon',
-]);
-
-const VisibilityEnum = z.enum(['draft', 'private', 'unlisted', 'public']);
-const EmojiTagEnum = z.enum(['fire', 'rocket', 'thumbsup', 'neutral', 'thumbsdown', 'nauseated']);
-
-const AdditionalPreparationTypeEnum = z.enum(['milk', 'water', 'syrup', 'spice', 'other']);
+const BrewMethodEnum = z.enum(BREW_METHOD_VALUES);
+const DrinkTypeEnum = z.enum(DRINK_TYPE_VALUES);
+const VisibilityEnum = z.enum(VISIBILITY_VALUES);
+const EmojiTagEnum = z.enum(EMOJI_TAG_VALUES);
+const AdditionalPreparationTypeEnum = z.enum(ADDITIONAL_PREPARATION_TYPE_VALUES);
 
 const AdditionalPreparationSchema = z.object({
   name: z.string().min(1).max(100),

--- a/packages/shared/src/schemas/user.test.ts
+++ b/packages/shared/src/schemas/user.test.ts
@@ -11,7 +11,7 @@ describe('UserPreferencesSchema', () => {
       expect(result.data.temperatureUnit).toBe('celsius');
       expect(result.data.theme).toBe('light');
       expect(result.data.locale).toBe('en');
-      expect(result.data.dateFormat).toBe('YYYY-MM-DD');
+      expect(result.data.dateFormat).toBe('YYYY_MM_DD');
     }
   });
 
@@ -44,6 +44,40 @@ describe('UserPreferencesSchema', () => {
       },
     });
     expect(result.success).toBe(true);
+  });
+});
+
+/** DateFormat / TemperatureUnit regression coverage for the D07 storage-vs-display fix. */
+describe('UserPreferencesSchema: DateFormat fix (D07)', () => {
+  it('should accept every stored DateFormat value (DD_MM_YYYY / MM_DD_YYYY / YYYY_MM_DD)', () => {
+    for (const dateFormat of ['DD_MM_YYYY', 'MM_DD_YYYY', 'YYYY_MM_DD'] as const) {
+      const result = UserPreferencesSchema.safeParse({ dateFormat });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.dateFormat).toBe(dateFormat);
+    }
+  });
+
+  it('should reject the old slash/dash DateFormat values', () => {
+    for (const dateFormat of ['DD/MM/YYYY', 'MM/DD/YYYY', 'YYYY-MM-DD']) {
+      const result = UserPreferencesSchema.safeParse({ dateFormat });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path.includes('dateFormat'))).toBe(true);
+      }
+    }
+  });
+
+  it('should accept every TemperatureUnit value', () => {
+    for (const temperatureUnit of ['celsius', 'fahrenheit'] as const) {
+      const result = UserPreferencesSchema.safeParse({ temperatureUnit });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.temperatureUnit).toBe(temperatureUnit);
+    }
+  });
+
+  it('should reject invalid TemperatureUnit', () => {
+    const result = UserPreferencesSchema.safeParse({ temperatureUnit: 'kelvin' });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/packages/shared/src/schemas/user.ts
+++ b/packages/shared/src/schemas/user.ts
@@ -1,12 +1,18 @@
 import { z } from 'zod';
+import {
+  DATE_FORMAT_VALUES,
+  TEMPERATURE_UNIT_VALUES,
+  THEME_VALUES,
+  UNIT_SYSTEM_VALUES,
+} from '../constants/index.ts';
 
 export const UserPreferencesSchema = z.object({
-  unitSystem: z.enum(['metric', 'imperial']).default('metric'),
-  temperatureUnit: z.enum(['celsius', 'fahrenheit']).default('celsius'),
-  theme: z.enum(['light', 'dark', 'coffee']).default('light'),
+  unitSystem: z.enum(UNIT_SYSTEM_VALUES).default('metric'),
+  temperatureUnit: z.enum(TEMPERATURE_UNIT_VALUES).default('celsius'),
+  theme: z.enum(THEME_VALUES).default('light'),
   locale: z.string().default('en'),
   timezone: z.string().default('UTC'),
-  dateFormat: z.enum(['DD/MM/YYYY', 'MM/DD/YYYY', 'YYYY-MM-DD']).default('YYYY-MM-DD'),
+  dateFormat: z.enum(DATE_FORMAT_VALUES).default('YYYY_MM_DD'),
   emailNotifications: z.object({
     newFollower: z.boolean().default(true),
     recipeLiked: z.boolean().default(true),

--- a/packages/shared/src/types/badge.ts
+++ b/packages/shared/src/types/badge.ts
@@ -3,20 +3,14 @@
  *
  * Badges are awarded to users automatically when they meet a rule's
  * threshold (e.g. brewing 100 recipes earns the "Centurion" badge).
+ *
+ * The {@link BadgeRule} type is aliased to the corresponding constants in
+ * `@brewform/shared/constants` for a single source of truth.
  */
+import type { BadgeRule as _BadgeRule } from '../constants/badges.ts';
 
 /** Machine-readable badge rule identifier. */
-export type BadgeRule =
-  | 'first_brew'
-  | 'decade_brewer'
-  | 'centurion'
-  | 'first_fork'
-  | 'fan_favourite'
-  | 'community_star'
-  | 'conversationalist'
-  | 'precision_brewer'
-  | 'explorer'
-  | 'influencer';
+export type BadgeRule = _BadgeRule;
 
 /** Badge definition (platform-wide, not per-user). */
 export interface Badge {

--- a/packages/shared/src/types/coffee-variety.ts
+++ b/packages/shared/src/types/coffee-variety.ts
@@ -1,4 +1,13 @@
-export type CoffeeVarietyCategory = 'variety' | 'processing' | 'market_name';
+/**
+ * Coffee-variety-related types shared between API and frontend.
+ *
+ * The {@link CoffeeVarietyCategory} type is aliased to the corresponding
+ * constant in `@brewform/shared/constants` so the database enum, Zod schema,
+ * and TypeScript union share a single source of truth.
+ */
+import type { CoffeeVarietyCategory as _CoffeeVarietyCategory } from '../constants/coffee-variety.ts';
+
+export type CoffeeVarietyCategory = _CoffeeVarietyCategory;
 
 export interface CoffeeVariety {
   id: string;

--- a/packages/shared/src/types/equipment.ts
+++ b/packages/shared/src/types/equipment.ts
@@ -4,27 +4,14 @@
  * Equipment represents brewing tools users can associate with recipes
  * and saved setups. Specialized sub-types (Portafilter, Basket, etc.)
  * extend the base Equipment with type-specific detail fields.
+ *
+ * Enum types in this file are aliased to the corresponding constants in
+ * `@brewform/shared/constants` for a single source of truth.
  */
+import type { EquipmentType as _EquipmentType } from '../constants/equipment-types.ts';
 
 /** Category of brewing equipment. */
-export type EquipmentType =
-  | 'espresso_machine'
-  | 'grinder'
-  | 'pour_over_brewer'
-  | 'immersion_brewer'
-  | 'kettle'
-  | 'milk_tool'
-  | 'scale_accessory'
-  | 'roaster'
-  | 'portafilter'
-  | 'basket'
-  | 'puck_screen'
-  | 'paper_filter'
-  | 'tamper'
-  | 'mesh_filter'
-  | 'cezve'
-  | 'thermometer'
-  | 'other';
+export type EquipmentType = _EquipmentType;
 
 /**
  * Base equipment entity returned by equipment endpoints

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -6,9 +6,18 @@
  */
 
 export type { ApiError, ApiResponse, PaginationMeta, PaginationQuery } from './api.ts';
-export type { UnitSystem, User, UserPreferences, UserProfile } from './user.ts';
+export type {
+  DateFormat,
+  TemperatureUnit,
+  Theme,
+  UnitSystem,
+  User,
+  UserPreferences,
+  UserProfile,
+} from './user.ts';
 export type {
   AdditionalPreparation,
+  AdditionalPreparationCategory,
   BrewMethod,
   DrinkType,
   EmojiTag,
@@ -21,6 +30,7 @@ export type {
 export type {
   Basket,
   Equipment,
+  EquipmentType,
   PaperFilter,
   Portafilter,
   PuckScreen,

--- a/packages/shared/src/types/recipe.ts
+++ b/packages/shared/src/types/recipe.ts
@@ -3,45 +3,29 @@
  *
  * Recipes are the core entity — each recipe has one or more versioned snapshots
  * (RecipeVersion) that capture the full brewing parameters at a point in time.
+ *
+ * Enum types in this file are aliased to the corresponding constants in
+ * `@brewform/shared/constants`. They preserve the original public names so
+ * every downstream consumer continues to compile unchanged while the source
+ * of truth lives in one place.
  */
+import type { BrewMethodValue } from '../constants/brew-methods.ts';
+import type { DrinkTypeValue } from '../constants/drink-types.ts';
+import type { EmojiTagKey } from '../constants/emoji-tags.ts';
+import type { VisibilityValue } from '../constants/visibility.ts';
+import type { AdditionalPreparationCategory as _AdditionalPreparationCategory } from '../constants/additional-preparation-types.ts';
 
 /** Visibility state for a recipe. Drafts are only visible to the author. */
-export type Visibility = 'draft' | 'private' | 'unlisted' | 'public';
+export type Visibility = VisibilityValue;
 
 /** Supported brewing devices and techniques. */
-export type BrewMethod =
-  | 'espresso_machine'
-  | 'v60'
-  | 'french_press'
-  | 'aeropress'
-  | 'turkish_coffee'
-  | 'drip_coffee'
-  | 'chemex'
-  | 'kalita_wave'
-  | 'moka_pot'
-  | 'cold_brew'
-  | 'siphon';
+export type BrewMethod = BrewMethodValue;
 
 /** Final drink served to the consumer (may differ from the brew method). */
-export type DrinkType =
-  | 'espresso'
-  | 'americano'
-  | 'flat_white'
-  | 'latte'
-  | 'cappuccino'
-  | 'cortado'
-  | 'macchiato'
-  | 'turkish_coffee'
-  | 'pour_over'
-  | 'cold_brew'
-  | 'french_press'
-  | 'aeropress'
-  | 'drip_coffee'
-  | 'moka_pot'
-  | 'siphon';
+export type DrinkType = DrinkTypeValue;
 
 /** Quick-reaction emoji a user can attach to their own brew. */
-export type EmojiTag = 'fire' | 'rocket' | 'thumbsup' | 'neutral' | 'thumbsdown' | 'nauseated';
+export type EmojiTag = EmojiTagKey;
 
 /**
  * Full recipe response returned by `GET /api/v1/recipes/:slugOrId`.
@@ -191,7 +175,7 @@ export interface RecipeCreateInput {
 }
 
 /** Category of an additional preparation step. */
-export type AdditionalPreparationCategory = 'milk' | 'water' | 'syrup' | 'spice' | 'other';
+export type AdditionalPreparationCategory = _AdditionalPreparationCategory;
 
 /**
  * An additional preparation step applied to a recipe version

--- a/packages/shared/src/types/user.ts
+++ b/packages/shared/src/types/user.ts
@@ -3,16 +3,34 @@
  *
  * Defines the authenticated user object, public profile shape,
  * and user-configurable preferences.
+ *
+ * Preference enum types are aliased to the corresponding constants in
+ * `@brewform/shared/constants` so the database enum, Zod schema, and
+ * TypeScript union share a single source of truth.
  */
+import type {
+  DateFormat as _DateFormat,
+  TemperatureUnit as _TemperatureUnit,
+  Theme as _Theme,
+  UnitSystem as _UnitSystem,
+} from '../constants/user-preferences.ts';
 
 /** UI colour theme. */
-export type Theme = 'light' | 'dark' | 'coffee';
+export type Theme = _Theme;
 
 /** Measurement system for weight and volume display. */
-export type UnitSystem = 'metric' | 'imperial';
+export type UnitSystem = _UnitSystem;
 
-/** Date display format. */
-export type DateFormat = 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY-MM-DD';
+/**
+ * Date display format.
+ * Stored values use underscore separators to match the PostgreSQL `date_format` enum.
+ * For human-readable display strings (e.g. `DD/MM/YYYY`) use the
+ * `DATE_FORMAT_DISPLAY` map from `@brewform/shared/constants`.
+ */
+export type DateFormat = _DateFormat;
+
+/** Temperature unit for display. */
+export type TemperatureUnit = _TemperatureUnit;
 
 /**
  * Serialisable user preferences stored in the `preferences` JSON column.
@@ -22,7 +40,7 @@ export type DateFormat = 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY-MM-DD';
  */
 export interface UserPreferences {
   unitSystem: UnitSystem;
-  temperatureUnit: 'celsius' | 'fahrenheit';
+  temperatureUnit: TemperatureUnit;
   theme: Theme;
   locale: string;
   timezone: string;

--- a/plans/D07-enum-single-source.md
+++ b/plans/D07-enum-single-source.md
@@ -10,208 +10,863 @@ Enum values are defined in 3 separate locations that must be kept in sync manual
 2. **Zod schemas** (`packages/shared/src/schemas/*.ts`) — validation schemas
 3. **TypeScript types** (`packages/shared/src/types/*.ts`) — type union definitions
 
-Adding or removing an enum value requires updating all 3 locations in lockstep. This is error-prone and has already caused drift (see D06: `DrinkType` missing 4 values in the TS type).
+Adding or removing an enum value requires updating all 3 locations in lockstep. This is error-prone and has already caused a production-breaking drift (see below).
+
+## Existing Drift (production bug)
+
+**`date_format` enum — the only active drift found in the codebase:**
+
+| Layer | Values stored |
+|-------|--------------|
+| DB (`schema.ts` pgEnum) | `'DD_MM_YYYY'`, `'MM_DD_YYYY'`, `'YYYY_MM_DD'` |
+| Zod (`schemas/user.ts`) | `'DD/MM/YYYY'`, `'MM/DD/YYYY'`, `'YYYY-MM-DD'` |
+| TypeScript (`types/user.ts`) | `'DD/MM/YYYY' \| 'MM/DD/YYYY' \| 'YYYY-MM-DD'` |
+
+These are **incompatible string values**. The Zod schema accepts `'DD/MM/YYYY'` but PostgreSQL will reject it at INSERT/UPDATE time because the `date_format` column enum was migrated with underscores. All other 12 enums are currently in sync across all layers.
+
+> **Prior note on D06:** The DrinkType drift referenced in the original issue description is already resolved. All 15 `drink_type` values match across DB, Zod, and TypeScript as of the current main branch.
+
+## Current State of `packages/shared/src/constants/`
+
+A `constants/` directory already exists with rich-object arrays for several enums. This is the correct foundation — the work here is to connect it to the layers that still maintain independent inline definitions.
+
+| Constants file | What exists | What's missing |
+|---|---|---|
+| `visibility.ts` | `VISIBILITY_STATES` (rich objects), `VisibilityValue` type | `VISIBILITY_VALUES` tuple for Drizzle/Zod |
+| `brew-methods.ts` | `BREW_METHODS` (rich objects), `BrewMethodValue` type | `BREW_METHOD_VALUES` tuple |
+| `drink-types.ts` | `DRINK_TYPES` (rich objects), `DrinkTypeValue` type | `DRINK_TYPE_VALUES` tuple |
+| `emoji-tags.ts` | `EMOJI_TAGS` (rich objects with `key` field), `EmojiTagKey` type | `EMOJI_TAG_VALUES` tuple |
+| `badges.ts` | `BADGE_RULES` (rich objects with `rule` field) | `BadgeRule` type, `BADGE_RULE_VALUES` tuple |
+| `brew-method-rules.ts` | `EQUIPMENT_TYPES` (non-const array), `EQUIPMENT_TYPE_LABELS` | These should move to a new `equipment-types.ts` file |
+| `units.ts` | Unit conversion helpers | Not an enum; no action needed |
+| *(missing)* | `equipment_type`, `additional_preparation_type`, `unit_system`, `temperature_unit`, `theme`, `date_format`, `coffee_variety_category`, `equipment_delete_request_status` | New constants files needed |
+
+**Additionally**, several types that ARE defined in `types/` files are not yet re-exported through `types/index.ts`:
+- `EquipmentType` (in `types/equipment.ts` — not in barrel)
+- `Theme` (in `types/user.ts` — not in barrel)
+- `DateFormat` (in `types/user.ts` — not in barrel)
+- `AdditionalPreparationCategory` (in `types/recipe.ts` — not in barrel)
+- `TemperatureUnit` (does not exist as a named type anywhere — only inline in `UserPreferences`)
+
+And several types that exist in individual constants files are not exported from `constants/index.ts`:
+- `BrewMethodValue`, `DrinkTypeValue`, `EmojiTagKey`, `VisibilityValue`
 
 ## Impact
 
+- **Production bug**: Saving a user's `dateFormat` preference will be rejected by PostgreSQL (enum value mismatch).
 - **High drift risk**: Any new enum value must be added in 3+ files. Missing one causes silent type mismatches.
-- **Maintenance burden**: Developers must remember all locations and keep them synchronized.
-- **Existing drift**: `DrinkType` already has this issue (D06), proving the risk is real.
-- **Testing overhead**: Tests must verify consistency across all 3 locations.
-
-## Root Cause
-
-No shared constant or single source of truth was established for enum values. Each layer (DB, validation, types) independently defined its own copy of the same values.
-
-## Affected Enums
-
-| Enum | DB Location | Zod Location | TS Type Location |
-|------|-------------|--------------|------------------|
-| `visibility` | `schema.ts:25-30` | `schemas/recipe.ts:35` | `types/recipe.ts:9` |
-| `brew_method` | `schema.ts:34-46` | `schemas/recipe.ts:3-15` | `types/recipe.ts:12-23` |
-| `drink_type` | `schema.ts:48-64` | `schemas/recipe.ts:17-33` | `types/recipe.ts:26-37` ⚠️ DRIFT |
-| `emoji_tag` | `schema.ts:86-93` | `schemas/recipe.ts:36` | `types/recipe.ts:40` |
-| `equipment_type` | `schema.ts:66-84` | `schemas/equipment.ts:3-21` | — |
-| `additional_preparation_type` | `schema.ts:130-136` | `schemas/recipe.ts:38` | `types/recipe.ts:190` |
-| `badge_rule` | `schema.ts:95-106` | `schemas/badge.ts` | — |
-| `unit_system` | `schema.ts:108-111` | — | `types/user.ts:12` |
-| `temperature_unit` | `schema.ts:113-116` | — | `types/user.ts:25` |
-| `theme` | `schema.ts:118-122` | — | `types/user.ts:9` |
-| `date_format` | `schema.ts:124-128` | — | `types/user.ts:15` |
-| `coffee_variety_category` | `schema.ts:417-421` | `schemas/coffee-variety.ts` | — |
+- **Maintenance burden**: Developers must remember all locations and keep them synchronised.
+- **Incomplete barrel exports**: `EquipmentType`, `Theme`, `DateFormat`, `AdditionalPreparationCategory`, and `TemperatureUnit` are not publicly accessible via the shared package's export paths.
 
 ## Fix Approach
 
-Create a single source of truth in `packages/shared/src/constants/enums.ts` using `as const` arrays. Derive Zod schemas and TypeScript types from these constants. The Drizzle schema in `packages/db` must keep its own `pgEnum()` definitions (Drizzle requires this for migrations), but they should reference the shared constants where possible.
+Extend the existing `constants/` directory to be the single source of truth for all enum values. Each existing rich-object file gains a plain values tuple that derives from the objects it already owns. New files are created for missing enums. Zod schemas and TypeScript types derive from these tuples. The Drizzle schema imports the tuples from `@brewform/shared/constants` and passes them to `pgEnum()`.
 
-Reference: [Drizzle ORM pgEnum](/drizzle-team/drizzle-orm-docs)
+The existing rich-object exports (`BREW_METHODS`, `DRINK_TYPES`, etc.) are **preserved unchanged** — only additions are made to those files.
+
+---
 
 ## Implementation Steps
 
-### Step 1: Create shared enum constants
+### Step 1 — Fix the `DateFormat` production bug (do this first, independently)
 
-Create `packages/shared/src/constants/enums.ts`:
+This is a standalone fix that does not require the rest of the refactor and should be merged immediately.
+
+**`packages/shared/src/schemas/user.ts`** — correct the three drift values:
 
 ```typescript
-// packages/shared/src/constants/enums.ts
+// BEFORE (incorrect — does not match DB enum):
+dateFormat: z.enum(['DD/MM/YYYY', 'MM/DD/YYYY', 'YYYY-MM-DD']).default('YYYY-MM-DD'),
 
-export const VISIBILITY_VALUES = ['draft', 'private', 'unlisted', 'public'] as const;
-export type Visibility = typeof VISIBILITY_VALUES[number];
+// AFTER (matches DB pgEnum values):
+dateFormat: z.enum(['DD_MM_YYYY', 'MM_DD_YYYY', 'YYYY_MM_DD']).default('YYYY_MM_DD'),
+```
 
-export const BREW_METHOD_VALUES = [
-  'espresso_machine', 'v60', 'french_press', 'aeropress', 'turkish_coffee',
-  'drip_coffee', 'chemex', 'kalita_wave', 'moka_pot', 'cold_brew', 'siphon',
-] as const;
-export type BrewMethod = typeof BREW_METHOD_VALUES[number];
+**`packages/shared/src/types/user.ts`** — fix the `DateFormat` type and the `UserPreferences` interface:
 
-export const DRINK_TYPE_VALUES = [
-  'espresso', 'americano', 'flat_white', 'latte', 'cappuccino', 'cortado',
-  'macchiato', 'turkish_coffee', 'pour_over', 'cold_brew', 'french_press',
-  'aeropress', 'drip_coffee', 'moka_pot', 'siphon',
-] as const;
-export type DrinkType = typeof DRINK_TYPE_VALUES[number];
+```typescript
+// BEFORE:
+export type DateFormat = 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY-MM-DD';
 
-export const EMOJI_TAG_VALUES = [
-  'fire', 'rocket', 'thumbsup', 'neutral', 'thumbsdown', 'nauseated',
-] as const;
-export type EmojiTag = typeof EMOJI_TAG_VALUES[number];
+// AFTER:
+export type DateFormat = 'DD_MM_YYYY' | 'MM_DD_YYYY' | 'YYYY_MM_DD';
+```
 
+**Run immediately after this change:**
+```bash
+# Confirm no rows in the DB have the old slash/dash values
+# (if the date format preference UI was never shipped, this should return 0 rows)
+psql -c "SELECT id, date_format FROM user_preferences
+         WHERE date_format NOT IN ('DD_MM_YYYY', 'MM_DD_YYYY', 'YYYY_MM_DD');"
+```
+
+If rows are found, write a one-off data migration to convert `'DD/MM/YYYY'` → `'DD_MM_YYYY'`, etc. before deploying.
+
+**Update any display/formatting helpers** that render the stored value as a human-readable pattern. They currently receive `'DD/MM/YYYY'` directly; after the fix they receive `'DD_MM_YYYY'` and must map it:
+
+```typescript
+import type { DateFormat } from '@brewform/shared/types';
+
+// Add this helper (or update the existing one):
+export const DATE_FORMAT_DISPLAY: Record<DateFormat, string> = {
+  DD_MM_YYYY: 'DD/MM/YYYY',
+  MM_DD_YYYY: 'MM/DD/YYYY',
+  YYYY_MM_DD: 'YYYY-MM-DD',
+};
+```
+
+```bash
+# Find every reference to the old slash/dash values in apps/
+grep -rn "DD/MM/YYYY\|MM/DD/YYYY\|YYYY-MM-DD" apps/ packages/
+```
+
+---
+
+### Step 2 — Add `_VALUES` tuples to existing constants files
+
+Add the following exports at the **end** of each existing file. The `.map()` derivation ensures the values tuple is always derived from the rich objects, so they cannot diverge.
+
+**`packages/shared/src/constants/visibility.ts`** — add:
+
+```typescript
+// Derived pure-values tuple — always in sync with VISIBILITY_STATES above
+export const VISIBILITY_VALUES = VISIBILITY_STATES.map((s) => s.value) as
+  [VisibilityValue, ...VisibilityValue[]];
+```
+
+**`packages/shared/src/constants/brew-methods.ts`** — add:
+
+```typescript
+// Derived pure-values tuple — always in sync with BREW_METHODS above
+export const BREW_METHOD_VALUES = BREW_METHODS.map((m) => m.value) as
+  [BrewMethodValue, ...BrewMethodValue[]];
+```
+
+**`packages/shared/src/constants/drink-types.ts`** — add:
+
+```typescript
+// Derived pure-values tuple — always in sync with DRINK_TYPES above
+export const DRINK_TYPE_VALUES = DRINK_TYPES.map((d) => d.value) as
+  [DrinkTypeValue, ...DrinkTypeValue[]];
+```
+
+**`packages/shared/src/constants/emoji-tags.ts`** — add (note: the field is `key`, not `value`):
+
+```typescript
+// Derived pure-values tuple — always in sync with EMOJI_TAGS above
+export const EMOJI_TAG_VALUES = EMOJI_TAGS.map((t) => t.key) as
+  [EmojiTagKey, ...EmojiTagKey[]];
+```
+
+**`packages/shared/src/constants/badges.ts`** — add (note: the field is `rule`, not `value`):
+
+```typescript
+// Add the named type (currently missing from this file):
+export type BadgeRule = (typeof BADGE_RULES)[number]['rule'];
+
+// Derived pure-values tuple — always in sync with BADGE_RULES above
+export const BADGE_RULE_VALUES = BADGE_RULES.map((b) => b.rule) as
+  [BadgeRule, ...BadgeRule[]];
+```
+
+---
+
+### Step 3 — Create `constants/equipment-types.ts` (migrating from `brew-method-rules.ts`)
+
+`EQUIPMENT_TYPES` and `EQUIPMENT_TYPE_LABELS` already exist in `brew-method-rules.ts` but are typed as mutable `EquipmentType[]` (non-const) and are not exported from `constants/index.ts`. Promote them to a dedicated file.
+
+Create **`packages/shared/src/constants/equipment-types.ts`**:
+
+```typescript
+/**
+ * Equipment type enum values — single source of truth.
+ * Consumed by Drizzle pgEnum, Zod schemas, and TypeScript types.
+ */
 export const EQUIPMENT_TYPE_VALUES = [
-  'espresso_machine', 'grinder', 'pour_over_brewer', 'immersion_brewer',
-  'kettle', 'milk_tool', 'scale_accessory', 'roaster', 'portafilter',
-  'basket', 'puck_screen', 'paper_filter', 'tamper', 'mesh_filter',
-  'cezve', 'thermometer', 'other',
+  'espresso_machine',
+  'grinder',
+  'pour_over_brewer',
+  'immersion_brewer',
+  'kettle',
+  'milk_tool',
+  'scale_accessory',
+  'roaster',
+  'portafilter',
+  'basket',
+  'puck_screen',
+  'paper_filter',
+  'tamper',
+  'mesh_filter',
+  'cezve',
+  'thermometer',
+  'other',
 ] as const;
+
 export type EquipmentType = typeof EQUIPMENT_TYPE_VALUES[number];
 
+/** Human-readable labels for each equipment type. */
+export const EQUIPMENT_TYPE_LABELS: Record<EquipmentType, string> = {
+  espresso_machine: 'Espresso Machine',
+  grinder: 'Grinder',
+  pour_over_brewer: 'Pour-Over & Filter Brewer',
+  immersion_brewer: 'Immersion & Pressure Brewer',
+  kettle: 'Kettle',
+  milk_tool: 'Milk Tool',
+  scale_accessory: 'Scale & Accessory',
+  roaster: 'Roaster',
+  portafilter: 'Portafilter',
+  basket: 'Basket',
+  puck_screen: 'Puck Screen',
+  paper_filter: 'Paper Filter',
+  tamper: 'Tamper',
+  mesh_filter: 'Mesh Filter',
+  cezve: 'Cezve',
+  thermometer: 'Thermometer',
+  other: 'Other',
+};
+
+/** Mutable copy for use in .map()/.filter() in React components. */
+export const EQUIPMENT_TYPES: EquipmentType[] = [...EQUIPMENT_TYPE_VALUES];
+```
+
+Then **update `constants/brew-method-rules.ts`** to:
+1. Import from the new file instead of from `types/`
+2. Remove the now-duplicate `EQUIPMENT_TYPES` and `EQUIPMENT_TYPE_LABELS` declarations
+
+```typescript
+// BEFORE (top of file):
+import type { BrewMethod } from '../types/recipe.ts';
+import type { EquipmentType } from '../types/equipment.ts';
+
+export const EQUIPMENT_TYPES: EquipmentType[] = [ ... ];       // DELETE
+export const EQUIPMENT_TYPE_LABELS: Record<...> = { ... };     // DELETE
+
+// AFTER:
+import type { BrewMethodValue } from './brew-methods.ts';
+import type { EquipmentType } from './equipment-types.ts';
+
+// Update the interface and BREW_METHOD_EQUIPMENT_RULES to use BrewMethodValue
+// (BrewMethodValue is the same type as BrewMethod — just the name from constants)
+export interface BrewMethodEquipmentRuleDef {
+  brewMethod: BrewMethodValue;
+  equipmentType: EquipmentType;
+  compatible: boolean;
+}
+// BREW_METHOD_EQUIPMENT_RULES array body is unchanged
+```
+
+---
+
+### Step 4 — Create new constants files for remaining missing enums
+
+Create **`packages/shared/src/constants/additional-preparation-types.ts`**:
+
+```typescript
 export const ADDITIONAL_PREPARATION_TYPE_VALUES = [
-  'milk', 'water', 'syrup', 'spice', 'other',
+  'milk',
+  'water',
+  'syrup',
+  'spice',
+  'other',
 ] as const;
-export type AdditionalPreparationCategory = typeof ADDITIONAL_PREPARATION_TYPE_VALUES[number];
 
-export const BADGE_RULE_VALUES = [
-  'first_brew', 'decade_brewer', 'centurion', 'first_fork',
-  'fan_favourite', 'community_star', 'conversationalist',
-  'precision_brewer', 'explorer', 'influencer',
-] as const;
-export type BadgeRule = typeof BADGE_RULE_VALUES[number];
+/**
+ * Named "Category" to match the existing TypeScript convention in types/recipe.ts.
+ * The DB enum and Zod schema use the word "type" but the TS convention is "category".
+ */
+export type AdditionalPreparationCategory =
+  typeof ADDITIONAL_PREPARATION_TYPE_VALUES[number];
+```
 
+Create **`packages/shared/src/constants/user-preferences.ts`**:
+
+```typescript
 export const UNIT_SYSTEM_VALUES = ['metric', 'imperial'] as const;
 export type UnitSystem = typeof UNIT_SYSTEM_VALUES[number];
 
 export const TEMPERATURE_UNIT_VALUES = ['celsius', 'fahrenheit'] as const;
+/** Named type — was previously only defined inline in the UserPreferences interface. */
 export type TemperatureUnit = typeof TEMPERATURE_UNIT_VALUES[number];
 
 export const THEME_VALUES = ['light', 'dark', 'coffee'] as const;
 export type Theme = typeof THEME_VALUES[number];
 
+/**
+ * DateFormat values use underscore separators to match the PostgreSQL enum.
+ * Display-formatted strings ('DD/MM/YYYY' etc.) must NOT be used as stored values.
+ * Use DATE_FORMAT_DISPLAY in your rendering helpers (see Step 1).
+ */
 export const DATE_FORMAT_VALUES = ['DD_MM_YYYY', 'MM_DD_YYYY', 'YYYY_MM_DD'] as const;
 export type DateFormat = typeof DATE_FORMAT_VALUES[number];
 
-export const COFFEE_VARIETY_CATEGORY_VALUES = ['variety', 'processing', 'market_name'] as const;
-export type CoffeeVarietyCategory = typeof COFFEE_VARIETY_CATEGORY_VALUES[number];
-
-export const EQUIPMENT_DELETE_REQUEST_STATUS_VALUES = [
-  'pending', 'approved', 'rejected',
-] as const;
-export type EquipmentDeleteRequestStatus = typeof EQUIPMENT_DELETE_REQUEST_STATUS_VALUES[number];
+export const DATE_FORMAT_DISPLAY: Record<DateFormat, string> = {
+  DD_MM_YYYY: 'DD/MM/YYYY',
+  MM_DD_YYYY: 'MM/DD/YYYY',
+  YYYY_MM_DD: 'YYYY-MM-DD',
+};
 ```
 
-### Step 2: Derive Zod schemas from constants
+Create **`packages/shared/src/constants/coffee-variety.ts`**:
 
-Update `packages/shared/src/schemas/recipe.ts`:
+```typescript
+export const COFFEE_VARIETY_CATEGORY_VALUES = [
+  'variety',
+  'processing',
+  'market_name',
+] as const;
+
+export type CoffeeVarietyCategory =
+  typeof COFFEE_VARIETY_CATEGORY_VALUES[number];
+```
+
+Create **`packages/shared/src/constants/equipment-delete-request.ts`**:
+
+```typescript
+export const EQUIPMENT_DELETE_REQUEST_STATUS_VALUES = [
+  'pending',
+  'approved',
+  'rejected',
+] as const;
+
+export type EquipmentDeleteRequestStatus =
+  typeof EQUIPMENT_DELETE_REQUEST_STATUS_VALUES[number];
+```
+
+---
+
+### Step 5 — Update `constants/index.ts`
+
+Replace the entire file with the full set of exports, including types that were previously unexported:
+
+```typescript
+// ── Existing rich-object exports (unchanged) ─────────────────────────────────
+export {
+  BREW_METHODS,
+  BREW_METHODS_LIST,
+  type BrewMethodOption,
+} from './brew-methods.ts';
+export {
+  DRINK_TYPES,
+  DRINK_TYPES_LIST,
+  type DrinkTypeOption,
+} from './drink-types.ts';
+export {
+  EMOJI_TAGS,
+  EMOJI_TAGS_LIST,
+  type EmojiTagOption,
+} from './emoji-tags.ts';
+export { CANONICAL_UNITS, UNIT_CONVERSIONS } from './units.ts';
+export {
+  VISIBILITY_STATES,
+  VISIBILITY_STATES_LIST,
+  type VisibilityOption,
+} from './visibility.ts';
+export { BADGE_RULES } from './badges.ts';
+export {
+  BREW_METHOD_EQUIPMENT_RULES,
+  type BrewMethodEquipmentRuleDef,
+} from './brew-method-rules.ts';
+
+// ── New: pure-value tuples and their derived types ────────────────────────────
+export {
+  BREW_METHOD_VALUES,
+  type BrewMethodValue,
+} from './brew-methods.ts';
+export {
+  DRINK_TYPE_VALUES,
+  type DrinkTypeValue,
+} from './drink-types.ts';
+export {
+  EMOJI_TAG_VALUES,
+  type EmojiTagKey,
+} from './emoji-tags.ts';
+export {
+  VISIBILITY_VALUES,
+  type VisibilityValue,
+} from './visibility.ts';
+export {
+  BADGE_RULE_VALUES,
+  type BadgeRule,
+} from './badges.ts';
+
+// ── New files ─────────────────────────────────────────────────────────────────
+export {
+  EQUIPMENT_TYPE_VALUES,
+  EQUIPMENT_TYPE_LABELS,
+  EQUIPMENT_TYPES,
+  type EquipmentType,
+} from './equipment-types.ts';
+export {
+  ADDITIONAL_PREPARATION_TYPE_VALUES,
+  type AdditionalPreparationCategory,
+} from './additional-preparation-types.ts';
+export {
+  DATE_FORMAT_VALUES,
+  DATE_FORMAT_DISPLAY,
+  TEMPERATURE_UNIT_VALUES,
+  THEME_VALUES,
+  UNIT_SYSTEM_VALUES,
+  type DateFormat,
+  type TemperatureUnit,
+  type Theme,
+  type UnitSystem,
+} from './user-preferences.ts';
+export {
+  COFFEE_VARIETY_CATEGORY_VALUES,
+  type CoffeeVarietyCategory,
+} from './coffee-variety.ts';
+export {
+  EQUIPMENT_DELETE_REQUEST_STATUS_VALUES,
+  type EquipmentDeleteRequestStatus,
+} from './equipment-delete-request.ts';
+```
+
+---
+
+### Step 6 — Derive Zod schemas from constants
+
+**`packages/shared/src/schemas/recipe.ts`** — replace the five inline enum declarations at the top:
 
 ```typescript
 import { z } from 'zod';
 import {
-  BREW_METHOD_VALUES,
-  DRINK_TYPE_VALUES,
-  VISIBILITY_VALUES,
-  EMOJI_TAG_VALUES,
   ADDITIONAL_PREPARATION_TYPE_VALUES,
-} from '../constants/enums.ts';
-
-export const BrewMethodEnum = z.enum(BREW_METHOD_VALUES);
-export const DrinkTypeEnum = z.enum(DRINK_TYPE_VALUES);
-export const VisibilityEnum = z.enum(VISIBILITY_VALUES);
-export const EmojiTagEnum = z.enum(EMOJI_TAG_VALUES);
-export const AdditionalPreparationTypeEnum = z.enum(ADDITIONAL_PREPARATION_TYPE_VALUES);
-```
-
-Do the same for `schemas/equipment.ts`, `schemas/badge.ts`, etc.
-
-### Step 3: Update TypeScript type files
-
-Update `packages/shared/src/types/recipe.ts`:
-
-```typescript
-export type { BrewMethod, DrinkType, Visibility, EmojiTag } from '../constants/enums.ts';
-```
-
-Update `packages/shared/src/types/user.ts`:
-
-```typescript
-export type { Theme, UnitSystem, DateFormat, TemperatureUnit } from '../constants/enums.ts';
-```
-
-### Step 4: Update Drizzle schema
-
-In `packages/db/src/schema.ts`, import values from shared constants:
-
-```typescript
-import {
-  VISIBILITY_VALUES,
   BREW_METHOD_VALUES,
   DRINK_TYPE_VALUES,
-  // ... etc
-} from '@brewform/shared/constants/enums';
+  EMOJI_TAG_VALUES,
+  VISIBILITY_VALUES,
+} from '../constants/index.ts';
 
-export const visibilityEnum = pgEnum('visibility', VISIBILITY_VALUES);
-export const brewMethodEnum = pgEnum('brew_method', BREW_METHOD_VALUES);
-export const drinkTypeEnum = pgEnum('drink_type', DRINK_TYPE_VALUES);
-// ... etc
+const BrewMethodEnum = z.enum(BREW_METHOD_VALUES);
+const DrinkTypeEnum = z.enum(DRINK_TYPE_VALUES);
+const VisibilityEnum = z.enum(VISIBILITY_VALUES);
+const EmojiTagEnum = z.enum(EMOJI_TAG_VALUES);
+const AdditionalPreparationTypeEnum = z.enum(ADDITIONAL_PREPARATION_TYPE_VALUES);
+// ── remainder of the file is unchanged ──────────────────────────────────────
 ```
 
-Note: If Drizzle's `pgEnum` does not accept `readonly` arrays, cast with `[...BREW_METHOD_VALUES]` or use `as const` assertions.
-
-### Step 5: Export from package index
-
-Add to `packages/shared/src/index.ts` or a new `packages/shared/src/constants/index.ts`:
+**`packages/shared/src/schemas/equipment.ts`** — replace the inline `EquipmentTypeEnum`:
 
 ```typescript
-export * from './enums.ts';
+import { z } from 'zod';
+import { EQUIPMENT_TYPE_VALUES } from '../constants/index.ts';
+
+const EquipmentTypeEnum = z.enum(EQUIPMENT_TYPE_VALUES);
+// ── remainder of the file is unchanged ──────────────────────────────────────
 ```
 
-### Step 6: Update imports across codebase
+**`packages/shared/src/schemas/badge.ts`** — replace the inline `BadgeRuleEnum`:
 
-Search for all imports of the old type/schema locations and update to use the new shared constants. Key files:
+```typescript
+import { z } from 'zod';
+import { BADGE_RULE_VALUES } from '../constants/index.ts';
 
-- `apps/api/src/modules/recipe/service.ts` — uses `BrewMethod`, `DrinkType`
-- `apps/api/src/modules/recipe/index.ts` — uses Zod schemas
-- `apps/web/src/**/*.ts(x)` — uses types
-- `packages/shared/src/schemas/*.ts` — uses local enum definitions
+const BadgeRuleEnum = z.enum(BADGE_RULE_VALUES);
+// ── remainder of the file is unchanged ──────────────────────────────────────
+```
 
-### Step 7: Run full verification
+**`packages/shared/src/schemas/user.ts`** — replace all four inline enums and fix the DateFormat default (if Step 1 has not already been applied):
+
+```typescript
+import { z } from 'zod';
+import {
+  DATE_FORMAT_VALUES,
+  TEMPERATURE_UNIT_VALUES,
+  THEME_VALUES,
+  UNIT_SYSTEM_VALUES,
+} from '../constants/index.ts';
+
+export const UserPreferencesSchema = z.object({
+  unitSystem: z.enum(UNIT_SYSTEM_VALUES).default('metric'),
+  temperatureUnit: z.enum(TEMPERATURE_UNIT_VALUES).default('celsius'),
+  theme: z.enum(THEME_VALUES).default('light'),
+  locale: z.string().default('en'),
+  timezone: z.string().default('UTC'),
+  dateFormat: z.enum(DATE_FORMAT_VALUES).default('YYYY_MM_DD'), // fixed from 'YYYY-MM-DD'
+  emailNotifications: z.object({
+    newFollower: z.boolean().default(true),
+    recipeLiked: z.boolean().default(true),
+    recipeCommented: z.boolean().default(true),
+    followedUserPosted: z.boolean().default(true),
+  }).default({
+    newFollower: true,
+    recipeLiked: true,
+    recipeCommented: true,
+    followedUserPosted: true,
+  }),
+});
+
+export const UserProfileUpdateSchema = z.object({
+  displayName: z.string().max(50).optional(),
+  bio: z.string().max(500).optional(),
+  avatarUrl: z.url().optional(),
+});
+```
+
+**`packages/shared/src/schemas/coffee-variety.ts`** — replace the inline `CoffeeVarietyCategoryEnum`:
+
+```typescript
+import { z } from 'zod';
+import { COFFEE_VARIETY_CATEGORY_VALUES } from '../constants/index.ts';
+
+export const CoffeeVarietyCategoryEnum = z.enum(COFFEE_VARIETY_CATEGORY_VALUES);
+// ── remainder of the file is unchanged ──────────────────────────────────────
+```
+
+---
+
+### Step 7 — Derive TypeScript types from constants
+
+Replace inline string-union type definitions with derivations from constants. The strategy is to import the constants type into the types file and create a local alias — this preserves the existing type name so all consumers continue to compile unchanged.
+
+**`packages/shared/src/types/recipe.ts`** — replace the four standalone type definitions at the top:
+
+```typescript
+// REMOVE these four inline definitions:
+// export type Visibility = 'draft' | 'private' | 'unlisted' | 'public';
+// export type BrewMethod = 'espresso_machine' | 'v60' | ...;
+// export type DrinkType = 'espresso' | 'americano' | ...;
+// export type EmojiTag = 'fire' | 'rocket' | ...;
+// export type AdditionalPreparationCategory = 'milk' | 'water' | ...;
+
+// REPLACE WITH (add at the top, after the JSDoc block):
+import type { VisibilityValue } from '../constants/visibility.ts';
+import type { BrewMethodValue } from '../constants/brew-methods.ts';
+import type { DrinkTypeValue } from '../constants/drink-types.ts';
+import type { EmojiTagKey } from '../constants/emoji-tags.ts';
+import type {
+  AdditionalPreparationCategory as _AdditionalPreparationCategory,
+} from '../constants/additional-preparation-types.ts';
+
+/** Visibility state for a recipe. Drafts are only visible to the author. */
+export type Visibility = VisibilityValue;
+
+/** Supported brewing devices and techniques. */
+export type BrewMethod = BrewMethodValue;
+
+/** Final drink served to the consumer (may differ from the brew method). */
+export type DrinkType = DrinkTypeValue;
+
+/** Quick-reaction emoji a user can attach to their own brew. */
+export type EmojiTag = EmojiTagKey;
+
+/** Category of an additional preparation step. */
+export type AdditionalPreparationCategory = _AdditionalPreparationCategory;
+
+// ── remainder of the file (interfaces using these types) is unchanged ────────
+```
+
+**`packages/shared/src/types/user.ts`** — replace the three standalone type definitions:
+
+```typescript
+// REMOVE:
+// export type Theme = 'light' | 'dark' | 'coffee';
+// export type UnitSystem = 'metric' | 'imperial';
+// export type DateFormat = 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY-MM-DD';
+// (temperatureUnit was inline in the interface)
+
+// REPLACE WITH (add after the JSDoc block, before the type declarations):
+import type {
+  DateFormat as _DateFormat,
+  TemperatureUnit as _TemperatureUnit,
+  Theme as _Theme,
+  UnitSystem as _UnitSystem,
+} from '../constants/user-preferences.ts';
+
+/** UI colour theme. */
+export type Theme = _Theme;
+
+/** Measurement system for weight and volume display. */
+export type UnitSystem = _UnitSystem;
+
+/**
+ * Date display format.
+ * Stored value uses underscore separators to match the PostgreSQL enum.
+ * Use DATE_FORMAT_DISPLAY from @brewform/shared/constants for rendering.
+ */
+export type DateFormat = _DateFormat;
+
+/** Temperature unit for display. */
+export type TemperatureUnit = _TemperatureUnit;
+
+// ── Update UserPreferences interface — replace inline temperatureUnit:
+export interface UserPreferences {
+  unitSystem: UnitSystem;
+  temperatureUnit: TemperatureUnit;   // was: 'celsius' | 'fahrenheit' inline
+  theme: Theme;
+  locale: string;
+  timezone: string;
+  dateFormat: DateFormat;
+  emailNotifications: {
+    newFollower: boolean;
+    recipeLiked: boolean;
+    recipeCommented: boolean;
+    followedUserPosted: boolean;
+  };
+}
+// ── remainder of the file is unchanged ──────────────────────────────────────
+```
+
+**`packages/shared/src/types/equipment.ts`** — replace the standalone `EquipmentType` definition:
+
+```typescript
+// REMOVE:
+// export type EquipmentType = 'espresso_machine' | 'grinder' | ...;
+
+// REPLACE WITH:
+import type { EquipmentType as _EquipmentType } from '../constants/equipment-types.ts';
+
+/** Category of brewing equipment. */
+export type EquipmentType = _EquipmentType;
+
+// ── remainder of the file (Equipment, Portafilter, Basket, etc.) is unchanged ─
+```
+
+**`packages/shared/src/types/badge.ts`** — replace the standalone `BadgeRule` definition:
+
+```typescript
+// REMOVE:
+// export type BadgeRule = 'first_brew' | 'decade_brewer' | ...;
+
+// REPLACE WITH:
+import type { BadgeRule as _BadgeRule } from '../constants/badges.ts';
+
+/** Machine-readable badge rule identifier. */
+export type BadgeRule = _BadgeRule;
+
+// ── remainder of the file is unchanged ──────────────────────────────────────
+```
+
+**`packages/shared/src/types/coffee-variety.ts`** — replace the standalone `CoffeeVarietyCategory` definition:
+
+```typescript
+// REMOVE:
+// export type CoffeeVarietyCategory = 'variety' | 'processing' | 'market_name';
+
+// REPLACE WITH:
+import type {
+  CoffeeVarietyCategory as _CoffeeVarietyCategory,
+} from '../constants/coffee-variety.ts';
+
+export type CoffeeVarietyCategory = _CoffeeVarietyCategory;
+
+// ── remainder of the file is unchanged ──────────────────────────────────────
+```
+
+---
+
+### Step 8 — Fix missing exports in `types/index.ts`
+
+The following types are defined in their respective files but were not exported through the barrel. Add them to `packages/shared/src/types/index.ts`:
+
+```typescript
+// UPDATE the user.ts export line (add Theme, DateFormat, TemperatureUnit):
+export type {
+  DateFormat,
+  TemperatureUnit,
+  Theme,
+  UnitSystem,
+  User,
+  UserPreferences,
+  UserProfile,
+} from './user.ts';
+
+// UPDATE the equipment.ts export line (add EquipmentType):
+export type {
+  Basket,
+  Equipment,
+  EquipmentType,   // ← add
+  PaperFilter,
+  Portafilter,
+  PuckScreen,
+  Tamper,
+} from './equipment.ts';
+
+// UPDATE the recipe.ts export line (add AdditionalPreparationCategory):
+export type {
+  AdditionalPreparation,
+  AdditionalPreparationCategory,  // ← add
+  BrewMethod,
+  DrinkType,
+  EmojiTag,
+  Recipe,
+  RecipeCreateInput,
+  RecipeUpdateInput,
+  RecipeVersion,
+  Visibility,
+} from './recipe.ts';
+```
+
+No other lines in `types/index.ts` need to change.
+
+---
+
+### Step 9 — Update Drizzle schema to import from shared constants
+
+In **`packages/db/src/schema.ts`**, add imports from `@brewform/shared/constants` and replace all inline `pgEnum` value arrays with spread calls.
+
+> **Note:** `packages/db` has no dependency on `packages/shared` today. Since this is a Deno workspace, adding `@brewform/shared` as an import is valid — the workspace resolver handles it. No `deno.json` change is needed because workspace members share the same resolution graph.
+
+> **Note on spread:** Drizzle ORM 0.45 `pgEnum` accepts `Readonly<[T, ...T[]]>`. The spread `[...VALUES]` converts to a mutable tuple, which satisfies the constraint in all TypeScript strict-mode configurations without type assertions.
+
+```typescript
+import { relations } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
+import {
+  AnyPgColumn,
+  boolean,
+  check,
+  decimal,
+  foreignKey,
+  index,
+  integer,
+  pgEnum,
+  pgTable,
+  real,
+  text,
+  timestamp,
+  unique,
+  varchar,
+} from 'drizzle-orm/pg-core';
+import {
+  ADDITIONAL_PREPARATION_TYPE_VALUES,
+  BADGE_RULE_VALUES,
+  BREW_METHOD_VALUES,
+  COFFEE_VARIETY_CATEGORY_VALUES,
+  DATE_FORMAT_VALUES,
+  DRINK_TYPE_VALUES,
+  EMOJI_TAG_VALUES,
+  EQUIPMENT_DELETE_REQUEST_STATUS_VALUES,
+  EQUIPMENT_TYPE_VALUES,
+  TEMPERATURE_UNIT_VALUES,
+  THEME_VALUES,
+  UNIT_SYSTEM_VALUES,
+  VISIBILITY_VALUES,
+} from '@brewform/shared/constants';
+
+// ============================================================
+// Enums — values imported from @brewform/shared/constants
+// ============================================================
+
+export const visibilityEnum = pgEnum('visibility', [...VISIBILITY_VALUES]);
+export const brewMethodEnum = pgEnum('brew_method', [...BREW_METHOD_VALUES]);
+export const drinkTypeEnum = pgEnum('drink_type', [...DRINK_TYPE_VALUES]);
+export const equipmentTypeEnum = pgEnum('equipment_type', [...EQUIPMENT_TYPE_VALUES]);
+export const emojiTagEnum = pgEnum('emoji_tag', [...EMOJI_TAG_VALUES]);
+export const badgeRuleEnum = pgEnum('badge_rule', [...BADGE_RULE_VALUES]);
+export const unitSystemEnum = pgEnum('unit_system', [...UNIT_SYSTEM_VALUES]);
+export const temperatureUnitEnum = pgEnum('temperature_unit', [...TEMPERATURE_UNIT_VALUES]);
+export const themeEnum = pgEnum('theme', [...THEME_VALUES]);
+export const dateFormatEnum = pgEnum('date_format', [...DATE_FORMAT_VALUES]);
+export const additionalPreparationTypeEnum = pgEnum(
+  'additional_preparation_type',
+  [...ADDITIONAL_PREPARATION_TYPE_VALUES],
+);
+export const coffeeVarietyCategoryEnum = pgEnum(
+  'coffee_variety_category',
+  [...COFFEE_VARIETY_CATEGORY_VALUES],
+);
+export const equipmentDeleteRequestStatusEnum = pgEnum(
+  'equipment_delete_request_status',
+  [...EQUIPMENT_DELETE_REQUEST_STATUS_VALUES],
+);
+
+// RecipeVisibility alias is unchanged — it derives from the enum object
+export type RecipeVisibility = typeof visibilityEnum.enumValues[number];
+
+// ── All table definitions and relations below this line are unchanged ─────────
+```
+
+---
+
+### Step 10 — Run full verification
 
 ```bash
-make db-generate   # Generate new migration if schema changed
-make db-migrate    # Apply migration
-make check         # Type-check all workspaces
-make lint          # Lint all code
-make test          # Run all tests
+deno task db:generate   # Must produce a NO-OP migration (enum values unchanged)
+deno task db:migrate    # Apply only if a migration was generated
+deno task check         # Zero type errors across all workspaces
+deno task lint          # No new warnings
+deno task test          # All existing tests pass
 ```
+
+**If `db:generate` produces a non-empty migration**, stop and investigate before proceeding. A value change (e.g. any lingering DateFormat slash/dash value in the constants) would cause Drizzle to emit a destructive `ALTER TYPE` migration.
+
+---
 
 ## Testing Strategy
 
-- **Type-check**: `make check` — zero errors.
-- **Lint**: `make lint` — no new warnings.
-- **Unit tests**: `make test` — all existing tests pass.
-- **Enum consistency test**: Add a test that verifies all 3 locations (DB, Zod, TS) have the same values for each enum.
-- **Manual verification**: Create a recipe with each drink type via the API to verify end-to-end.
+**Enum consistency test** — add to `packages/shared/src/constants/enums.test.ts` (new file):
+
+```typescript
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { BREW_METHODS, BREW_METHOD_VALUES } from './brew-methods.ts';
+import { DRINK_TYPES, DRINK_TYPE_VALUES } from './drink-types.ts';
+import { VISIBILITY_STATES, VISIBILITY_VALUES } from './visibility.ts';
+import { EMOJI_TAGS, EMOJI_TAG_VALUES } from './emoji-tags.ts';
+import { BADGE_RULES, BADGE_RULE_VALUES } from './badges.ts';
+
+describe('Enum single-source-of-truth: _VALUES tuples match rich objects', () => {
+  it('BREW_METHOD_VALUES matches BREW_METHODS', () => {
+    expect([...BREW_METHOD_VALUES].sort())
+      .toEqual(BREW_METHODS.map((m) => m.value).sort());
+  });
+
+  it('DRINK_TYPE_VALUES matches DRINK_TYPES', () => {
+    expect([...DRINK_TYPE_VALUES].sort())
+      .toEqual(DRINK_TYPES.map((d) => d.value).sort());
+  });
+
+  it('VISIBILITY_VALUES matches VISIBILITY_STATES', () => {
+    expect([...VISIBILITY_VALUES].sort())
+      .toEqual(VISIBILITY_STATES.map((s) => s.value).sort());
+  });
+
+  it('EMOJI_TAG_VALUES matches EMOJI_TAGS keys', () => {
+    expect([...EMOJI_TAG_VALUES].sort())
+      .toEqual(EMOJI_TAGS.map((t) => t.key).sort());
+  });
+
+  it('BADGE_RULE_VALUES matches BADGE_RULES rules', () => {
+    expect([...BADGE_RULE_VALUES].sort())
+      .toEqual(BADGE_RULES.map((b) => b.rule).sort());
+  });
+});
+```
+
+**Other verification:**
+- `make check` / `deno task check` — zero errors
+- `make lint` / `deno task lint` — no new warnings
+- `deno task test` — all existing tests pass
+- Manual: update a user's date format preference via the API and verify the round-trip succeeds with `'DD_MM_YYYY'`
+
+---
 
 ## Risk Assessment
 
-- **Medium risk**: This changes import paths across many files. Incorrect imports will cause compile errors (caught by `make check`).
-- **Migration risk**: If the Drizzle `pgEnum` values change order, Drizzle may generate a migration that drops and recreates the enum. Verify `make db-generate` produces a no-op migration.
-- **Rollback**: Revert the commit and restore original files.
-- **Verification**: `make check` + `make test` + `make db-generate` (should be no-op).
+| Risk | Severity | Mitigation |
+|------|----------|-----------|
+| DateFormat data migration | **High if feature was live** | Run audit query before deploying Step 1; write migration if rows found |
+| `db:generate` produces non-empty migration | Medium | Verify no-op before committing; investigate immediately if not |
+| Import path changes break compilation | Low | `deno task check` catches all errors before merge |
+| Dependency direction change (`db` → `shared`) | Low | This direction is architecturally correct; shared has no dependency on db |
+| Aliased re-exports confuse IDE tooling | Low | Most language servers resolve through aliases correctly |
+
+---
+
+## Summary of All Changes vs. Previous Plan Version
+
+| Item | Previous plan | This plan (corrected) |
+|------|--------------|----------------------|
+| Drift found | DateFormat | DateFormat ✅ (confirmed as only active drift) |
+| D06 DrinkType note | Listed as unresolved | Removed — already fixed in main branch |
+| `AdditionalPreparationType` naming | Used `AdditionalPreparationType` | Corrected to `AdditionalPreparationCategory` (existing TS convention) |
+| `BadgeRule` naming | Used `BadgeRuleValue` | Corrected to `BadgeRule` (existing TS type name) |
+| `EmojiTag` key field | Referenced as `value` | Corrected to `key` (actual field name in EMOJI_TAGS) |
+| `EQUIPMENT_TYPES` / `EQUIPMENT_TYPE_LABELS` migration | Not mentioned | Moved from `brew-method-rules.ts` → new `equipment-types.ts` |
+| `brew-method-rules.ts` imports | Not mentioned | Updated to import from `constants/` not `types/` |
+| Missing `types/index.ts` exports | Only `EquipmentType`, `TemperatureUnit` | All five: `EquipmentType`, `Theme`, `DateFormat`, `AdditionalPreparationCategory`, `TemperatureUnit` |
+| Missing `constants/index.ts` type exports | Not addressed | `BrewMethodValue`, `DrinkTypeValue`, `EmojiTagKey`, `VisibilityValue` now exported |
+| `UserPreferencesSchema` default | `'YYYY_MM_DD'` | ✅ Same — confirmed correct |
+| `RecipeVisibility` alias in schema.ts | Not mentioned | Preserved explicitly — it derives from Drizzle enum object, not from constants |
+| Step to verify `db:generate` is a no-op | Listed only in verification | Elevated to a hard stop — investigate immediately if non-empty |


### PR DESCRIPTION
# D07: Enum Single Source of Truth — Refactor + DateFormat Bug Fix

## Summary

This PR fixes a **production bug** (the `date_format` enum drift) and **eliminates a class of future bugs** by establishing a single source of truth for all 13 enum values used across the database, Zod validators, and TypeScript types. Adding or removing an enum value now requires editing exactly one file. The change is also **fully backwards-compatible** for every existing import path — `db:generate` produces a no-op migration.

### Production Bug Fixed

The `date_format` column enum and the Zod/TypeScript representations were out of sync:

| Layer | Values accepted | DB-storable? |
|-------|----------------|--------------|
| DB (`pgEnum` in `schema.ts`) | `'DD_MM_YYYY'`, `'MM_DD_YYYY'`, `'YYYY_MM_DD'` | ✅ |
| Zod (`UserPreferencesSchema`) | `'DD/MM/YYYY'`, `'MM/DD/YYYY'`, `'YYYY-MM-DD'` | ❌ (rejected at INSERT) |
| TypeScript (`DateFormat` type) | same as Zod | ❌ |

Any user who saved the date format preference would have hit a PostgreSQL error at write time. This PR unifies all three layers on the underscore-separated values (`DD_MM_YYYY`, `MM_DD_YYYY`, `YYYY_MM_DD`) and introduces a `DATE_FORMAT_DISPLAY` helper that maps the stored value to the human-readable pattern (`DD/MM/YYYY` etc.) for UI rendering.

> **Note:** All other 12 enums in the codebase are already in sync. Only `date_format` had active drift; the `drink_type` drift referenced in the original D06 issue is already resolved in `main`.

---

## What This PR Changes

### 1. Bug fix — `DateFormat` (the only active drift)

- **`packages/shared/src/schemas/user.ts`** — `UserPreferencesSchema.dateFormat` now uses `'DD_MM_YYYY' | 'MM_DD_YYYY' | 'YYYY_MM_DD'` (default: `'YYYY_MM_DD'`).
- **`packages/shared/src/types/user.ts`** — `DateFormat` type aligned to the same values; `UserPreferences.temperatureUnit` is now a named `TemperatureUnit` type instead of an inline string union.
- **`apps/web/src/pages/settings/SettingsPage.tsx`** — `<option value="…">` strings updated to the underscore values (the visible text remains `DD/MM/YYYY` etc.).
- **`packages/shared/src/schemas/user.test.ts`** — default-value assertion updated to `'YYYY_MM_DD'`.

### 2. New constants — `packages/shared/src/constants/`

Five new files, all with JSDoc:

| File | Purpose |
|------|---------|
| `equipment-types.ts` | Promoted from `brew-method-rules.ts`. Owns `EQUIPMENT_TYPE_VALUES`, `EQUIPMENT_TYPE_LABELS`, `EQUIPMENT_TYPES`, and the `EquipmentType` type. |
| `additional-preparation-types.ts` | `ADDITIONAL_PREPARATION_TYPE_VALUES` and the `AdditionalPreparationCategory` type. |
| `user-preferences.ts` | All four user-preference enums (`UnitSystem`, `TemperatureUnit`, `Theme`, `DateFormat`) plus `DATE_FORMAT_DISPLAY`. |
| `coffee-variety.ts` | `COFFEE_VARIETY_CATEGORY_VALUES` and the `CoffeeVarietyCategory` type. |
| `equipment-delete-request.ts` | `EQUIPMENT_DELETE_REQUEST_STATUS_VALUES` and its type. |

### 3. New tuples — appended to existing rich-object files

A `_VALUES` tuple was added to each of the five existing rich-object files. The tuple is derived from the rich objects via `.map()`, so it can never drift:

| File | New export |
|------|-----------|
| `visibility.ts` | `VISIBILITY_VALUES` (from `value`) |
| `brew-methods.ts` | `BREW_METHOD_VALUES` (from `value`) |
| `drink-types.ts` | `DRINK_TYPE_VALUES` (from `value`) |
| `emoji-tags.ts` | `EMOJI_TAG_VALUES` (from `key`) |
| `badges.ts` | `BadgeRule` type + `BADGE_RULE_VALUES` (from `rule`) |

### 4. Barrel updates

- **`packages/shared/src/constants/index.ts`** — re-exports every new value tuple, every new rich object, and the `CANONICAL_UNITS` / `UNIT_CONVERSIONS` exports. The TypeScript types are intentionally **not** re-exported from this barrel (see *Design Decisions* below).
- **`packages/shared/src/types/index.ts`** — adds the previously-missing re-exports: `DateFormat`, `TemperatureUnit`, `Theme`, `UnitSystem`, `EquipmentType`, `AdditionalPreparationCategory`.

### 5. Consumer rewires (derive from constants)

- **Zod schemas** (`recipe.ts`, `equipment.ts`, `badge.ts`, `coffee-variety.ts`, `user.ts`) — every `z.enum([…])` now reads from the corresponding `_VALUES` tuple. Schema names (`BrewMethodEnum`, `EquipmentTypeEnum`, etc.) are preserved.
- **TypeScript types** (`recipe.ts`, `user.ts`, `equipment.ts`, `badge.ts`, `coffee-variety.ts`) — every enum union (`BrewMethod`, `Visibility`, `EquipmentType`, `BadgeRule`, `CoffeeVarietyCategory`, `AdditionalPreparationCategory`, `DateFormat`, `Theme`, `UnitSystem`, `TemperatureUnit`) is now an alias of the corresponding constant's type via a local `import { … as _… }`. Public type names are preserved; no consumer needs to change.
- **Drizzle schema** (`packages/db/src/schema.ts`) — every `pgEnum()` call now uses the spread form `[…VISIBILITY_VALUES]`, etc. The `RecipeVisibility` type alias is preserved and still derives from the Drizzle enum object (it does not need to be migrated).

### 6. Test coverage

- **New file: `packages/shared/src/constants/enums.test.ts`** — runtime guards for the single-source-of-truth contract:
  - Each `_VALUES` tuple exactly matches the rich-object set (sorted equality).
  - Every standalone `*_VALUES` covers its corresponding TypeScript type.
  - `EQUIPMENT_TYPE_LABELS` covers every `EquipmentType`.
  - `DATE_FORMAT_VALUES` use underscores only (no `/` characters).
  - `DATE_FORMAT_DISPLAY` covers every `DATE_FORMAT_VALUES` entry.
  - All user-preference value sets are present and correct.
- **Updated `packages/shared/src/constants/brew-method-rules.test.ts`** — imports `EQUIPMENT_TYPES` / `EQUIPMENT_TYPE_LABELS` from the new `equipment-types.ts` location (the source of the data moved during the refactor).
- **Updated `packages/shared/src/schemas/user.test.ts`** — the default-`dateFormat` assertion now matches the corrected enum.

---

## File-level Change Summary

```
 apps/web/src/pages/settings/SettingsPage.tsx       |   6 +-   (DateFormat UI fix)
 packages/db/src/schema.ts                          | 160 +--   (Drizzle derives from constants)
 packages/shared/src/constants/                      |          (single source of truth)
   ├── badges.ts                                    |  18 +    (BadgeRule type + _VALUES)
   ├── brew-method-rules.ts                         |  53 +-   (no longer owns equipment types)
   ├── brew-method-rules.test.ts                    |   7 +-   (imports updated)
   ├── brew-methods.ts                              |  13 +    (BREW_METHOD_VALUES)
   ├── drink-types.ts                               |  13 +    (DRINK_TYPE_VALUES)
   ├── emoji-tags.ts                                |   9 +    (EMOJI_TAG_VALUES)
   ├── index.ts                                     |  45 +-   (barrel updated)
   ├── visibility.ts                                |  13 +    (VISIBILITY_VALUES)
   ├── additional-preparation-types.ts              | new      (new file)
   ├── coffee-variety.ts                            | new      (new file)
   ├── equipment-delete-request.ts                  | new      (new file)
   ├── equipment-types.ts                           | new      (new file)
   ├── enums.test.ts                                | new      (new test file)
   └── user-preferences.ts                          | new      (new file)
 packages/shared/src/schemas/                        |          (Zod derives from constants)
   ├── badge.ts                                     |  14 +-
   ├── coffee-variety.ts                            |   3 +-
   ├── equipment.ts                                 |  21 +-
   ├── recipe.ts                                    |  48 +-
   ├── user.ts                                      |  14 +-
   └── user.test.ts                                 |   2 +-   (DateFormat default updated)
 packages/shared/src/types/                          |          (TS unions derive from constants)
   ├── badge.ts                                     |  16 +-
   ├── coffee-variety.ts                            |  11 +-
   ├── equipment.ts                                 |  23 +-
   ├── index.ts                                     |  12 +-   (barrel updated)
   ├── recipe.ts                                    |  46 +-
   └── user.ts                                      |  28 +-
 plans/D07-enum-single-source.md                    | 887 +++   (the source plan)
```

23 files modified, 6 new files. 1033 insertions, 429 deletions.

---

## How to Add or Remove an Enum Value (After This PR)

For example, to add a new `cold_brew_tower` equipment type:

1. Open `packages/shared/src/constants/equipment-types.ts`.
2. Add `'cold_brew_tower'` to `EQUIPMENT_TYPE_VALUES`.
3. Add a label to `EQUIPMENT_TYPE_LABELS`.

That's it. The Drizzle `pgEnum`, the Zod `EquipmentTypeEnum`, and the TypeScript `EquipmentType` union all pick up the new value automatically. The consistency test in `enums.test.ts` will catch any future regression where the tuple is forgotten.

---

## Design Decisions

### Why types are not re-exported from `constants/index.ts`

The plan originally called for `BrewMethodValue`, `DrinkTypeValue`, `VisibilityValue`, `EmojiTagKey`, and `BadgeRule` to be re-exported from both `constants/index.ts` and `types/index.ts`. This caused a `TS2308` collision at the root `packages/shared/src/index.ts`, which uses `export *` from both sub-barrels. To avoid breaking the wildcard re-export pattern, the public type surface lives in `types/index.ts` only. The `types/*.ts` files still `import` the canonical definition from `constants/`, so the single-source-of-truth invariant is preserved — the type is defined exactly once in the codebase, just behind a public alias.

Net effect: the user-facing import paths are unchanged. `import type { BrewMethod } from '@brewform/shared/types'` and `import type { BrewMethod } from '@brewform/shared'` both still work.

### Why a `DATE_FORMAT_DISPLAY` map (and not the other way around)

The PostgreSQL `date_format` enum is the source of truth and uses underscores (`DD_MM_YYYY`). The display strings (`DD/MM/YYYY`) are a UI concern. Storing the underscored form is the only way to make the enum round-trip work; producing the display form via a `Record<DateFormat, string>` map is the simplest rendering helper. This keeps the database representation decoupled from the user-facing representation.

### Why spread `[...VALUES]` for `pgEnum()`

Drizzle 0.45's `pgEnum()` accepts `Readonly<[T, ...T[]]>`. The constant tuples are `as const` (so `readonly`). Spreading them creates a mutable tuple that satisfies the type constraint in all TypeScript strict-mode configurations without explicit type assertions.

---

## Verification

| Step | Command | Result |
|------|---------|--------|
| Type check (all 4 packages) | `make check` | ✅ pass |
| Lint | `make lint` | ✅ 0 errors, 788 files checked |
| Format | `make fmt-check` | ✅ 0 issues, 413 files checked |
| Tests (all 4 packages) | `make test` | ✅ **731 tests pass**, 0 failed |
| Migration check | `make db-generate` | ✅ **No schema changes, nothing to migrate** |

Test breakdown:
- `packages/shared` — 57 tests, 380 steps
- `apps/api` — 63 tests, 580 steps
- `packages/db` — seed and constraint tests
- `apps/web` — 49 test files, 731 tests, 8.57s

The new `enums.test.ts` contributes 18 test cases covering the single-source-of-truth contract.

---

## Pre-Deployment Checklist (DateFormat migration)

The DateFormat bug fix changes the values accepted by `PATCH /api/v1/preferences/`. The pre-fix schema accepted `'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY-MM-DD'`, which PostgreSQL would have rejected at write time. **This means it is highly unlikely any production rows exist with the old values**, but please verify with the following audit query before deploying:

```sql
SELECT id, date_format
FROM   user_preferences
WHERE  date_format NOT IN ('DD_MM_YYYY', 'MM_DD_YYYY', 'YYYY_MM_DD');
```

If any rows are returned, write a one-off data migration:

```sql
UPDATE user_preferences SET date_format = 'DD_MM_YYYY' WHERE date_format = 'DD/MM/YYYY';
UPDATE user_preferences SET date_format = 'MM_DD_YYYY' WHERE date_format = 'MM/DD/YYYY';
UPDATE user_preferences SET date_format = 'YYYY_MM_DD' WHERE date_format = 'YYYY-MM-DD';
```

This data migration can be run in the same release as the application deploy — there is no destructive `ALTER TYPE` because the column type was already `date_format` enum with underscore values.

---

## Out of Scope / Follow-up Opportunities

These were noticed during the refactor but deliberately **not** fixed in this PR to keep scope tight. Each is a candidate for a separate, small follow-up PR:

1. **Local `EQUIPMENT_TYPE_LABELS` in web pages.** `apps/web/src/pages/recipes/RecipeListPage.tsx` and `apps/web/src/pages/recipes/StarredRecipesPage.tsx` each define a local `EQUIPMENT_TYPE_LABELS` map typed as `Record<string, string>`. These should import from `@brewform/shared/constants` instead. StarredRecipesPage in particular has labels for `gooseneck_kettle` and `scale` that don't exist in the database enum — these filters will always return 0 results from the API.
2. **Pre-existing `user.test.ts` test for `'YYYY-MM-DD'`.** Fixed in this PR. No other places use the old date format literals in `apps/`.
3. **ESLint enforcement.** Consider adding a custom rule (or a `deno lint` plugin) to forbid inline `z.enum([...])` definitions outside of the constants layer. The `enums.test.ts` consistency check guards the value side; an ESLint rule would guard the syntax side.

---

## Risk Assessment

| Risk | Severity | Mitigation |
|------|----------|-----------|
| Existing rows with old `DD/MM/YYYY` format | Low (likely zero — DB always rejected them) | Run audit query before deploy; one-off SQL migration if needed |
| `db:generate` produces a non-empty migration | Mitigated — confirmed no-op on the current schema | Re-run after merge to `main`; investigate immediately if non-empty |
| Import path changes break a downstream consumer | Low — every public type name is preserved | `deno task check` catches all errors before merge |
| `db` → `shared` dependency direction reversal | Low — architecturally correct; `shared` has no dependency on `db` | No `deno.json` change needed; workspace resolver handles it |
| Aliased re-exports (`Theme as _Theme`) confuse IDE tooling | Low — most language servers resolve through aliases correctly | If observed, swap to non-aliased imports |
| `EquipmentType` re-export collision at the root barrel | Mitigated — types live in `types/index.ts` only | Confirmed by `make check` passing on all 4 packages |

---

## Related Work

- **Plan document:** `plans/D07-enum-single-source.md` — the full design rationale, including the pre-plan audit of all 13 enums.
- **DrinkType drift** (D06, separate concern) — already resolved in `main` as of commit `4bcfe93` (`Fix: Sync DrinkType TypeScript Union with Database Enum (#63)`).

---

## Reviewer Notes

- **Read order:** `plans/D07-enum-single-source.md` → `constants/enums.test.ts` → any one of the new constants files → the corresponding Zod/TypeScript rewires.
- **Quick smoke test:** after checking out, run `make dev`, then in another shell:
  ```bash
  curl -X PATCH http://localhost:8000/api/v1/preferences/ \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer <jwt>" \
    -d '{"dateFormat": "DD_MM_YYYY"}'
  ```
  Should succeed (previously returned 500 from PG enum violation).
- **Schema change?** No. `db:generate` confirms a no-op migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized all enum definitions across the database, validation, and type systems to establish a single source of truth, improving consistency and maintainability.
  * Updated date format value handling with display mapping to ensure user-friendly formatting while standardizing internal storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->