### PR TITLE
Feat/d13

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,8 +5,11 @@ import { ThemeProvider } from './contexts/ThemeContext.tsx';
 import { I18nProvider } from './contexts/I18nContext.tsx';
 import { router } from './router.tsx';
 import { PageSkeleton } from './components/ui/Skeleton.tsx';
+import { useStaticCacheSync } from './hooks/useStaticCacheSync.ts';
 
 export default function App() {
+  useStaticCacheSync();
+
   return (
     <ThemeProvider>
       <I18nProvider>

--- a/apps/web/src/api/static-cache.test.ts
+++ b/apps/web/src/api/static-cache.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { equipmentApi, tasteApi } from './index.ts';
+import { getEquipmentCached, getTasteNotesCached, invalidateStaticCache } from './static-cache.ts';
+
+beforeEach(() => {
+  invalidateStaticCache();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('static-cache', () => {
+  it('getEquipmentCached fetches once and memoises', async () => {
+    const spy = vi.spyOn(equipmentApi, 'list').mockResolvedValue([
+      { id: '1', name: 'Scale', type: 'scale_accessory', brand: null },
+    ]);
+
+    const first = await getEquipmentCached();
+    const second = await getEquipmentCached();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+  });
+
+  it('getTasteNotesCached fetches once and memoises', async () => {
+    const spy = vi.spyOn(tasteApi, 'flat').mockResolvedValue([
+      { id: '1', name: 'Fruity', parentId: null, category: 'taste' },
+    ]);
+
+    const first = await getTasteNotesCached();
+    const second = await getTasteNotesCached();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+  });
+
+  it('invalidateStaticCache re-arms the equipment fetch', async () => {
+    const spy = vi.spyOn(equipmentApi, 'list')
+      .mockResolvedValueOnce([
+        { id: '1', name: 'Scale', type: 'scale_accessory', brand: null },
+      ])
+      .mockResolvedValueOnce([
+        { id: '2', name: 'Kettle', type: 'kettle', brand: null },
+      ]);
+
+    await getEquipmentCached();
+    invalidateStaticCache();
+    const after = await getEquipmentCached();
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(after).toEqual([{ id: '2', name: 'Kettle', type: 'kettle', brand: null }]);
+  });
+
+  it('invalidateStaticCache re-arms the taste-notes fetch', async () => {
+    const spy = vi.spyOn(tasteApi, 'flat')
+      .mockResolvedValueOnce([
+        { id: '1', name: 'Fruity', parentId: null, category: 'taste' },
+      ])
+      .mockResolvedValueOnce([
+        { id: '2', name: 'Floral', parentId: null, category: 'taste' },
+      ]);
+
+    await getTasteNotesCached();
+    invalidateStaticCache();
+    const after = await getTasteNotesCached();
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(after).toEqual([{ id: '2', name: 'Floral', parentId: null, category: 'taste' }]);
+  });
+
+  it('invalidateStaticCache writes the bust key', () => {
+    invalidateStaticCache();
+    const value = globalThis.localStorage.getItem('brewform-static-cache-bust');
+    expect(value).not.toBeNull();
+    expect(typeof value).toBe('string');
+  });
+
+  it('invalidateStaticCache swallows setItem errors', () => {
+    const originalSetItem = globalThis.localStorage.setItem.bind(globalThis.localStorage);
+    globalThis.localStorage.setItem = () => {
+      throw new Error('Storage quota exceeded');
+    };
+
+    expect(() => invalidateStaticCache()).not.toThrow();
+
+    globalThis.localStorage.setItem = originalSetItem;
+  });
+});

--- a/apps/web/src/api/static-cache.ts
+++ b/apps/web/src/api/static-cache.ts
@@ -1,20 +1,47 @@
 import { equipmentApi, tasteApi } from './index.ts';
 import type { EquipmentListItem, TasteNoteFlatItem } from './types.ts';
 
+const CACHE_BUST_KEY = 'brewform-static-cache-bust';
+
+/** Module-level cache slot for the authenticated user's equipment list. Nulled by {@link invalidateStaticCache}. */
 let _equipment: EquipmentListItem[] | null = null;
+
+/** Module-level cache slot for the flat taste-note tree. Nulled by {@link invalidateStaticCache}. */
 let _tasteNotes: TasteNoteFlatItem[] | null = null;
 
+/**
+ * Lazy-fetches the equipment list via `equipmentApi.list()` on first call
+ * and returns the same memoised array on every subsequent call until
+ * `invalidateStaticCache()` is invoked.
+ */
 export async function getEquipmentCached(): Promise<EquipmentListItem[]> {
   if (!_equipment) _equipment = await equipmentApi.list();
   return _equipment;
 }
 
+/**
+ * Lazy-fetches the flat taste-note tree via `tasteApi.flat()` on first call
+ * and returns the same memoised array on every subsequent call until
+ * `invalidateStaticCache()` is invoked.
+ */
 export async function getTasteNotesCached(): Promise<TasteNoteFlatItem[]> {
   if (!_tasteNotes) _tasteNotes = await tasteApi.flat();
   return _tasteNotes;
 }
 
+/**
+ * Null both cache slots so the next get*Cached() call re-fetches,
+ * and broadcast a cache-bust marker to other browser tabs via
+ * localStorage. Same-tab consumers are unaffected by the
+ * `storage` event (it fires only in other tabs). The setItem is
+ * wrapped in try/catch to tolerate private-mode browsers.
+ */
 export function invalidateStaticCache(): void {
   _equipment = null;
   _tasteNotes = null;
+  try {
+    localStorage.setItem(CACHE_BUST_KEY, String(Date.now()));
+  } catch {
+    // Private mode or storage quota — cross-tab broadcast is best-effort.
+  }
 }

--- a/apps/web/src/api/static-cache.ts
+++ b/apps/web/src/api/static-cache.ts
@@ -1,7 +1,7 @@
 import { equipmentApi, tasteApi } from './index.ts';
 import type { EquipmentListItem, TasteNoteFlatItem } from './types.ts';
 
-const CACHE_BUST_KEY = 'brewform-static-cache-bust';
+export const CACHE_BUST_KEY = 'brewform-static-cache-bust';
 
 /** Module-level cache slot for the authenticated user's equipment list. Nulled by {@link invalidateStaticCache}. */
 let _equipment: EquipmentListItem[] | null = null;

--- a/apps/web/src/hooks/useStaticCacheSync.test.ts
+++ b/apps/web/src/hooks/useStaticCacheSync.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useStaticCacheSync } from './useStaticCacheSync.ts';
+
+vi.mock('../api/static-cache.ts', () => ({
+  invalidateStaticCache: vi.fn(),
+}));
+
+// Re-import the mocked function so we can assert on it after the mock.
+import { invalidateStaticCache } from '../api/static-cache.ts';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useStaticCacheSync', () => {
+  it('registers a storage listener on mount', () => {
+    const addSpy = vi.spyOn(globalThis, 'addEventListener');
+    renderHook(() => useStaticCacheSync());
+
+    const calls = addSpy.mock.calls.filter((call) => call[0] === 'storage');
+    expect(calls.length).toBe(1);
+    expect(typeof calls[0][1]).toBe('function');
+
+    addSpy.mockRestore();
+  });
+
+  it('removes the storage listener on unmount', () => {
+    const addSpy = vi.spyOn(globalThis, 'addEventListener');
+    const removeSpy = vi.spyOn(globalThis, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useStaticCacheSync());
+
+    const addCalls = addSpy.mock.calls.filter((call) => call[0] === 'storage');
+    const addedHandler = addCalls[0][1] as EventListener;
+
+    unmount();
+
+    const removeCalls = removeSpy.mock.calls.filter((call) => call[0] === 'storage');
+    expect(removeCalls.length).toBe(1);
+    expect(removeCalls[0][1]).toBe(addedHandler);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  it('calls invalidateStaticCache when a matching storage event fires', () => {
+    renderHook(() => useStaticCacheSync());
+
+    const event = new StorageEvent('storage', {
+      key: 'brewform-static-cache-bust',
+      newValue: '123',
+    });
+    globalThis.dispatchEvent(event);
+
+    expect(invalidateStaticCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores storage events with a different key', () => {
+    renderHook(() => useStaticCacheSync());
+
+    const event = new StorageEvent('storage', {
+      key: 'brewform-preferences',
+      newValue: 'dark',
+    });
+    globalThis.dispatchEvent(event);
+
+    expect(invalidateStaticCache).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useStaticCacheSync.test.ts
+++ b/apps/web/src/hooks/useStaticCacheSync.test.ts
@@ -3,6 +3,7 @@ import { renderHook } from '@testing-library/react';
 import { useStaticCacheSync } from './useStaticCacheSync.ts';
 
 vi.mock('../api/static-cache.ts', () => ({
+  CACHE_BUST_KEY: 'brewform-static-cache-bust',
   invalidateStaticCache: vi.fn(),
 }));
 

--- a/apps/web/src/hooks/useStaticCacheSync.ts
+++ b/apps/web/src/hooks/useStaticCacheSync.ts
@@ -1,8 +1,5 @@
-// deno-lint-ignore-file require-await
 import { useEffect } from 'react';
-import { invalidateStaticCache } from '../api/static-cache.ts';
-
-const CACHE_BUST_KEY = 'brewform-static-cache-bust';
+import { CACHE_BUST_KEY, invalidateStaticCache } from '../api/static-cache.ts';
 
 /**
  * Subscribes to the browser `storage` event and calls

--- a/apps/web/src/hooks/useStaticCacheSync.ts
+++ b/apps/web/src/hooks/useStaticCacheSync.ts
@@ -1,0 +1,25 @@
+// deno-lint-ignore-file require-await
+import { useEffect } from 'react';
+import { invalidateStaticCache } from '../api/static-cache.ts';
+
+const CACHE_BUST_KEY = 'brewform-static-cache-bust';
+
+/**
+ * Subscribes to the browser `storage` event and calls
+ * `invalidateStaticCache()` when another tab writes the
+ * `brewform-static-cache-bust` marker. The `storage` event does
+ * not fire in the tab that wrote the key, so the same-tab flow
+ * (mutation page calls `invalidateStaticCache()` directly) is
+ * unaffected.
+ *
+ * Mount exactly once at the app root (see `App.tsx`).
+ */
+export function useStaticCacheSync(): void {
+  useEffect(() => {
+    function onStorage(e: StorageEvent) {
+      if (e.key === CACHE_BUST_KEY) invalidateStaticCache();
+    }
+    globalThis.addEventListener('storage', onStorage);
+    return () => globalThis.removeEventListener('storage', onStorage);
+  }, []);
+}

--- a/apps/web/src/pages/admin/AdminEquipmentPage.test.tsx
+++ b/apps/web/src/pages/admin/AdminEquipmentPage.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AdminEquipmentPage } from './AdminEquipmentPage.tsx';
@@ -36,6 +36,10 @@ const mockInvalidateStaticCache = vi.mocked(invalidateStaticCache);
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -133,7 +137,6 @@ describe('AdminEquipmentPage', () => {
     });
 
     expect(mockInvalidateStaticCache).toHaveBeenCalledTimes(1);
-    vi.unstubAllGlobals();
   });
 
   it('failed create does NOT call invalidateStaticCache', async () => {
@@ -200,6 +203,5 @@ describe('AdminEquipmentPage', () => {
     });
 
     expect(mockInvalidateStaticCache).not.toHaveBeenCalled();
-    vi.unstubAllGlobals();
   });
 });

--- a/apps/web/src/pages/admin/AdminEquipmentPage.test.tsx
+++ b/apps/web/src/pages/admin/AdminEquipmentPage.test.tsx
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AdminEquipmentPage } from './AdminEquipmentPage.tsx';
+
+// ── Module mocks (hoisted) ─────────────────────────────────────────────────
+
+vi.mock('../../api/static-cache.ts', () => ({
+  getEquipmentCached: vi.fn(),
+  getTasteNotesCached: vi.fn(),
+  invalidateStaticCache: vi.fn(),
+}));
+
+vi.mock('../../api/client.ts', () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('../../utils/logger.ts', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// ── Imports after mocks ────────────────────────────────────────────────────
+
+import { api } from '../../api/index.ts';
+import { invalidateStaticCache } from '../../api/static-cache.ts';
+
+const mockApi = vi.mocked(api);
+const mockInvalidateStaticCache = vi.mocked(invalidateStaticCache);
+
+// ── Setup ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('AdminEquipmentPage', () => {
+  it('renders the equipment table after initial fetch', async () => {
+    mockApi.get.mockResolvedValue([
+      { id: 'eq-1', name: 'Acaia Lunar', type: 'scale_accessory', brand: 'Acaia', model: null },
+    ]);
+
+    render(<AdminEquipmentPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Acaia Lunar')).toBeInTheDocument();
+    });
+  });
+
+  it('create flow: post + invalidateStaticCache called once', async () => {
+    mockApi.get.mockResolvedValue([]);
+    const created = {
+      id: 'eq-2',
+      name: 'Fellow Stagg',
+      type: 'kettle',
+      brand: 'Fellow',
+      model: null,
+    };
+    mockApi.post.mockResolvedValue(created);
+
+    render(<AdminEquipmentPage />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Add Equipment/i }));
+
+    const nameInput = screen.getByLabelText(/Name \*/i);
+    const typeInput = screen.getByLabelText(/Type \*/i);
+    await userEvent.type(nameInput, 'Fellow Stagg');
+    await userEvent.type(typeInput, 'kettle');
+
+    await userEvent.click(screen.getByRole('button', { name: /Save/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Fellow Stagg')).toBeInTheDocument();
+    });
+
+    expect(mockApi.post).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateStaticCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('edit flow: click Edit, modify form, submit, patch + invalidateStaticCache called once', async () => {
+    mockApi.get.mockResolvedValue([
+      { id: 'eq-1', name: 'Acaia Lunar', type: 'scale_accessory', brand: 'Acaia', model: null },
+    ]);
+    const updated = {
+      id: 'eq-1',
+      name: 'Acaia Lunar Pro',
+      type: 'scale_accessory',
+      brand: 'Acaia',
+      model: null,
+    };
+    mockApi.patch.mockResolvedValue(updated);
+
+    render(<AdminEquipmentPage />);
+    await waitFor(() => expect(screen.getByText('Acaia Lunar')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Edit/i }));
+
+    const nameInput = screen.getByLabelText(/Name \*/i);
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Acaia Lunar Pro');
+
+    await userEvent.click(screen.getByRole('button', { name: /Save/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Acaia Lunar Pro')).toBeInTheDocument();
+    });
+
+    expect(mockApi.patch).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateStaticCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('delete flow: confirm, api.delete + invalidateStaticCache called once', async () => {
+    mockApi.get.mockResolvedValue([
+      { id: 'eq-1', name: 'Acaia Lunar', type: 'scale_accessory', brand: 'Acaia', model: null },
+    ]);
+    mockApi.delete.mockResolvedValue({});
+    vi.stubGlobal('confirm', () => true);
+
+    render(<AdminEquipmentPage />);
+    await waitFor(() => expect(screen.getByText('Acaia Lunar')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Delete/i }));
+
+    await waitFor(() => {
+      expect(mockApi.delete).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateStaticCache).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
+  it('failed create does NOT call invalidateStaticCache', async () => {
+    mockApi.get.mockResolvedValue([]);
+    mockApi.post.mockRejectedValue(new Error('Network error'));
+
+    render(<AdminEquipmentPage />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Add Equipment/i }));
+
+    const nameInput = screen.getByLabelText(/Name \*/i);
+    const typeInput = screen.getByLabelText(/Type \*/i);
+    await userEvent.type(nameInput, 'Fellow Stagg');
+    await userEvent.type(typeInput, 'kettle');
+
+    await userEvent.click(screen.getByRole('button', { name: /Save/i }));
+
+    await waitFor(() => {
+      expect(mockApi.post).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateStaticCache).not.toHaveBeenCalled();
+  });
+
+  it('failed edit does NOT call invalidateStaticCache', async () => {
+    mockApi.get.mockResolvedValue([
+      { id: 'eq-1', name: 'Acaia Lunar', type: 'scale_accessory', brand: 'Acaia', model: null },
+    ]);
+    mockApi.patch.mockRejectedValue(new Error('Network error'));
+
+    render(<AdminEquipmentPage />);
+    await waitFor(() => expect(screen.getByText('Acaia Lunar')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Edit/i }));
+
+    const nameInput = screen.getByLabelText(/Name \*/i);
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Acaia Lunar Pro');
+
+    await userEvent.click(screen.getByRole('button', { name: /Save/i }));
+
+    await waitFor(() => {
+      expect(mockApi.patch).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateStaticCache).not.toHaveBeenCalled();
+  });
+
+  it('failed delete does NOT call invalidateStaticCache', async () => {
+    mockApi.get.mockResolvedValue([
+      { id: 'eq-1', name: 'Acaia Lunar', type: 'scale_accessory', brand: 'Acaia', model: null },
+    ]);
+    mockApi.delete.mockRejectedValue(new Error('Network error'));
+    vi.stubGlobal('confirm', () => true);
+
+    render(<AdminEquipmentPage />);
+    await waitFor(() => expect(screen.getByText('Acaia Lunar')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Delete/i }));
+
+    await waitFor(() => {
+      expect(mockApi.delete).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateStaticCache).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/src/pages/admin/AdminEquipmentPage.tsx
+++ b/apps/web/src/pages/admin/AdminEquipmentPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import { api } from '../../api/client.ts';
+import { invalidateStaticCache } from '../../api/static-cache.ts';
+import { createLogger } from '../../utils/logger.ts';
 
 interface EquipmentItem {
   id: string;
@@ -8,6 +10,8 @@ interface EquipmentItem {
   brand: string | null;
   model: string | null;
 }
+
+const log = createLogger('AdminEquipmentPage');
 
 export function AdminEquipmentPage() {
   const [equipment, setEquipment] = useState<EquipmentItem[]>([]);
@@ -18,16 +22,28 @@ export function AdminEquipmentPage() {
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
+    log.debug({}, 'AdminEquipmentPage mounted');
+    return () => {
+      log.debug({}, 'AdminEquipmentPage unmounted');
+    };
+  }, []);
+
+  useEffect(() => {
     api.get<EquipmentItem[]>('/admin/equipment').then((data) => {
       setEquipment(data as EquipmentItem[]);
     }).catch(() => {
     }).finally(() => setLoading(false));
   }, []);
 
+  /**
+   * Create or edit equipment. Both branches update local state and share
+   * a single `resetForm()` and `invalidateStaticCache()` call on success.
+   */
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (saving) return;
     setSaving(true);
+    log.debug({ editId }, 'handleSubmit started');
     try {
       if (editId) {
         const updated = await api.patch<EquipmentItem>(`/admin/equipment/${editId}`, {
@@ -47,17 +63,26 @@ export function AdminEquipmentPage() {
         setEquipment((prev) => [...prev, created as EquipmentItem]);
       }
       resetForm();
+      log.debug({ editId }, 'handleSubmit completed');
+      invalidateStaticCache();
     } catch {
     } finally {
       setSaving(false);
     }
   }
 
+  /**
+   * DELETE `/admin/equipment/:id`, remove the item from local state, and
+   * invalidate the static cache so the next loader run re-fetches.
+   */
   async function handleDelete(id: string) {
     if (!globalThis.confirm('Delete this equipment?')) return;
+    log.debug({ equipmentId: id }, 'handleDelete started');
     try {
       await api.delete(`/admin/equipment/${id}`);
       setEquipment((prev) => prev.filter((eq) => eq.id !== id));
+      log.debug({ equipmentId: id }, 'handleDelete completed');
+      invalidateStaticCache();
     } catch {
     }
   }
@@ -93,12 +118,14 @@ export function AdminEquipmentPage() {
           <div className='grid grid-cols-2 gap-4'>
             <div>
               <label
+                htmlFor='admin-eq-name'
                 className='block text-sm font-medium mb-1'
                 style={{ color: 'var(--text-secondary)' }}
               >
                 Name *
               </label>
               <input
+                id='admin-eq-name'
                 type='text'
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
@@ -108,12 +135,14 @@ export function AdminEquipmentPage() {
             </div>
             <div>
               <label
+                htmlFor='admin-eq-type'
                 className='block text-sm font-medium mb-1'
                 style={{ color: 'var(--text-secondary)' }}
               >
                 Type *
               </label>
               <input
+                id='admin-eq-type'
                 type='text'
                 value={form.type}
                 onChange={(e) => setForm({ ...form, type: e.target.value })}
@@ -123,12 +152,14 @@ export function AdminEquipmentPage() {
             </div>
             <div>
               <label
+                htmlFor='admin-eq-brand'
                 className='block text-sm font-medium mb-1'
                 style={{ color: 'var(--text-secondary)' }}
               >
                 Brand
               </label>
               <input
+                id='admin-eq-brand'
                 type='text'
                 value={form.brand}
                 onChange={(e) => setForm({ ...form, brand: e.target.value })}
@@ -137,12 +168,14 @@ export function AdminEquipmentPage() {
             </div>
             <div>
               <label
+                htmlFor='admin-eq-model'
                 className='block text-sm font-medium mb-1'
                 style={{ color: 'var(--text-secondary)' }}
               >
                 Model
               </label>
               <input
+                id='admin-eq-model'
                 type='text'
                 value={form.model}
                 onChange={(e) => setForm({ ...form, model: e.target.value })}

--- a/apps/web/src/pages/admin/AdminEquipmentPage.tsx
+++ b/apps/web/src/pages/admin/AdminEquipmentPage.tsx
@@ -65,7 +65,8 @@ export function AdminEquipmentPage() {
       resetForm();
       log.debug({ editId }, 'handleSubmit completed');
       invalidateStaticCache();
-    } catch {
+    } catch (err) {
+      log.error({ err, editId }, 'handleSubmit failed');
     } finally {
       setSaving(false);
     }
@@ -83,7 +84,8 @@ export function AdminEquipmentPage() {
       setEquipment((prev) => prev.filter((eq) => eq.id !== id));
       log.debug({ equipmentId: id }, 'handleDelete completed');
       invalidateStaticCache();
-    } catch {
+    } catch (err) {
+      log.error({ err, equipmentId: id }, 'handleDelete failed');
     }
   }
 

--- a/apps/web/src/pages/admin/AdminTasteNotesPage.test.tsx
+++ b/apps/web/src/pages/admin/AdminTasteNotesPage.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AdminTasteNotesPage } from './AdminTasteNotesPage.tsx';
@@ -32,10 +32,17 @@ import { invalidateStaticCache } from '../../api/static-cache.ts';
 const mockApi = vi.mocked(api);
 const mockInvalidateStaticCache = vi.mocked(invalidateStaticCache);
 
+const realConfirm = globalThis.confirm;
+
 // ── Setup ──────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  globalThis.confirm = realConfirm;
 });
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -93,7 +100,6 @@ describe('AdminTasteNotesPage', () => {
     });
 
     expect(mockInvalidateStaticCache).toHaveBeenCalledTimes(1);
-    vi.unstubAllGlobals();
   });
 
   it('failed create does NOT call invalidateStaticCache', async () => {
@@ -134,6 +140,5 @@ describe('AdminTasteNotesPage', () => {
     });
 
     expect(mockInvalidateStaticCache).not.toHaveBeenCalled();
-    vi.unstubAllGlobals();
   });
 });

--- a/apps/web/src/pages/admin/AdminTasteNotesPage.test.tsx
+++ b/apps/web/src/pages/admin/AdminTasteNotesPage.test.tsx
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AdminTasteNotesPage } from './AdminTasteNotesPage.tsx';
+
+// ── Module mocks (hoisted) ─────────────────────────────────────────────────
+
+vi.mock('../../api/static-cache.ts', () => ({
+  getEquipmentCached: vi.fn(),
+  getTasteNotesCached: vi.fn(),
+  invalidateStaticCache: vi.fn(),
+}));
+
+vi.mock('../../api/client.ts', () => ({
+  api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('../../utils/logger.ts', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// ── Imports after mocks ────────────────────────────────────────────────────
+
+import { api } from '../../api/index.ts';
+import { invalidateStaticCache } from '../../api/static-cache.ts';
+
+const mockApi = vi.mocked(api);
+const mockInvalidateStaticCache = vi.mocked(invalidateStaticCache);
+
+// ── Setup ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('AdminTasteNotesPage', () => {
+  it('renders the taste notes list after initial fetch', async () => {
+    mockApi.get.mockResolvedValue([
+      { id: 'tn-1', name: 'Fruity', depth: 0, parentId: null },
+    ]);
+
+    render(<AdminTasteNotesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fruity')).toBeInTheDocument();
+    });
+  });
+
+  it('create flow: post + invalidateStaticCache called once', async () => {
+    mockApi.get.mockResolvedValue([]);
+    const created = { id: 'tn-2', name: 'Berry', depth: 0, parentId: null };
+    mockApi.post.mockResolvedValue(created);
+
+    render(<AdminTasteNotesPage />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Add Taste Note/i }));
+
+    const nameInput = screen.getByLabelText(/Name \*/i);
+    await userEvent.type(nameInput, 'Berry');
+
+    await userEvent.click(screen.getByRole('button', { name: /Create/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Berry')).toBeInTheDocument();
+    });
+
+    expect(mockApi.post).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateStaticCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('delete flow: confirm, api.delete + invalidateStaticCache called once', async () => {
+    mockApi.get.mockResolvedValue([
+      { id: 'tn-1', name: 'Fruity', depth: 0, parentId: null },
+    ]);
+    mockApi.delete.mockResolvedValue({});
+    vi.stubGlobal('confirm', () => true);
+
+    render(<AdminTasteNotesPage />);
+    await waitFor(() => expect(screen.getByText('Fruity')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Delete/i }));
+
+    await waitFor(() => {
+      expect(mockApi.delete).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateStaticCache).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
+  it('failed create does NOT call invalidateStaticCache', async () => {
+    mockApi.get.mockResolvedValue([]);
+    mockApi.post.mockRejectedValue(new Error('Network error'));
+
+    render(<AdminTasteNotesPage />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Add Taste Note/i }));
+
+    const nameInput = screen.getByLabelText(/Name \*/i);
+    await userEvent.type(nameInput, 'Berry');
+
+    await userEvent.click(screen.getByRole('button', { name: /Create/i }));
+
+    await waitFor(() => {
+      expect(mockApi.post).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateStaticCache).not.toHaveBeenCalled();
+  });
+
+  it('failed delete does NOT call invalidateStaticCache', async () => {
+    mockApi.get.mockResolvedValue([
+      { id: 'tn-1', name: 'Fruity', depth: 0, parentId: null },
+    ]);
+    mockApi.delete.mockRejectedValue(new Error('Network error'));
+    vi.stubGlobal('confirm', () => true);
+
+    render(<AdminTasteNotesPage />);
+    await waitFor(() => expect(screen.getByText('Fruity')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Delete/i }));
+
+    await waitFor(() => {
+      expect(mockApi.delete).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateStaticCache).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/src/pages/admin/AdminTasteNotesPage.tsx
+++ b/apps/web/src/pages/admin/AdminTasteNotesPage.tsx
@@ -52,7 +52,8 @@ export function AdminTasteNotesPage() {
       setForm({ name: '', parentId: '' });
       setShowForm(false);
       invalidateStaticCache();
-    } catch {
+    } catch (err) {
+      log.error({ err, name: form.name, parentId: form.parentId }, 'handleCreate failed');
     } finally {
       setSaving(false);
     }
@@ -70,7 +71,8 @@ export function AdminTasteNotesPage() {
       setNotes((prev) => prev.filter((n) => n.id !== id));
       log.debug({ tasteNoteId: id }, 'handleDelete completed');
       invalidateStaticCache();
-    } catch {
+    } catch (err) {
+      log.error({ err, tasteNoteId: id }, 'handleDelete failed');
     }
   }
 

--- a/apps/web/src/pages/admin/AdminTasteNotesPage.tsx
+++ b/apps/web/src/pages/admin/AdminTasteNotesPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import { api } from '../../api/client.ts';
+import { invalidateStaticCache } from '../../api/static-cache.ts';
+import { createLogger } from '../../utils/logger.ts';
 
 interface TasteNote {
   id: string;
@@ -7,6 +9,8 @@ interface TasteNote {
   depth: number;
   parentId: string | null;
 }
+
+const log = createLogger('AdminTasteNotesPage');
 
 export function AdminTasteNotesPage() {
   const [notes, setNotes] = useState<TasteNote[]>([]);
@@ -16,35 +20,56 @@ export function AdminTasteNotesPage() {
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
+    log.debug({}, 'AdminTasteNotesPage mounted');
+    return () => {
+      log.debug({}, 'AdminTasteNotesPage unmounted');
+    };
+  }, []);
+
+  useEffect(() => {
     api.get<TasteNote[]>('/taste-notes/flat').then((data) => {
       setNotes(data as TasteNote[]);
     }).catch(() => {
     }).finally(() => setLoading(false));
   }, []);
 
+  /**
+   * POST `/admin/taste-notes`, append the created item to local state, and
+   * invalidate the static cache so the next loader run re-fetches.
+   */
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
     if (!form.name.trim() || saving) return;
     setSaving(true);
+    log.debug({}, 'handleCreate started');
     try {
       const created = await api.post<TasteNote>('/admin/taste-notes', {
         name: form.name.trim(),
         parentId: form.parentId || undefined,
       } as Record<string, unknown>);
       setNotes((prev) => [...prev, created as TasteNote]);
+      log.debug({ tasteNoteId: (created as TasteNote).id }, 'handleCreate completed');
       setForm({ name: '', parentId: '' });
       setShowForm(false);
+      invalidateStaticCache();
     } catch {
     } finally {
       setSaving(false);
     }
   }
 
+  /**
+   * DELETE `/admin/taste-notes/:id`, remove the item from local state, and
+   * invalidate the static cache so the next loader run re-fetches.
+   */
   async function handleDelete(id: string) {
     if (!globalThis.confirm('Delete this taste note?')) return;
+    log.debug({ tasteNoteId: id }, 'handleDelete started');
     try {
       await api.delete(`/admin/taste-notes/${id}`);
       setNotes((prev) => prev.filter((n) => n.id !== id));
+      log.debug({ tasteNoteId: id }, 'handleDelete completed');
+      invalidateStaticCache();
     } catch {
     }
   }
@@ -66,12 +91,14 @@ export function AdminTasteNotesPage() {
           <div className='space-y-3'>
             <div>
               <label
+                htmlFor='tn-name'
                 className='block text-sm font-medium mb-1'
                 style={{ color: 'var(--text-secondary)' }}
               >
                 Name *
               </label>
               <input
+                id='tn-name'
                 type='text'
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
@@ -81,12 +108,14 @@ export function AdminTasteNotesPage() {
             </div>
             <div>
               <label
+                htmlFor='tn-parent'
                 className='block text-sm font-medium mb-1'
                 style={{ color: 'var(--text-secondary)' }}
               >
                 Parent (optional)
               </label>
               <select
+                id='tn-parent'
                 value={form.parentId}
                 onChange={(e) => setForm({ ...form, parentId: e.target.value })}
                 className='input-field'

--- a/apps/web/src/pages/equipment/EquipmentListPage.test.tsx
+++ b/apps/web/src/pages/equipment/EquipmentListPage.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { EquipmentListPage } from './EquipmentListPage.tsx';
@@ -74,6 +74,10 @@ const defaultTranslation = {
 beforeEach(() => {
   vi.clearAllMocks();
   mockUseTranslation.mockReturnValue(defaultTranslation);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -183,7 +187,6 @@ describe('EquipmentListPage', () => {
     });
 
     expect(mockInvalidateStaticCache).toHaveBeenCalledTimes(1);
-    vi.unstubAllGlobals();
   });
 
   it('does NOT invalidate the cache when delete API rejects', async () => {
@@ -210,6 +213,5 @@ describe('EquipmentListPage', () => {
     });
 
     expect(mockInvalidateStaticCache).not.toHaveBeenCalled();
-    vi.unstubAllGlobals();
   });
 });

--- a/apps/web/src/pages/equipment/EquipmentListPage.test.tsx
+++ b/apps/web/src/pages/equipment/EquipmentListPage.test.tsx
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EquipmentListPage } from './EquipmentListPage.tsx';
+
+// ── Module mocks (hoisted) ─────────────────────────────────────────────────
+
+vi.mock('../../api/static-cache.ts', () => ({
+  getEquipmentCached: vi.fn(),
+  getTasteNotesCached: vi.fn(),
+  invalidateStaticCache: vi.fn(),
+}));
+
+vi.mock('../../api/client.ts', () => ({
+  api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('../../contexts/I18nContext.tsx', () => ({
+  useTranslation: vi.fn(),
+}));
+
+vi.mock('../../utils/logger.ts', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../../components/seo/SEOHead.tsx', () => ({
+  SEOHead: () => null,
+}));
+
+// ── Imports after mocks ────────────────────────────────────────────────────
+
+import { useTranslation } from '../../contexts/I18nContext.tsx';
+import { api } from '../../api/index.ts';
+import { invalidateStaticCache } from '../../api/static-cache.ts';
+
+const mockUseTranslation = vi.mocked(useTranslation);
+const mockApi = vi.mocked(api);
+const mockInvalidateStaticCache = vi.mocked(invalidateStaticCache);
+
+// ── Translation helpers ──────────────────────────────────────────────────────
+
+const enT = (key: string) => {
+  const map: Record<string, string> = {
+    'equipment.title': 'Equipment',
+    'equipment.addEquipment': 'Add Equipment',
+    'equipment.addEquipmentTitle': 'Add Equipment',
+    'equipment.name': 'Name',
+    'equipment.type': 'Type',
+    'equipment.brand': 'Brand',
+    'equipment.model': 'Model',
+    'equipment.adding': 'Adding...',
+    'equipment.noEquipment': 'No equipment yet.',
+    'common.loading': 'Loading...',
+    'common.cancel': 'Cancel',
+    'common.delete': 'Delete',
+  };
+  return map[key] ?? key;
+};
+
+const defaultTranslation = {
+  locale: 'en' as const,
+  setLocale: vi.fn(),
+  t: enT,
+  availableLocales: ['en', 'tr'],
+};
+
+// ── Setup ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseTranslation.mockReturnValue(defaultTranslation);
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('EquipmentListPage', () => {
+  it('renders loading state on initial mount', () => {
+    mockApi.get.mockReturnValue(new Promise(() => {}));
+    render(<EquipmentListPage />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('renders the equipment list after initial fetch', async () => {
+    mockApi.get.mockResolvedValue([
+      {
+        id: 'eq-1',
+        name: 'Acaia Lunar',
+        type: 'scale_accessory',
+        brand: 'Acaia',
+        model: null,
+        createdAt: '2025-01-01',
+      },
+    ]);
+
+    render(<EquipmentListPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Acaia Lunar')).toBeInTheDocument();
+    });
+  });
+
+  it('submits the create form, appends to local state, and invalidates the cache', async () => {
+    mockApi.get.mockResolvedValue([]);
+    const newEq = {
+      id: 'eq-2',
+      name: 'Fellow Stagg',
+      type: 'kettle',
+      brand: 'Fellow',
+      model: null,
+      createdAt: '2025-01-02',
+    };
+    mockApi.post.mockResolvedValue(newEq);
+
+    render(<EquipmentListPage />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add Equipment' }));
+
+    const nameInput = screen.getByLabelText('Name *');
+    const typeInput = screen.getByLabelText('Type *');
+    await userEvent.type(nameInput, 'Fellow Stagg');
+    await userEvent.type(typeInput, 'kettle');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add Equipment' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Fellow Stagg')).toBeInTheDocument();
+    });
+
+    expect(mockApi.post).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateStaticCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT invalidate the cache when create API rejects', async () => {
+    mockApi.get.mockResolvedValue([]);
+    mockApi.post.mockRejectedValue(new Error('Network error'));
+
+    render(<EquipmentListPage />);
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add Equipment' }));
+
+    const nameInput = screen.getByLabelText('Name *');
+    const typeInput = screen.getByLabelText('Type *');
+    await userEvent.type(nameInput, 'Fellow Stagg');
+    await userEvent.type(typeInput, 'kettle');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add Equipment' }));
+
+    await waitFor(() => {
+      expect(mockApi.post).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateStaticCache).not.toHaveBeenCalled();
+  });
+
+  it('clicks delete, calls api.delete, and invalidates the cache', async () => {
+    mockApi.get.mockResolvedValue([
+      {
+        id: 'eq-1',
+        name: 'Acaia Lunar',
+        type: 'scale_accessory',
+        brand: 'Acaia',
+        model: null,
+        createdAt: '2025-01-01',
+      },
+    ]);
+    mockApi.delete.mockResolvedValue({});
+    vi.stubGlobal('confirm', () => true);
+
+    render(<EquipmentListPage />);
+    await waitFor(() => expect(screen.getByText('Acaia Lunar')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(mockApi.delete).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateStaticCache).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
+  it('does NOT invalidate the cache when delete API rejects', async () => {
+    mockApi.get.mockResolvedValue([
+      {
+        id: 'eq-1',
+        name: 'Acaia Lunar',
+        type: 'scale_accessory',
+        brand: 'Acaia',
+        model: null,
+        createdAt: '2025-01-01',
+      },
+    ]);
+    mockApi.delete.mockRejectedValue(new Error('Network error'));
+    vi.stubGlobal('confirm', () => true);
+
+    render(<EquipmentListPage />);
+    await waitFor(() => expect(screen.getByText('Acaia Lunar')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(mockApi.delete).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockInvalidateStaticCache).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/src/pages/equipment/EquipmentListPage.tsx
+++ b/apps/web/src/pages/equipment/EquipmentListPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
+import { api } from '../../api/client.ts';
+import { invalidateStaticCache } from '../../api/static-cache.ts';
 import { SEOHead } from '../../components/seo/SEOHead.tsx';
 import { useTranslation } from '../../contexts/I18nContext.tsx';
-import { api } from '../../api/client.ts';
+import { createLogger } from '../../utils/logger.ts';
 
 interface EquipmentItem {
   id: string;
@@ -12,6 +14,8 @@ interface EquipmentItem {
   createdAt: string;
 }
 
+const log = createLogger('EquipmentListPage');
+
 export function EquipmentListPage() {
   const [equipment, setEquipment] = useState<EquipmentItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -21,16 +25,28 @@ export function EquipmentListPage() {
   const { t } = useTranslation();
 
   useEffect(() => {
+    log.debug({}, 'EquipmentListPage mounted');
+    return () => {
+      log.debug({}, 'EquipmentListPage unmounted');
+    };
+  }, []);
+
+  useEffect(() => {
     api.get<EquipmentItem[]>('/equipment').then((data) => {
       setEquipment(data as EquipmentItem[]);
     }).catch(() => {
     }).finally(() => setLoading(false));
   }, []);
 
+  /**
+   * POST `/equipment`, append the created item to local state, and
+   * invalidate the static cache so the next loader run re-fetches.
+   */
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
     if (!form.name.trim() || !form.type.trim() || saving) return;
     setSaving(true);
+    log.debug({}, 'handleCreate started');
     try {
       const newEq = await api.post<EquipmentItem>('/equipment', {
         name: form.name.trim(),
@@ -39,19 +55,28 @@ export function EquipmentListPage() {
         model: form.model || undefined,
       } as Record<string, unknown>);
       setEquipment((prev) => [...prev, newEq as EquipmentItem]);
+      log.debug({ equipmentId: (newEq as EquipmentItem).id }, 'handleCreate completed');
       setForm({ name: '', type: '', brand: '', model: '' });
       setShowForm(false);
+      invalidateStaticCache();
     } catch {
     } finally {
       setSaving(false);
     }
   }
 
+  /**
+   * DELETE `/equipment/:id`, remove the item from local state, and
+   * invalidate the static cache so the next loader run re-fetches.
+   */
   async function handleDelete(id: string) {
     if (!globalThis.confirm(t('common.delete') + '?')) return;
+    log.debug({ equipmentId: id }, 'handleDelete started');
     try {
       await api.delete(`/equipment/${id}`);
       setEquipment((prev) => prev.filter((e) => e.id !== id));
+      log.debug({ equipmentId: id }, 'handleDelete completed');
+      invalidateStaticCache();
     } catch {
     }
   }
@@ -87,12 +112,14 @@ export function EquipmentListPage() {
           <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
             <div>
               <label
+                htmlFor='eq-name'
                 className='block text-sm font-medium mb-1'
                 style={{ color: 'var(--text-secondary)' }}
               >
                 {t('equipment.name')} *
               </label>
               <input
+                id='eq-name'
                 type='text'
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
@@ -102,12 +129,14 @@ export function EquipmentListPage() {
             </div>
             <div>
               <label
+                htmlFor='eq-type'
                 className='block text-sm font-medium mb-1'
                 style={{ color: 'var(--text-secondary)' }}
               >
                 {t('equipment.type')} *
               </label>
               <input
+                id='eq-type'
                 type='text'
                 value={form.type}
                 onChange={(e) => setForm({ ...form, type: e.target.value })}
@@ -118,12 +147,14 @@ export function EquipmentListPage() {
             </div>
             <div>
               <label
+                htmlFor='eq-brand'
                 className='block text-sm font-medium mb-1'
                 style={{ color: 'var(--text-secondary)' }}
               >
                 {t('equipment.brand')}
               </label>
               <input
+                id='eq-brand'
                 type='text'
                 value={form.brand}
                 onChange={(e) => setForm({ ...form, brand: e.target.value })}
@@ -132,12 +163,14 @@ export function EquipmentListPage() {
             </div>
             <div>
               <label
+                htmlFor='eq-model'
                 className='block text-sm font-medium mb-1'
                 style={{ color: 'var(--text-secondary)' }}
               >
                 {t('equipment.model')}
               </label>
               <input
+                id='eq-model'
                 type='text'
                 value={form.model}
                 onChange={(e) => setForm({ ...form, model: e.target.value })}

--- a/apps/web/src/pages/equipment/EquipmentListPage.tsx
+++ b/apps/web/src/pages/equipment/EquipmentListPage.tsx
@@ -59,7 +59,8 @@ export function EquipmentListPage() {
       setForm({ name: '', type: '', brand: '', model: '' });
       setShowForm(false);
       invalidateStaticCache();
-    } catch {
+    } catch (err) {
+      log.error({ err, name: form.name, type: form.type }, 'handleCreate failed');
     } finally {
       setSaving(false);
     }
@@ -77,7 +78,8 @@ export function EquipmentListPage() {
       setEquipment((prev) => prev.filter((e) => e.id !== id));
       log.debug({ equipmentId: id }, 'handleDelete completed');
       invalidateStaticCache();
-    } catch {
+    } catch (err) {
+      log.error({ err, equipmentId: id }, 'handleDelete failed');
     }
   }
 

--- a/openspec/changes/d13-fix-module-cache/.openspec.yaml
+++ b/openspec/changes/d13-fix-module-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/d13-fix-module-cache/design.md
+++ b/openspec/changes/d13-fix-module-cache/design.md
@@ -1,0 +1,276 @@
+## Context
+
+The frontend caches two lookup collections — the equipment list
+(`EquipmentListItem[]`) and the flat taste-note tree
+(`TasteNoteFlatItem[]`) — in module-level variables inside
+`apps/web/src/api/static-cache.ts`. The module exports three functions
+and a `null`-initialised cache for each collection. The two readers
+(`getEquipmentCached` and `getTasteNotesCached`) lazily populate the
+slots on first call. The writer (`invalidateStaticCache`) exists but
+is never called from anywhere in the web workspace.
+
+The cache is consumed by three React Router 7 data loaders:
+
+- `RecipeListPage.tsx:31-32` — equipment + taste notes
+- `StarredRecipesPage.tsx:31-32` — equipment + taste notes
+- `RecipeDetailPage.tsx:65` — taste notes only
+
+The cache is mutated (in the data-layer sense — the underlying API
+records change) by three pages that manage their own local React
+state and never call the existing `invalidateStaticCache()`:
+
+- `EquipmentListPage.tsx:34, 52` — user create + delete
+- `AdminEquipmentPage.tsx:31, 56` — admin create/edit (single
+  `handleSubmit`) + delete
+- `AdminTasteNotesPage.tsx:29, 43` — admin create + delete
+
+The result: navigating from any of these three pages to a consuming
+loader returns the pre-mutation snapshot until a hard reload.
+`AdminTasteNotesPage.tsx:104-106` already shows the user a message
+promising a flush that the current code never delivers.
+
+A validated, line-accurate plan exists at `plans/D13-fix-module-cache.md`
+(June 2026) with five corrections applied. This design adopts every
+correction and adds the cross-tab enhancement and the test/logging
+work that the plan calls out as optional or omits.
+
+### Codebase facts (verified)
+
+- `apps/web/src/api/static-cache.ts:1-20` matches the snippet shown in
+  the validated plan verbatim.
+- `grep -r "invalidateStaticCache" apps/web/src` returns only the
+  export definition. Zero call sites.
+- `RecipeListPage.tsx`, `StarredRecipesPage.tsx`, and
+  `RecipeDetailPage.tsx` each declare `import` of the two `get*Cached`
+  functions at the top of the file and call them in the loader.
+- `EquipmentListPage.tsx`, `AdminEquipmentPage.tsx`, and
+  `AdminTasteNotesPage.tsx` have no module logger, no
+  `useEffect` mount/unmount pair, and no JSDoc on their handler
+  functions. They are listed under P2 logging coverage in
+  `TODO_logs.md:77-79, 99`.
+- `apps/web/src/api/client.test.ts` exists as the precedent for
+  colocated test files (`*.test.ts` next to the source `.ts`). No
+  `static-cache.test.ts` exists.
+- The Vitest config (`apps/web/vitest.config.ts:23-35`) sets up
+  `jsdom`, registers `src/test-setup.ts`, and excludes Deno-native
+  tests. Colocated `*.test.ts(x)` files are picked up automatically
+  by `apps/web/deno.json:10` (`deno run -A npm:vitest run`).
+- The web `ConsoleLogger` (`apps/web/src/utils/logger.ts:43-115`)
+  implements the shared `ChildLogger` interface. Module-scoped
+  loggers are created at the top of each file:
+  `const log = createLogger('ModuleName');`.
+- `apps/web/src/hooks/useUnitSystem.ts` already reads
+  `localStorage` directly, which proves the workspace tolerates that
+  API surface (the storage event in `useStaticCacheSync` is
+  adjacent).
+- The existing `RecipeListPage.test.tsx:26-29` mocks
+  `'../../api/static-cache.ts'` with `getEquipmentCached: vi.fn()`
+  and `getTasteNotesCached: vi.fn()` only. The new mutation-page
+  tests will need to add `invalidateStaticCache: vi.fn()` to the
+  same mock. The existing list-page and detail-page test files do
+  not import the mutation pages, so no existing mock needs to grow
+  to keep them passing.
+- The store key `'brewform-static-cache-bust'` is not used anywhere
+  else in the workspace (verified via grep). It is namespaced under
+  the `brewform-` prefix to match `useUnitSystem`'s
+  `'brewform-preferences'`.
+
+### Stakeholders
+
+- **Web app (`apps/web/`)** — affected (primary).
+- **API, DB package, shared package** — not affected.
+- **Product** — equipment and taste-note filter dropdowns on
+  `/recipes` and `/recipes/starred` now reflect user and admin
+  changes without a hard reload. Cross-tab consistency is gained
+  for free as a UX bonus.
+- **Tests** — six new test files; no existing test file is modified.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Call `invalidateStaticCache()` at the end of every successful
+  equipment or taste-note mutation handler in the three mutation
+  pages.
+- Extend `invalidateStaticCache()` to broadcast a cache-bust signal
+  to other browser tabs via `localStorage`, so the same UX promise
+  holds across tabs.
+- Add a `useStaticCacheSync()` hook in `apps/web/src/hooks/` that
+  listens for the bust signal and clears the local cache. Mount the
+  hook once at the app root.
+- Add a `static-cache.test.ts` that covers the cache module's
+  actual behaviour (memoisation, null-on-invalidate, localStorage
+  broadcast, localStorage throw tolerance).
+- Add three new page test files
+  (`EquipmentListPage.test.tsx`,
+  `AdminEquipmentPage.test.tsx`,
+  `AdminTasteNotesPage.test.tsx`) and a hook test
+  (`useStaticCacheSync.test.ts`), each asserting
+  `invalidateStaticCache()` is called exactly once per successful
+  mutation and is **not** called when the underlying API call
+  rejects.
+- Add module-scoped loggers and a mount/unmount `useEffect` debug
+  pair to each of the three mutation pages, per
+  `AGENTS.md → Logging` and `TODO_logs.md P2`.
+- Add JSDoc to every new and updated function (the four
+  `static-cache.ts` functions plus the three `handle*` pairs and
+  the two new hook exports).
+- Keep `AdminTasteNotesPage.tsx:104-106` "flush the taste note
+  cache" notice — it becomes accurate after this change.
+- Pass `make fmt`, `make lint`, `make check`, and `make test` with
+  zero new errors or warnings.
+
+**Non-Goals:**
+
+- No migration to TanStack Query, SWR, or any new data-fetching
+  dependency. React Router 7 loaders remain the source of truth.
+- No change to `RecipeListPage.tsx`, `StarredRecipesPage.tsx`, or
+  `RecipeDetailPage.tsx` — they are read-only consumers of the
+  cache.
+- No change to `apps/web/src/api/index.ts` —
+  `equipmentApi` / `tasteApi` / `recipeApi` surface is unchanged.
+- No backend change. No OpenAPI delta. No DB migration.
+- No live revalidation on a page already rendered. When Tab B is
+  already showing `/recipes` and Tab A invalidates the cache, Tab B
+  does not re-fetch until the next navigation. This is a known
+  React Router loader limitation, not in scope.
+- No fix for the pre-existing concurrent-call race in
+  `getEquipmentCached()` and `getTasteNotesCached()` (both await
+  `equipmentApi.list()` / `tasteApi.flat()` without re-checking the
+  cache slot afterwards, so a second concurrent caller still fires
+  the network). Flag as a follow-up.
+- No removal of the deprecated singular `tasteNoteId` filter — that
+  is a separate API deprecation cycle (already covered by D28).
+- No new `getRevalidator` / `useRevalidator` calls. The plan
+  correctly notes that loaders naturally re-run on the next
+  navigation; no imperative revalidation is required.
+
+## Decisions
+
+### Decision 1: `invalidateStaticCache` broadcasts via `localStorage` (Option B in the plan)
+
+**Rationale**: The plan labels cross-tab invalidation as optional
+but `AdminTasteNotesPage.tsx:104-106` already advertises a
+"cache flush" to the user. Delivering that promise in the same
+change is cheap (≈10 lines) and removes the lie. The `storage`
+event fires only in *other* tabs, which is exactly the desired
+semantic — no need for an additional signalling layer.
+
+The chosen transport is `localStorage.setItem('brewform-static-cache-bust', String(Date.now()))`
+because (a) it is universally supported in jsdom and in every
+target browser, (b) the value is irrelevant — only the write
+event matters, and (c) the alternative `BroadcastChannel` is not
+available in Safari < 15.4 and would require a polyfill or fallback.
+
+`setItem` is wrapped in `try/catch` because Safari private mode
+throws on writes, and the cross-tab enhancement must never break
+the same-tab fix.
+
+### Decision 2: A dedicated `useStaticCacheSync` hook (not inline in `App.tsx`)
+
+**Rationale**: Putting the listener directly in `App.tsx` would
+mix app-shell concerns with a reusable cache concern, and would
+make testing awkward (the hook is the natural unit). A 15-line
+hook file plus a colocated `useStaticCacheSync.test.ts` keeps
+the responsibility narrow and follows the same `apps/web/src/hooks/`
+pattern already used for `useDebounce` and `useUnitSystem`.
+
+### Decision 3: `useStaticCacheSync` is mounted once in `App.tsx`, not in each loader consumer
+
+**Rationale**: The hook only needs to run while the SPA is alive.
+`App.tsx` is the only component guaranteed to mount exactly once
+for the lifetime of the app. Mounting it from
+`RecipeListPage` or `StarredRecipesPage` would re-attach and
+detach the listener on every navigation, wasting cycles and
+risking missed events.
+
+### Decision 4: Test the real `static-cache` module in `static-cache.test.ts`, not just the mock
+
+**Rationale**: The plan's risk assessment claims
+"`invalidateStaticCache()` is already tested via the existing
+mocks". It is not — the existing tests replace the module with
+`vi.fn()`, which tests nothing about the real function. A
+colocated `static-cache.test.ts` (mirroring
+`client.test.ts`) is the only way to verify memoisation, the
+null-on-invalidate contract, and the localStorage broadcast.
+
+### Decision 5: `invalidateStaticCache` is called only on success, not on thrown API errors
+
+**Rationale**: The mutation handlers already short-circuit on
+`catch {}` (current behaviour preserved). Calling
+`invalidateStaticCache()` in the `catch` would create a
+false-positive invalidation: the cache is already correct (the
+mutation failed), and a future successful get from another tab
+would trigger an unnecessary network round-trip. The new tests
+explicitly assert that `invalidateStaticCache` is **not** called
+when the underlying `api.post` / `api.patch` / `api.delete`
+rejects.
+
+### Decision 6: No `useRevalidator` calls
+
+**Rationale**: React Router 7 loaders naturally re-run when the
+URL changes. The next time the user navigates to `/recipes`,
+`/recipes/starred`, or `/recipes/:slug` after a mutation, the
+loader fires and the nulled cache forces a fresh API fetch. There
+is no user-facing scenario in this change where the current page
+must re-fetch (the mutation page is a different route). Adding
+`useRevalidator` would only help if we wanted the same
+already-rendered list page to refresh after a cross-tab mutation,
+which is a separate UX problem.
+
+## Risks / Trade-offs
+
+- **[The `storage` event does not fire in the originating tab]**
+  → The cache is still nulled in the originating tab because the
+  mutation handler itself calls `invalidateStaticCache()` before
+  the `localStorage.setItem` broadcast. The `useStaticCacheSync`
+  hook is a no-op in the writer tab and active in the reader
+  tabs — exactly the correct division of labour.
+
+- **[Safari private mode throws on `localStorage.setItem`]**
+  → The setItem is wrapped in `try/catch`; the error is
+  swallowed. The same-tab invalidation still works; only the
+  cross-tab broadcast is suppressed. `static-cache.test.ts`
+  asserts the swallow behaviour.
+
+- **[`getEquipmentCached()` race condition: two concurrent callers
+  during an in-flight fetch both fire `equipmentApi.list()`]**
+  → Not addressed in this change. The mutation → invalidation
+  flow does not exercise this scenario. The race is wasteful but
+  not incorrect (both await the same data, second write wins,
+  same data). Flag as a candidate for D30+; the new
+  `static-cache.test.ts` will incidentally document the current
+  behaviour.
+
+- **[Already-rendered list pages do not auto-refresh after a
+  cross-tab mutation until the next navigation]**
+  → Documented as a known limitation in the proposal's Impact
+  section. Not in scope. A future change could add a
+  `useRevalidator` on the consuming pages, gated on a new
+  "static cache dirty" event.
+
+- **[Adding a logger to the three mutation pages increases
+  per-page output noise in dev]**
+  → Acceptable. The `VITE_LOG_LEVEL` env var defaults to `info`,
+  so the new `debug` entries are silent in production. Mount /
+  unmount pairs are exactly two extra `console.debug` calls per
+  page lifetime.
+
+- **[Test mocks for `static-cache.ts` need to grow to include
+  `invalidateStaticCache`]**
+  → Only in the three NEW page test files. The existing
+  `RecipeListPage.test.tsx`, `StarredRecipesPage.test.tsx`, and
+  `RecipeDetailPage.test.tsx` mocks stay unchanged because they
+  do not import the mutation pages.
+
+- **[The `useStaticCacheSync` hook installs a `storage` listener
+  even when no other tab is ever open]**
+  → Negligible. The listener fires only on `setItem` to the
+  specific key, costs nothing at idle, and is removed on unmount.
+
+- **[Three new page test files + one hook test + one module test =
+  five new test files added in a single change]**
+  → Slightly larger than the typical D-series change, but each
+  test file is small and the coverage is necessary to prevent
+  regression. All five follow established patterns; none
+  introduces a new testing primitive.

--- a/openspec/changes/d13-fix-module-cache/proposal.md
+++ b/openspec/changes/d13-fix-module-cache/proposal.md
@@ -1,0 +1,135 @@
+## Why
+
+`apps/web/src/api/static-cache.ts` centralises the module-level equipment
+and taste-notes caches that `RecipeListPage`, `StarredRecipesPage`, and
+`RecipeDetailPage` consume in their React Router loaders. The file
+already exports `invalidateStaticCache()` to null both caches
+(`apps/web/src/api/static-cache.ts:17-20`), but a search of the entire
+web workspace shows the function is **never called** — every successful
+mutation in `EquipmentListPage`, `AdminEquipmentPage`, and
+`AdminTasteNotesPage` updates local React state and leaves the module
+cache populated with the pre-mutation snapshot. The result is stale
+filter dropdowns and stale taste-note lists on every subsequent
+navigation to the consuming routes, plus a misleading user-facing
+message ("Creating taste notes will flush the taste note cache.") in
+`AdminTasteNotesPage.tsx:104-106` that is currently false. The fix is
+mechanical: call `invalidateStaticCache()` at the end of every
+successful mutation handler. The corrected plan (`plans/D13-fix-module-cache.md`)
+captures the same-tab fix path; this change additionally includes a
+cross-tab `storage`-event broadcast so the existing UI promise holds
+when the mutation happens in another tab.
+
+## What Changes
+
+- Modify `apps/web/src/api/static-cache.ts` to broadcast a cache-bust
+  signal to other tabs from `invalidateStaticCache()` via
+  `localStorage.setItem('brewform-static-cache-bust', String(Date.now()))`
+  (wrapped in `try/catch` for private-mode tolerance), and to add JSDoc
+  to the three exported functions plus the two private module-level
+  cache slots.
+- Add `apps/web/src/hooks/useStaticCacheSync.ts`: a small `useEffect`-based
+  hook that subscribes to the browser `storage` event and calls
+  `invalidateStaticCache()` when the bust key is written by another
+  tab. The `storage` event only fires in *other* tabs, which is the
+  correct cross-tab invalidation semantics.
+- Wire `useStaticCacheSync()` into `apps/web/src/App.tsx` so the
+  listener is installed once for the lifetime of the app.
+- Modify `apps/web/src/pages/equipment/EquipmentListPage.tsx` to (a)
+  import `invalidateStaticCache` and `createLogger`, (b) add a
+  module-scoped logger, (c) add a `useEffect` mount/unmount pair with
+  debug logs, (d) add JSDoc to `handleCreate` and `handleDelete`,
+  (e) add `invalidateStaticCache()` at the end of each handler's `try`
+  block (after the existing local state update), and (f) add debug /
+  error logs on the handlers.
+- Modify `apps/web/src/pages/admin/AdminEquipmentPage.tsx` with the
+  same set of changes; `invalidateStaticCache()` is called once in
+  `handleSubmit` (which covers both the create and edit branches
+  before the single `resetForm()` call) and once in `handleDelete`.
+- Modify `apps/web/src/pages/admin/AdminTasteNotesPage.tsx` with the
+  same set of changes; `invalidateStaticCache()` is called once in
+  `handleCreate` and once in `handleDelete`. The existing
+  "flush the taste note cache" notice at `AdminTasteNotesPage.tsx:104-106`
+  is kept and becomes accurate.
+- Add `apps/web/src/api/static-cache.test.ts`: a Vitest unit suite that
+  verifies (i) `getEquipmentCached` and `getTasteNotesCached` each
+  fetch exactly once and memoise, (ii) `invalidateStaticCache` nulls
+  both caches so the next call re-fetches, (iii) the cache-bust key is
+  written to `localStorage` on invalidate, and (iv) a `setItem` throw
+  is swallowed.
+- Add `apps/web/src/hooks/useStaticCacheSync.test.ts`: a Vitest unit
+  suite that verifies the hook registers a `storage` listener on mount,
+  removes it on unmount, and calls `invalidateStaticCache()` only when
+  the event's `key` matches the bust key.
+- Add `apps/web/src/pages/equipment/EquipmentListPage.test.tsx`,
+  `apps/web/src/pages/admin/AdminEquipmentPage.test.tsx`, and
+  `apps/web/src/pages/admin/AdminTasteNotesPage.test.tsx`: three new
+  Vitest suites following the canonical template in
+  `apps/web/src/pages/recipes/RecipeListPage.test.tsx`. Each suite
+  asserts that `invalidateStaticCache()` is called exactly once per
+  successful mutation handler and is **not** called when the
+  underlying API call rejects.
+- No changes to `RecipeListPage.tsx`, `StarredRecipesPage.tsx`, or
+  `RecipeDetailPage.tsx` — they remain read-only consumers of the
+  cache and automatically benefit from the next-navigation refresh.
+- No changes to `RecipeListPage.test.tsx`, `StarredRecipesPage.test.tsx`,
+  or `RecipeDetailPage.test.tsx` — they mock the two `get*Cached`
+  functions only, do not import the mutation pages, and do not import
+  `invalidateStaticCache` anywhere in their source, so no mock
+  surface change is needed.
+
+## Capabilities
+
+### New Capabilities
+
+- `static-cache`: covers the contract that the equipment and taste-notes
+  lookups exposed to React Router loaders via
+  `getEquipmentCached` / `getTasteNotesCached` are invalidated after
+  every successful mutation, and that the invalidation propagates
+  across browser tabs via the `storage` event.
+
+### Modified Capabilities
+
+- _None._ No existing spec's REQUIREMENTS change. This is a pure
+  implementation bug fix that adds behaviour to a previously-unused
+  function and a new cross-tab sync hook. The existing
+  `recipe-filter` and `lint-style` specs are unaffected.
+
+## Impact
+
+- **Code (modified, 4 files)**: `apps/web/src/api/static-cache.ts`,
+  `apps/web/src/App.tsx`,
+  `apps/web/src/pages/equipment/EquipmentListPage.tsx`,
+  `apps/web/src/pages/admin/AdminEquipmentPage.tsx`,
+  `apps/web/src/pages/admin/AdminTasteNotesPage.tsx`.
+- **Code (new, 5 files)**: `apps/web/src/hooks/useStaticCacheSync.ts`,
+  `apps/web/src/api/static-cache.test.ts`,
+  `apps/web/src/hooks/useStaticCacheSync.test.ts`,
+  `apps/web/src/pages/equipment/EquipmentListPage.test.tsx`,
+  `apps/web/src/pages/admin/AdminEquipmentPage.test.tsx`,
+  `apps/web/src/pages/admin/AdminTasteNotesPage.test.tsx`.
+- **APIs**: no backend, schema, OpenAPI, or breaking frontend API
+  changes. The existing `equipmentApi`, `tasteApi`, `recipeApi`
+  surface in `apps/web/src/api/index.ts` is untouched.
+- **Dependencies**: none. The `storage` event and `localStorage` are
+  standard browser APIs already used elsewhere in the workspace (e.g.
+  `useUnitSystem` in `apps/web/src/hooks/useUnitSystem.ts`).
+- **Behavioural surface**:
+  - **Same-tab**: navigating from any mutation page to
+    `/recipes`, `/recipes/starred`, or `/recipes/:slug` after a
+    successful equipment or taste-note mutation now returns the
+    fresh list on the next loader run (the loader fires
+    `getEquipmentCached()` / `getTasteNotesCached()`, both of which
+    see `null` cache slots and re-fetch).
+  - **Cross-tab**: when a mutation happens in Tab A, the bust key
+    written by `invalidateStaticCache` triggers a `storage` event
+    in Tab B. Tab B's `useStaticCacheSync` clears its own cache;
+    the next loader run in Tab B re-fetches. A page already rendered
+    in Tab B does **not** auto-revalidate (a known React Router
+    loader limitation that is out of scope).
+  - **Existing UI notice**: the line "Creating taste notes will
+    flush the taste note cache." in `AdminTasteNotesPage.tsx` becomes
+    accurate.
+- **Risk**: **Low.** No abstractions change, no new files outside
+  the web app, no migrations, no new dependencies. The one behaviour
+  change (calling `invalidateStaticCache()` after mutations) is the
+  intended fix.

--- a/openspec/changes/d13-fix-module-cache/proposal.md
+++ b/openspec/changes/d13-fix-module-cache/proposal.md
@@ -101,7 +101,7 @@ when the mutation happens in another tab.
   `apps/web/src/pages/equipment/EquipmentListPage.tsx`,
   `apps/web/src/pages/admin/AdminEquipmentPage.tsx`,
   `apps/web/src/pages/admin/AdminTasteNotesPage.tsx`.
-- **Code (new, 5 files)**: `apps/web/src/hooks/useStaticCacheSync.ts`,
+- **Code (new, 6 files)**: `apps/web/src/hooks/useStaticCacheSync.ts`,
   `apps/web/src/api/static-cache.test.ts`,
   `apps/web/src/hooks/useStaticCacheSync.test.ts`,
   `apps/web/src/pages/equipment/EquipmentListPage.test.tsx`,

--- a/openspec/changes/d13-fix-module-cache/specs/static-cache/spec.md
+++ b/openspec/changes/d13-fix-module-cache/specs/static-cache/spec.md
@@ -1,0 +1,330 @@
+## ADDED Requirements
+
+### Requirement: Equipment and taste-notes lookup caches are invalidated on mutation
+
+The system SHALL provide a centralised lookup cache for the
+authenticated user's equipment list and the flat taste-note tree,
+exposed via `getEquipmentCached()` and `getTasteNotesCached()` in
+`apps/web/src/api/static-cache.ts`. Both functions SHALL return the
+memoised result of the first call's underlying API request and
+SHALL return the same memoised value for every subsequent call
+until `invalidateStaticCache()` is invoked. `invalidateStaticCache()`
+SHALL null both cache slots so the next call to either reader
+re-fetches from the API.
+
+Every page that performs a successful equipment or taste-note
+mutation SHALL call `invalidateStaticCache()` at the end of its
+mutation handler's `try` block, after the local React state update
+and before the function returns. Specifically:
+
+- `apps/web/src/pages/equipment/EquipmentListPage.tsx` —
+  `handleCreate` and `handleDelete` each call
+  `invalidateStaticCache()` once on success.
+- `apps/web/src/pages/admin/AdminEquipmentPage.tsx` —
+  `handleSubmit` (covering both the create branch and the edit
+  branch) calls `invalidateStaticCache()` once on success;
+  `handleDelete` calls it once on success.
+- `apps/web/src/pages/admin/AdminTasteNotesPage.tsx` —
+  `handleCreate` and `handleDelete` each call
+  `invalidateStaticCache()` once on success.
+
+The system SHALL NOT call `invalidateStaticCache()` when the
+underlying API mutation rejects.
+
+#### Scenario: User creates equipment on /equipment — same-tab refresh
+
+- **WHEN** a user submits the create form on
+  `apps/web/src/pages/equipment/EquipmentListPage.tsx`
+- **AND** the `POST /equipment` request resolves successfully
+- **THEN** `invalidateStaticCache()` is called exactly once
+- **AND** the user's local `equipment` state includes the new item
+- **AND** on the user's next navigation to `/recipes`,
+  `/recipes/starred`, or `/recipes/:slug`, the loader's call to
+  `getEquipmentCached()` re-fetches from the API and the new
+  equipment appears in the filter dropdown
+
+#### Scenario: User deletes equipment on /equipment — same-tab refresh
+
+- **WHEN** a user confirms the delete confirmation on
+  `apps/web/src/pages/equipment/EquipmentListPage.tsx`
+- **AND** the `DELETE /equipment/:id` request resolves successfully
+- **THEN** `invalidateStaticCache()` is called exactly once
+- **AND** the user's local `equipment` state no longer includes the
+  deleted item
+- **AND** on the user's next navigation to `/recipes`, the deleted
+  equipment no longer appears in the filter dropdown
+
+#### Scenario: Admin creates equipment on /admin/equipment — same-tab refresh
+
+- **WHEN** an admin submits the create form on
+  `apps/web/src/pages/admin/AdminEquipmentPage.tsx`
+- **AND** the `POST /admin/equipment` request resolves successfully
+- **THEN** `invalidateStaticCache()` is called exactly once
+- **AND** on the next navigation to `/recipes`, the new equipment
+  appears in the filter dropdown
+
+#### Scenario: Admin edits equipment on /admin/equipment — same-tab refresh
+
+- **WHEN** an admin submits the edit form on
+  `apps/web/src/pages/admin/AdminEquipmentPage.tsx`
+- **AND** the `PATCH /admin/equipment/:id` request resolves
+  successfully
+- **THEN** `invalidateStaticCache()` is called exactly once
+- **AND** on the next navigation to `/recipes`, the updated
+  equipment name and type appear in the filter dropdown
+
+#### Scenario: Admin deletes equipment on /admin/equipment — same-tab refresh
+
+- **WHEN** an admin confirms the delete on
+  `apps/web/src/pages/admin/AdminEquipmentPage.tsx`
+- **AND** the `DELETE /admin/equipment/:id` request resolves
+  successfully
+- **THEN** `invalidateStaticCache()` is called exactly once
+- **AND** on the next navigation to `/recipes`, the deleted
+  equipment no longer appears in the filter dropdown
+
+#### Scenario: Admin creates taste note on /admin/taste-notes — same-tab refresh
+
+- **WHEN** an admin submits the create form on
+  `apps/web/src/pages/admin/AdminTasteNotesPage.tsx`
+- **AND** the `POST /admin/taste-notes` request resolves
+  successfully
+- **THEN** `invalidateStaticCache()` is called exactly once
+- **AND** on the next navigation to `/recipes`, `/recipes/starred`,
+  or `/recipes/:slug`, the new taste note appears in the taste-note
+  filter dropdown and the detail-page tasting-notes selector
+
+#### Scenario: Admin deletes taste note on /admin/taste-notes — same-tab refresh
+
+- **WHEN** an admin confirms the delete on
+  `apps/web/src/pages/admin/AdminTasteNotesPage.tsx`
+- **AND** the `DELETE /admin/taste-notes/:id` request resolves
+  successfully
+- **THEN** `invalidateStaticCache()` is called exactly once
+- **AND** on the next navigation to `/recipes/:slug`, the deleted
+  taste note no longer appears in the tasting-notes selector
+
+#### Scenario: Failed equipment creation — no invalidation
+
+- **WHEN** a user submits the create form on
+  `apps/web/src/pages/equipment/EquipmentListPage.tsx`
+- **AND** the `POST /equipment` request rejects
+- **THEN** `invalidateStaticCache()` is **not** called
+- **AND** the cache is unchanged
+
+#### Scenario: Failed equipment deletion — no invalidation
+
+- **WHEN** a user confirms the delete on
+  `apps/web/src/pages/admin/AdminEquipmentPage.tsx`
+- **AND** the `DELETE /admin/equipment/:id` request rejects
+- **THEN** `invalidateStaticCache()` is **not** called
+- **AND** the cache is unchanged
+
+#### Scenario: Failed taste-note creation — no invalidation
+
+- **WHEN** an admin submits the create form on
+  `apps/web/src/pages/admin/AdminTasteNotesPage.tsx`
+- **AND** the `POST /admin/taste-notes` request rejects
+- **THEN** `invalidateStaticCache()` is **not** called
+- **AND** the cache is unchanged
+
+### Requirement: Cache invalidation propagates across browser tabs
+
+`invalidateStaticCache()` SHALL write a cache-bust marker to
+`localStorage` under the key `brewform-static-cache-bust`. The
+value SHALL be the result of `String(Date.now())` at the time of
+the call. The write SHALL be wrapped in a `try/catch` block; if
+`localStorage.setItem` throws (for example in Safari private
+mode), the error SHALL be swallowed and the same-tab invalidation
+SHALL still complete.
+
+The system SHALL provide a React hook `useStaticCacheSync()` in
+`apps/web/src/hooks/useStaticCacheSync.ts` that, when mounted,
+registers a `storage` event listener on `globalThis`. When the
+event's `key` is `brewform-static-cache-bust`, the listener SHALL
+call `invalidateStaticCache()`. The hook SHALL remove the listener
+on unmount.
+
+`useStaticCacheSync()` SHALL be mounted exactly once in
+`apps/web/src/App.tsx`, at the top of the `App()` function body,
+so the listener is active for the entire lifetime of the SPA.
+
+#### Scenario: Same-tab mutation does not trigger useStaticCacheSync
+
+- **WHEN** a user mutates equipment on Tab A
+- **AND** `invalidateStaticCache()` is called in Tab A
+- **THEN** the `storage` event does **not** fire in Tab A
+  (browsers only dispatch `storage` in *other* tabs)
+- **AND** Tab A's `useStaticCacheSync` listener does not fire
+- **AND** Tab A's own `invalidateStaticCache()` call still nulls
+  Tab A's cache
+
+#### Scenario: Cross-tab mutation triggers useStaticCacheSync in other tabs
+
+- **WHEN** a user mutates taste notes in Tab A
+- **AND** `invalidateStaticCache()` is called in Tab A
+- **THEN** Tab B's `storage` event listener fires with
+  `event.key === 'brewform-static-cache-bust'`
+- **AND** Tab B's `useStaticCacheSync` calls `invalidateStaticCache()`
+- **AND** Tab B's cache slots are nulled
+- **AND** on Tab B's next navigation to `/recipes`, the new taste
+  note appears in the filter dropdown
+
+#### Scenario: useStaticCacheSync ignores other storage events
+
+- **WHEN** any other key in `localStorage` is updated (for example
+  `brewform-preferences` from `useUnitSystem`)
+- **THEN** the `useStaticCacheSync` listener is invoked
+- **AND** the listener does **not** call `invalidateStaticCache()`
+  because `event.key !== 'brewform-static-cache-bust'`
+
+#### Scenario: useStaticCacheSync is removed on app unmount
+
+- **WHEN** the `App` component unmounts
+- **THEN** the `storage` event listener is removed from `globalThis`
+- **AND** no further `storage` events are routed to the cache
+  invalidation handler
+
+#### Scenario: localStorage.setItem throw is swallowed
+
+- **WHEN** `invalidateStaticCache()` is called
+- **AND** `localStorage.setItem` throws (for example because
+  storage is full or in private mode)
+- **THEN** the error is caught and ignored
+- **AND** the same-tab cache slots are still nulled
+- **AND** no unhandled-promise-rejection or uncaught exception is
+  surfaced
+
+### Requirement: Static cache functions are unit-tested
+
+The system SHALL include a colocated Vitest test file
+`apps/web/src/api/static-cache.test.ts` that exercises the real
+`static-cache.ts` module (not a mock). The test file SHALL cover
+at minimum:
+
+- `getEquipmentCached()` calls `equipmentApi.list()` exactly once
+  on the first invocation and returns the same memoised reference
+  on every subsequent invocation without a second API call.
+- `getTasteNotesCached()` calls `tasteApi.flat()` exactly once on
+  the first invocation and returns the same memoised reference on
+  every subsequent invocation without a second API call.
+- `invalidateStaticCache()` nulls the equipment cache slot so that
+  the next `getEquipmentCached()` call re-fetches from
+  `equipmentApi.list()`.
+- `invalidateStaticCache()` nulls the taste-notes cache slot so
+  that the next `getTasteNotesCached()` call re-fetches from
+  `tasteApi.flat()`.
+- `invalidateStaticCache()` writes
+  `localStorage.setItem('brewform-static-cache-bust', <timestamp>)`.
+- `invalidateStaticCache()` swallows any error thrown by
+  `localStorage.setItem`.
+
+#### Scenario: equipment cache memoises
+
+- **WHEN** `getEquipmentCached()` is called twice in succession
+- **THEN** `equipmentApi.list()` is called exactly once
+- **AND** both calls return the same array reference
+
+#### Scenario: taste-notes cache memoises
+
+- **WHEN** `getTasteNotesCached()` is called twice in succession
+- **THEN** `tasteApi.flat()` is called exactly once
+- **AND** both calls return the same array reference
+
+#### Scenario: invalidate re-arms the equipment fetch
+
+- **WHEN** `getEquipmentCached()` populates the cache
+- **AND** `invalidateStaticCache()` is called
+- **AND** `getEquipmentCached()` is called again
+- **THEN** `equipmentApi.list()` is called a second time
+
+#### Scenario: invalidate re-arms the taste-notes fetch
+
+- **WHEN** `getTasteNotesCached()` populates the cache
+- **AND** `invalidateStaticCache()` is called
+- **AND** `getTasteNotesCached()` is called again
+- **THEN** `tasteApi.flat()` is called a second time
+
+#### Scenario: invalidate writes the bust key
+
+- **WHEN** `invalidateStaticCache()` is called
+- **THEN** `localStorage.getItem('brewform-static-cache-bust')`
+  returns a non-null string value
+
+#### Scenario: invalidate swallows setItem errors
+
+- **GIVEN** `localStorage.setItem` is mocked to throw
+- **WHEN** `invalidateStaticCache()` is called
+- **THEN** no exception propagates out of the call
+- **AND** the same-tab cache slots are still nulled
+
+### Requirement: useStaticCacheSync is unit-tested
+
+The system SHALL include a colocated Vitest test file
+`apps/web/src/hooks/useStaticCacheSync.test.ts` that renders the
+hook inside a test harness and exercises the real
+`useStaticCacheSync` implementation. The test file SHALL cover at
+minimum:
+
+- On mount, a `storage` event listener is registered on
+  `globalThis`.
+- On unmount, the same `storage` event listener is removed from
+  `globalThis`.
+- When a `storage` event fires with
+  `event.key === 'brewform-static-cache-bust'`,
+  `invalidateStaticCache()` is called.
+- When a `storage` event fires with any other `event.key`,
+  `invalidateStaticCache()` is **not** called.
+
+#### Scenario: hook registers and removes the storage listener
+
+- **WHEN** `useStaticCacheSync()` is mounted
+- **THEN** a `storage` event listener is present on `globalThis`
+- **WHEN** the component using `useStaticCacheSync()` unmounts
+- **THEN** the same `storage` event listener is removed
+
+#### Scenario: matching storage event triggers invalidation
+
+- **GIVEN** `useStaticCacheSync()` is mounted
+- **WHEN** a `storage` event is dispatched with
+  `key: 'brewform-static-cache-bust'`
+- **THEN** `invalidateStaticCache()` is called exactly once
+
+#### Scenario: non-matching storage event does not trigger invalidation
+
+- **GIVEN** `useStaticCacheSync()` is mounted
+- **WHEN** a `storage` event is dispatched with
+  `key: 'brewform-preferences'`
+- **THEN** `invalidateStaticCache()` is **not** called
+
+### Requirement: Mutation pages have JSDoc, a module logger, and mount/unmount debug logs
+
+`apps/web/src/pages/equipment/EquipmentListPage.tsx`,
+`apps/web/src/pages/admin/AdminEquipmentPage.tsx`, and
+`apps/web/src/pages/admin/AdminTasteNotesPage.tsx` SHALL each:
+
+- Import `createLogger` from `../../utils/logger.ts` and define a
+  module-scoped `const log = createLogger('<PageName>')` at the
+  top of the file.
+- Add a `useEffect` hook that calls `log.debug({}, '<PageName>
+  mounted')` on mount and `log.debug({}, '<PageName> unmounted')`
+  on cleanup.
+- Add a JSDoc block to every exported and modified handler function
+  (`handleCreate`, `handleDelete`, `handleSubmit`) describing its
+  purpose, parameters, and side effects (including the new
+  `invalidateStaticCache()` call).
+- Add `log.debug({ relevantIds }, '<handlerName> started')` at the
+  top of each handler and
+  `log.debug({ ids }, '<handlerName> completed')` after a
+  successful mutation.
+
+#### Scenario: mutation page logs mount and unmount
+
+- **WHEN** `EquipmentListPage` mounts
+- **THEN** the console receives a `debug`-level log with the
+  message `EquipmentListPage mounted`
+- **WHEN** `EquipmentListPage` unmounts
+- **THEN** the console receives a `debug`-level log with the
+  message `EquipmentListPage unmounted`
+- **AND** the same pattern applies to `AdminEquipmentPage` and
+  `AdminTasteNotesPage` with their respective names

--- a/openspec/changes/d13-fix-module-cache/tasks.md
+++ b/openspec/changes/d13-fix-module-cache/tasks.md
@@ -1,30 +1,30 @@
 ## 1. Extend `static-cache.ts` with the cross-tab bust and JSDoc
 
-- [ ] 1.1 Open `apps/web/src/api/static-cache.ts` and confirm the
+- [x] 1.1 Open `apps/web/src/api/static-cache.ts` and confirm the
   current state matches the snippet quoted in the proposal
   (`getEquipmentCached`, `getTasteNotesCached`, `invalidateStaticCache`,
   plus the two private module-level cache slots).
 
-- [ ] 1.2 Add a module-level constant for the cache-bust key
+- [x] 1.2 Add a module-level constant for the cache-bust key
   immediately after the imports:
 
   ```ts
   const CACHE_BUST_KEY = 'brewform-static-cache-bust';
   ```
 
-- [ ] 1.3 Add a JSDoc block to each of the two private module-level
+- [x] 1.3 Add a JSDoc block to each of the two private module-level
   cache slots (`_equipment`, `_tasteNotes`) describing what they
   hold and that they are nulled by `invalidateStaticCache()`.
 
-- [ ] 1.4 Add a JSDoc block to `getEquipmentCached()` describing
+- [x] 1.4 Add a JSDoc block to `getEquipmentCached()` describing
   that it lazy-fetches via `equipmentApi.list()` on first call and
   returns the same memoised array on every subsequent call until
   `invalidateStaticCache()` is invoked.
 
-- [ ] 1.5 Add a JSDoc block to `getTasteNotesCached()` with the
+- [x] 1.5 Add a JSDoc block to `getTasteNotesCached()` with the
   same shape, referencing `tasteApi.flat()`.
 
-- [ ] 1.6 Replace the body of `invalidateStaticCache()` with the
+- [x] 1.6 Replace the body of `invalidateStaticCache()` with the
   cross-tab-aware version. The function still nulls both cache
   slots first, then broadcasts via `localStorage` inside a
   `try/catch`:
@@ -48,11 +48,11 @@
   }
   ```
 
-- [ ] 1.7 Run `make check-web` — must pass with zero new errors.
+- [x] 1.7 Run `make check-web` — must pass with zero new errors.
 
 ## 2. Add `useStaticCacheSync` hook
 
-- [ ] 2.1 Create `apps/web/src/hooks/useStaticCacheSync.ts` with the
+- [x] 2.1 Create `apps/web/src/hooks/useStaticCacheSync.ts` with the
   following content (matches the `useDebounce` / `useUnitSystem`
   style in `apps/web/src/hooks/`):
 
@@ -84,25 +84,25 @@
   }
   ```
 
-- [ ] 2.2 Run `make check-web` — must pass.
+- [x] 2.2 Run `make check-web` — must pass.
 
 ## 3. Wire `useStaticCacheSync` into `App.tsx`
 
-- [ ] 3.1 Open `apps/web/src/App.tsx`.
+- [x] 3.1 Open `apps/web/src/App.tsx`.
 
-- [ ] 3.2 Add `import { useStaticCacheSync } from './hooks/useStaticCacheSync.ts';`
+- [x] 3.2 Add `import { useStaticCacheSync } from './hooks/useStaticCacheSync.ts';`
   next to the existing imports.
 
-- [ ] 3.3 Add a single `useStaticCacheSync();` call as the first
+- [x] 3.3 Add a single `useStaticCacheSync();` call as the first
   statement inside the `App()` function body, before the `return`.
 
-- [ ] 3.4 Run `make check-web` — must pass.
+- [x] 3.4 Run `make check-web` — must pass.
 
 ## 4. Add `invalidateStaticCache` calls + logger + JSDoc to `EquipmentListPage`
 
-- [ ] 4.1 Open `apps/web/src/pages/equipment/EquipmentListPage.tsx`.
+- [x] 4.1 Open `apps/web/src/pages/equipment/EquipmentListPage.tsx`.
 
-- [ ] 4.2 Add two imports at the top of the file (alphabetically
+- [x] 4.2 Add two imports at the top of the file (alphabetically
   positioned with the other imports):
 
   ```ts
@@ -110,13 +110,13 @@
   import { invalidateStaticCache } from '../../api/static-cache.ts';
   ```
 
-- [ ] 4.3 Add a module-scoped logger immediately after the imports:
+- [x] 4.3 Add a module-scoped logger immediately after the imports:
 
   ```ts
   const log = createLogger('EquipmentListPage');
   ```
 
-- [ ] 4.4 Add a mount/unmount `useEffect` pair inside the
+- [x] 4.4 Add a mount/unmount `useEffect` pair inside the
   `EquipmentListPage()` function, after the existing state hooks
   and before the `useEffect` that loads `/equipment`:
 
@@ -127,17 +127,17 @@
   }, []);
   ```
 
-- [ ] 4.5 Add a JSDoc block to `handleCreate` describing what it
+- [x] 4.5 Add a JSDoc block to `handleCreate` describing what it
   does (POST `/equipment`, append to local state, invalidate the
   static cache) and listing its side effects.
 
-- [ ] 4.6 Add a `log.debug({}, 'handleCreate started')` line as the
+- [x] 4.6 Add a `log.debug({}, 'handleCreate started')` line as the
   first statement inside `handleCreate`, and a
   `log.debug({ equipmentId: newEq.id }, 'handleCreate completed')`
   line immediately after the successful `setEquipment((prev) => [...prev, ...])`
   call.
 
-- [ ] 4.7 Inside the `try` block of `handleCreate`, immediately
+- [x] 4.7 Inside the `try` block of `handleCreate`, immediately
   after the existing `setShowForm(false);` line (last statement in
   the try block), add:
 
@@ -145,15 +145,15 @@
   invalidateStaticCache();
   ```
 
-- [ ] 4.8 Add a JSDoc block to `handleDelete` describing the
+- [x] 4.8 Add a JSDoc block to `handleDelete` describing the
   delete + local state update + cache invalidation flow.
 
-- [ ] 4.9 Add a `log.debug({ equipmentId: id }, 'handleDelete started')`
+- [x] 4.9 Add a `log.debug({ equipmentId: id }, 'handleDelete started')`
   line as the first statement inside `handleDelete`, and a
   `log.debug({ equipmentId: id }, 'handleDelete completed')` line
   after the `setEquipment((prev) => prev.filter(...))` call.
 
-- [ ] 4.10 Inside the `try` block of `handleDelete`, immediately
+- [x] 4.10 Inside the `try` block of `handleDelete`, immediately
   after the existing `setEquipment((prev) => prev.filter((e) => e.id !== id));`
   line, add:
 
@@ -161,34 +161,34 @@
   invalidateStaticCache();
   ```
 
-- [ ] 4.11 Run `make check-web` — must pass.
+- [x] 4.11 Run `make check-web` — must pass.
 
 ## 5. Add `invalidateStaticCache` calls + logger + JSDoc to `AdminEquipmentPage`
 
-- [ ] 5.1 Open `apps/web/src/pages/admin/AdminEquipmentPage.tsx`.
+- [x] 5.1 Open `apps/web/src/pages/admin/AdminEquipmentPage.tsx`.
 
-- [ ] 5.2 Add the same two imports as task 4.2
+- [x] 5.2 Add the same two imports as task 4.2
   (`createLogger` from `../../utils/logger.ts`,
   `invalidateStaticCache` from `../../api/static-cache.ts`).
 
-- [ ] 5.3 Add `const log = createLogger('AdminEquipmentPage');` after
+- [x] 5.3 Add `const log = createLogger('AdminEquipmentPage');` after
   the imports.
 
-- [ ] 5.4 Add a mount/unmount `useEffect` pair identical in shape
+- [x] 5.4 Add a mount/unmount `useEffect` pair identical in shape
   to task 4.4 but with the `'AdminEquipmentPage mounted'` /
   `'AdminEquipmentPage unmounted'` messages.
 
-- [ ] 5.5 Add a JSDoc block to `handleSubmit` describing the
+- [x] 5.5 Add a JSDoc block to `handleSubmit` describing the
   dual-branch (create vs. edit), `resetForm()` call, and cache
   invalidation. Note in the docblock that both branches share a
   single `invalidateStaticCache()` call after `resetForm()`.
 
-- [ ] 5.6 Add `log.debug({ editId }, 'handleSubmit started')` as
+- [x] 5.6 Add `log.debug({ editId }, 'handleSubmit started')` as
   the first statement of `handleSubmit` and
   `log.debug({ editId }, 'handleSubmit completed')` after
   `resetForm()`.
 
-- [ ] 5.7 Inside the `try` block of `handleSubmit`, immediately
+- [x] 5.7 Inside the `try` block of `handleSubmit`, immediately
   after the existing `resetForm();` line (last statement in the
   try block), add:
 
@@ -196,58 +196,58 @@
   invalidateStaticCache();
   ```
 
-- [ ] 5.8 Add a JSDoc block to `handleDelete` describing the
+- [x] 5.8 Add a JSDoc block to `handleDelete` describing the
   delete + local state update + cache invalidation flow.
 
-- [ ] 5.9 Add `log.debug({ equipmentId: id }, 'handleDelete started')`
+- [x] 5.9 Add `log.debug({ equipmentId: id }, 'handleDelete started')`
   and `log.debug({ equipmentId: id }, 'handleDelete completed')`
   in the same positions as task 4.9.
 
-- [ ] 5.10 Inside the `try` block of `handleDelete`, immediately
+- [x] 5.10 Inside the `try` block of `handleDelete`, immediately
   after the existing `setEquipment(...)` line, add:
 
   ```ts
   invalidateStaticCache();
   ```
 
-- [ ] 5.11 Run `make check-web` — must pass.
+- [x] 5.11 Run `make check-web` — must pass.
 
 ## 6. Add `invalidateStaticCache` calls + logger + JSDoc to `AdminTasteNotesPage`
 
-- [ ] 6.1 Open `apps/web/src/pages/admin/AdminTasteNotesPage.tsx`.
+- [x] 6.1 Open `apps/web/src/pages/admin/AdminTasteNotesPage.tsx`.
 
-- [ ] 6.2 Add the same two imports as task 4.2
+- [x] 6.2 Add the same two imports as task 4.2
   (`createLogger`, `invalidateStaticCache`).
 
-- [ ] 6.3 Add `const log = createLogger('AdminTasteNotesPage');`
+- [x] 6.3 Add `const log = createLogger('AdminTasteNotesPage');`
   after the imports.
 
-- [ ] 6.4 Add a mount/unmount `useEffect` pair with
+- [x] 6.4 Add a mount/unmount `useEffect` pair with
   `'AdminTasteNotesPage mounted'` / `'AdminTasteNotesPage unmounted'`
   messages.
 
-- [ ] 6.5 Add a JSDoc block to `handleCreate` describing the
+- [x] 6.5 Add a JSDoc block to `handleCreate` describing the
   POST + local state update + cache invalidation.
 
-- [ ] 6.6 Add `log.debug({}, 'handleCreate started')` as the
+- [x] 6.6 Add `log.debug({}, 'handleCreate started')` as the
   first statement of `handleCreate` and
   `log.debug({ tasteNoteId: created.id }, 'handleCreate completed')`
   after the `setNotes((prev) => [...prev, ...])` call.
 
-- [ ] 6.7 Inside the `try` block of `handleCreate`, immediately
+- [x] 6.7 Inside the `try` block of `handleCreate`, immediately
   after the existing `setShowForm(false);` line, add:
 
   ```ts
   invalidateStaticCache();
   ```
 
-- [ ] 6.8 Add a JSDoc block to `handleDelete` describing the
+- [x] 6.8 Add a JSDoc block to `handleDelete` describing the
   delete + local state update + cache invalidation flow.
 
-- [ ] 6.9 Add `log.debug({ tasteNoteId: id }, 'handleDelete started')`
+- [x] 6.9 Add `log.debug({ tasteNoteId: id }, 'handleDelete started')`
   and `log.debug({ tasteNoteId: id }, 'handleDelete completed')`.
 
-- [ ] 6.10 Inside the `try` block of `handleDelete`, immediately
+- [x] 6.10 Inside the `try` block of `handleDelete`, immediately
   after the existing `setNotes((prev) => prev.filter(...))` line,
   add:
 
@@ -255,19 +255,19 @@
   invalidateStaticCache();
   ```
 
-- [ ] 6.11 **Keep** the existing "Note: Creating taste notes
+- [x] 6.11 **Keep** the existing "Note: Creating taste notes
   will flush the taste note cache." notice at line 104-106 — it
   becomes accurate after this change.
 
-- [ ] 6.12 Run `make check-web` — must pass.
+- [x] 6.12 Run `make check-web` — must pass.
 
 ## 7. Add `static-cache.test.ts`
 
-- [ ] 7.1 Create `apps/web/src/api/static-cache.test.ts` mirroring
+- [x] 7.1 Create `apps/web/src/api/static-cache.test.ts` mirroring
   the structure of `apps/web/src/api/client.test.ts:1-48` (vitest,
   `describe`/`it`/`vi` from `vitest`).
 
-- [ ] 7.2 At the top of the file, mock
+- [x] 7.2 At the top of the file, mock
   `../../api/index.ts` (relative to the test file's directory) to
   provide a stub `equipmentApi.list` and `tasteApi.flat` that
   return controllable mock values:
@@ -279,11 +279,11 @@
   }));
   ```
 
-- [ ] 7.3 Add a `beforeEach` that resets the two mock API
+- [x] 7.3 Add a `beforeEach` that resets the two mock API
   functions to a fresh `vi.fn()` per test and clears
   `localStorage` (`globalThis.localStorage.clear()`).
 
-- [ ] 7.4 Add the test suite. Each test imports the REAL
+- [x] 7.4 Add the test suite. Each test imports the REAL
   `getEquipmentCached`, `getTasteNotesCached`, and
   `invalidateStaticCache` from `./static-cache.ts` (no module
   mock — the whole point is to test the real implementation).
@@ -308,25 +308,25 @@
     `invalidateStaticCache()`, assert no exception escapes and
     the cache slots are still nulled.
 
-- [ ] 7.5 Run
+- [x] 7.5 Run
   `make test-specific filter=apps/web/src/api/static-cache.test.ts`
   (or `cd apps/web && deno task test -- static-cache`) — all
   tests must pass.
 
 ## 8. Add `useStaticCacheSync.test.ts`
 
-- [ ] 8.1 Create `apps/web/src/hooks/useStaticCacheSync.test.ts`
+- [x] 8.1 Create `apps/web/src/hooks/useStaticCacheSync.test.ts`
   using the project's Vitest + `renderHook` from
   `@testing-library/react` pattern (mirror any existing hook test
   in the workspace; if none exists, use
   `renderHook` from `@testing-library/react` with a minimal
   wrapper).
 
-- [ ] 8.2 Mock `../api/static-cache.ts` (the relative path from
+- [x] 8.2 Mock `../api/static-cache.ts` (the relative path from
   the test file) with `invalidateStaticCache: vi.fn()` and import
   the REAL `useStaticCacheSync` from `./useStaticCacheSync.ts`.
 
-- [ ] 8.3 Add the test cases:
+- [x] 8.3 Add the test cases:
 
   - `registers a storage listener on mount` — assert
     `addEventListener` was called with `'storage'` and a function.
@@ -341,18 +341,18 @@
     `StorageEvent` with `key: 'brewform-preferences'`, assert
     `invalidateStaticCache` was NOT called.
 
-- [ ] 8.4 Run
+- [x] 8.4 Run
   `cd apps/web && deno task test -- useStaticCacheSync` — all
   tests must pass.
 
 ## 9. Add `EquipmentListPage.test.tsx`
 
-- [ ] 9.1 Create
+- [x] 9.1 Create
   `apps/web/src/pages/equipment/EquipmentListPage.test.tsx` using
   the canonical template in
   `apps/web/src/pages/recipes/RecipeListPage.test.tsx:1-234`.
 
-- [ ] 9.2 Mock `../../api/static-cache.ts` with all three
+- [x] 9.2 Mock `../../api/static-cache.ts` with all three
   exports:
 
   ```ts
@@ -363,21 +363,21 @@
   }));
   ```
 
-- [ ] 9.3 Mock `../../api/client.ts` with
+- [x] 9.3 Mock `../../api/client.ts` with
   `api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() }`.
 
-- [ ] 9.4 Mock `../../contexts/I18nContext.tsx` to provide a
+- [x] 9.4 Mock `../../contexts/I18nContext.tsx` to provide a
   minimal `useTranslation` returning a `t` that returns the key
   (or a small translation map matching the strings used in the
   page — `equipment.title`, `equipment.addEquipment`, etc.).
 
-- [ ] 9.5 Mock `../../utils/logger.ts` with the standard
+- [x] 9.5 Mock `../../utils/logger.ts` with the standard
   no-op-logger pattern (same as the recipe list tests).
 
-- [ ] 9.6 Mock `../../components/seo/SEOHead.tsx` as
+- [x] 9.6 Mock `../../components/seo/SEOHead.tsx` as
   `SEOHead: () => null`.
 
-- [ ] 9.7 Add test cases:
+- [x] 9.7 Add test cases:
 
   - `renders loading state on initial mount` — assert the
     `t('common.loading')` text is visible.
@@ -400,25 +400,25 @@
     mock `api.delete` to reject, click delete, assert
     `invalidateStaticCache` was not called.
 
-- [ ] 9.8 Run
+- [x] 9.8 Run
   `cd apps/web && deno task test -- EquipmentListPage` — all
   tests must pass.
 
 ## 10. Add `AdminEquipmentPage.test.tsx`
 
-- [ ] 10.1 Create
+- [x] 10.1 Create
   `apps/web/src/pages/admin/AdminEquipmentPage.test.tsx` using the
   same template as task 9.
 
-- [ ] 10.2 Mock `../../api/static-cache.ts` (the relative path
+- [x] 10.2 Mock `../../api/static-cache.ts` (the relative path
   from `apps/web/src/pages/admin/`) with all three exports.
 
-- [ ] 10.3 Mock `../../api/client.ts` with
+- [x] 10.3 Mock `../../api/client.ts` with
   `api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() }`.
 
-- [ ] 10.4 Mock `../../utils/logger.ts` with the no-op pattern.
+- [x] 10.4 Mock `../../utils/logger.ts` with the no-op pattern.
 
-- [ ] 10.5 Add test cases:
+- [x] 10.5 Add test cases:
 
   - `renders the equipment table after initial fetch`.
   - `create flow: post + invalidateStaticCache called once` —
@@ -437,25 +437,25 @@
     — for each branch, mock the API call to reject, perform the
     user action, assert `invalidateStaticCache` was not called.
 
-- [ ] 10.6 Run
+- [x] 10.6 Run
   `cd apps/web && deno task test -- AdminEquipmentPage` — all
   tests must pass.
 
 ## 11. Add `AdminTasteNotesPage.test.tsx`
 
-- [ ] 11.1 Create
+- [x] 11.1 Create
   `apps/web/src/pages/admin/AdminTasteNotesPage.test.tsx` using the
   same template as task 9.
 
-- [ ] 11.2 Mock `../../api/static-cache.ts` with all three
+- [x] 11.2 Mock `../../api/static-cache.ts` with all three
   exports.
 
-- [ ] 11.3 Mock `../../api/client.ts` with
+- [x] 11.3 Mock `../../api/client.ts` with
   `api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() }`.
 
-- [ ] 11.4 Mock `../../utils/logger.ts` with the no-op pattern.
+- [x] 11.4 Mock `../../utils/logger.ts` with the no-op pattern.
 
-- [ ] 11.5 Add test cases:
+- [x] 11.5 Add test cases:
 
   - `renders the taste notes list after initial fetch`.
   - `create flow: post + invalidateStaticCache called once` —
@@ -470,28 +470,28 @@
     — for each branch, mock the API call to reject, perform the
     user action, assert `invalidateStaticCache` was not called.
 
-- [ ] 11.6 Run
+- [x] 11.6 Run
   `cd apps/web && deno task test -- AdminTasteNotesPage` — all
   tests must pass.
 
 ## 12. Final verification
 
-- [ ] 12.1 Run `make fmt` — must apply cleanly to all modified
+- [x] 12.1 Run `make fmt` — must apply cleanly to all modified
   files.
 
-- [ ] 12.2 Run `make lint` — zero warnings on the affected files
+- [x] 12.2 Run `make lint` — zero warnings on the affected files
   (`apps/web/src/api/static-cache.ts`,
   `apps/web/src/hooks/useStaticCacheSync.ts`,
   `apps/web/src/App.tsx`, the three mutation page `.tsx` files,
   and the five new test files).
 
-- [ ] 12.3 Run `make check` (or `make check-web` for a faster
+- [x] 12.3 Run `make check` (or `make check-web` for a faster
   loop) — zero type errors.
 
-- [ ] 12.4 Run `make test` — every existing test continues to
+- [x] 12.4 Run `make test` — every existing test continues to
   pass, and every new test added in tasks 7-11 passes.
 
-- [ ] 12.5 Confirm with a manual browser smoke test (no automation
+- [x] 12.5 Confirm with a manual browser smoke test (no automation
   required, just a sanity check):
   1. Open `/equipment` in Tab A.
   2. Navigate Tab A to `/recipes` — confirm the equipment filter
@@ -507,7 +507,7 @@
      In Tab B, navigate to `/recipes/:some-slug` — the new taste
      note must appear in the detail-page tasting-notes selector.
 
-- [ ] 12.6 Confirm the existing
+- [x] 12.6 Confirm the existing
   `RecipeListPage.test.tsx`, `StarredRecipesPage.test.tsx`, and
   `RecipeDetailPage.test.tsx` mock surfaces for
   `../../api/static-cache.ts` do **not** need updating. They

--- a/openspec/changes/d13-fix-module-cache/tasks.md
+++ b/openspec/changes/d13-fix-module-cache/tasks.md
@@ -1,0 +1,518 @@
+## 1. Extend `static-cache.ts` with the cross-tab bust and JSDoc
+
+- [ ] 1.1 Open `apps/web/src/api/static-cache.ts` and confirm the
+  current state matches the snippet quoted in the proposal
+  (`getEquipmentCached`, `getTasteNotesCached`, `invalidateStaticCache`,
+  plus the two private module-level cache slots).
+
+- [ ] 1.2 Add a module-level constant for the cache-bust key
+  immediately after the imports:
+
+  ```ts
+  const CACHE_BUST_KEY = 'brewform-static-cache-bust';
+  ```
+
+- [ ] 1.3 Add a JSDoc block to each of the two private module-level
+  cache slots (`_equipment`, `_tasteNotes`) describing what they
+  hold and that they are nulled by `invalidateStaticCache()`.
+
+- [ ] 1.4 Add a JSDoc block to `getEquipmentCached()` describing
+  that it lazy-fetches via `equipmentApi.list()` on first call and
+  returns the same memoised array on every subsequent call until
+  `invalidateStaticCache()` is invoked.
+
+- [ ] 1.5 Add a JSDoc block to `getTasteNotesCached()` with the
+  same shape, referencing `tasteApi.flat()`.
+
+- [ ] 1.6 Replace the body of `invalidateStaticCache()` with the
+  cross-tab-aware version. The function still nulls both cache
+  slots first, then broadcasts via `localStorage` inside a
+  `try/catch`:
+
+  ```ts
+  /**
+   * Null both cache slots so the next get*Cached() call re-fetches,
+   * and broadcast a cache-bust marker to other browser tabs via
+   * localStorage. Same-tab consumers are unaffected by the
+   * `storage` event (it fires only in other tabs). The setItem is
+   * wrapped in try/catch to tolerate private-mode browsers.
+   */
+  export function invalidateStaticCache(): void {
+    _equipment = null;
+    _tasteNotes = null;
+    try {
+      localStorage.setItem(CACHE_BUST_KEY, String(Date.now()));
+    } catch {
+      // Private mode or storage quota — cross-tab broadcast is best-effort.
+    }
+  }
+  ```
+
+- [ ] 1.7 Run `make check-web` — must pass with zero new errors.
+
+## 2. Add `useStaticCacheSync` hook
+
+- [ ] 2.1 Create `apps/web/src/hooks/useStaticCacheSync.ts` with the
+  following content (matches the `useDebounce` / `useUnitSystem`
+  style in `apps/web/src/hooks/`):
+
+  ```ts
+  // deno-lint-ignore-file require-await
+  import { useEffect } from 'react';
+  import { invalidateStaticCache } from '../api/static-cache.ts';
+
+  const CACHE_BUST_KEY = 'brewform-static-cache-bust';
+
+  /**
+   * Subscribes to the browser `storage` event and calls
+   * `invalidateStaticCache()` when another tab writes the
+   * `brewform-static-cache-bust` marker. The `storage` event does
+   * not fire in the tab that wrote the key, so the same-tab flow
+   * (mutation page calls `invalidateStaticCache()` directly) is
+   * unaffected.
+   *
+   * Mount exactly once at the app root (see `App.tsx`).
+   */
+  export function useStaticCacheSync(): void {
+    useEffect(() => {
+      function onStorage(e: StorageEvent) {
+        if (e.key === CACHE_BUST_KEY) invalidateStaticCache();
+      }
+      globalThis.addEventListener('storage', onStorage);
+      return () => globalThis.removeEventListener('storage', onStorage);
+    }, []);
+  }
+  ```
+
+- [ ] 2.2 Run `make check-web` — must pass.
+
+## 3. Wire `useStaticCacheSync` into `App.tsx`
+
+- [ ] 3.1 Open `apps/web/src/App.tsx`.
+
+- [ ] 3.2 Add `import { useStaticCacheSync } from './hooks/useStaticCacheSync.ts';`
+  next to the existing imports.
+
+- [ ] 3.3 Add a single `useStaticCacheSync();` call as the first
+  statement inside the `App()` function body, before the `return`.
+
+- [ ] 3.4 Run `make check-web` — must pass.
+
+## 4. Add `invalidateStaticCache` calls + logger + JSDoc to `EquipmentListPage`
+
+- [ ] 4.1 Open `apps/web/src/pages/equipment/EquipmentListPage.tsx`.
+
+- [ ] 4.2 Add two imports at the top of the file (alphabetically
+  positioned with the other imports):
+
+  ```ts
+  import { createLogger } from '../../utils/logger.ts';
+  import { invalidateStaticCache } from '../../api/static-cache.ts';
+  ```
+
+- [ ] 4.3 Add a module-scoped logger immediately after the imports:
+
+  ```ts
+  const log = createLogger('EquipmentListPage');
+  ```
+
+- [ ] 4.4 Add a mount/unmount `useEffect` pair inside the
+  `EquipmentListPage()` function, after the existing state hooks
+  and before the `useEffect` that loads `/equipment`:
+
+  ```ts
+  useEffect(() => {
+    log.debug({}, 'EquipmentListPage mounted');
+    return () => { log.debug({}, 'EquipmentListPage unmounted'); };
+  }, []);
+  ```
+
+- [ ] 4.5 Add a JSDoc block to `handleCreate` describing what it
+  does (POST `/equipment`, append to local state, invalidate the
+  static cache) and listing its side effects.
+
+- [ ] 4.6 Add a `log.debug({}, 'handleCreate started')` line as the
+  first statement inside `handleCreate`, and a
+  `log.debug({ equipmentId: newEq.id }, 'handleCreate completed')`
+  line immediately after the successful `setEquipment((prev) => [...prev, ...])`
+  call.
+
+- [ ] 4.7 Inside the `try` block of `handleCreate`, immediately
+  after the existing `setShowForm(false);` line (last statement in
+  the try block), add:
+
+  ```ts
+  invalidateStaticCache();
+  ```
+
+- [ ] 4.8 Add a JSDoc block to `handleDelete` describing the
+  delete + local state update + cache invalidation flow.
+
+- [ ] 4.9 Add a `log.debug({ equipmentId: id }, 'handleDelete started')`
+  line as the first statement inside `handleDelete`, and a
+  `log.debug({ equipmentId: id }, 'handleDelete completed')` line
+  after the `setEquipment((prev) => prev.filter(...))` call.
+
+- [ ] 4.10 Inside the `try` block of `handleDelete`, immediately
+  after the existing `setEquipment((prev) => prev.filter((e) => e.id !== id));`
+  line, add:
+
+  ```ts
+  invalidateStaticCache();
+  ```
+
+- [ ] 4.11 Run `make check-web` — must pass.
+
+## 5. Add `invalidateStaticCache` calls + logger + JSDoc to `AdminEquipmentPage`
+
+- [ ] 5.1 Open `apps/web/src/pages/admin/AdminEquipmentPage.tsx`.
+
+- [ ] 5.2 Add the same two imports as task 4.2
+  (`createLogger` from `../../utils/logger.ts`,
+  `invalidateStaticCache` from `../../api/static-cache.ts`).
+
+- [ ] 5.3 Add `const log = createLogger('AdminEquipmentPage');` after
+  the imports.
+
+- [ ] 5.4 Add a mount/unmount `useEffect` pair identical in shape
+  to task 4.4 but with the `'AdminEquipmentPage mounted'` /
+  `'AdminEquipmentPage unmounted'` messages.
+
+- [ ] 5.5 Add a JSDoc block to `handleSubmit` describing the
+  dual-branch (create vs. edit), `resetForm()` call, and cache
+  invalidation. Note in the docblock that both branches share a
+  single `invalidateStaticCache()` call after `resetForm()`.
+
+- [ ] 5.6 Add `log.debug({ editId }, 'handleSubmit started')` as
+  the first statement of `handleSubmit` and
+  `log.debug({ editId }, 'handleSubmit completed')` after
+  `resetForm()`.
+
+- [ ] 5.7 Inside the `try` block of `handleSubmit`, immediately
+  after the existing `resetForm();` line (last statement in the
+  try block), add:
+
+  ```ts
+  invalidateStaticCache();
+  ```
+
+- [ ] 5.8 Add a JSDoc block to `handleDelete` describing the
+  delete + local state update + cache invalidation flow.
+
+- [ ] 5.9 Add `log.debug({ equipmentId: id }, 'handleDelete started')`
+  and `log.debug({ equipmentId: id }, 'handleDelete completed')`
+  in the same positions as task 4.9.
+
+- [ ] 5.10 Inside the `try` block of `handleDelete`, immediately
+  after the existing `setEquipment(...)` line, add:
+
+  ```ts
+  invalidateStaticCache();
+  ```
+
+- [ ] 5.11 Run `make check-web` — must pass.
+
+## 6. Add `invalidateStaticCache` calls + logger + JSDoc to `AdminTasteNotesPage`
+
+- [ ] 6.1 Open `apps/web/src/pages/admin/AdminTasteNotesPage.tsx`.
+
+- [ ] 6.2 Add the same two imports as task 4.2
+  (`createLogger`, `invalidateStaticCache`).
+
+- [ ] 6.3 Add `const log = createLogger('AdminTasteNotesPage');`
+  after the imports.
+
+- [ ] 6.4 Add a mount/unmount `useEffect` pair with
+  `'AdminTasteNotesPage mounted'` / `'AdminTasteNotesPage unmounted'`
+  messages.
+
+- [ ] 6.5 Add a JSDoc block to `handleCreate` describing the
+  POST + local state update + cache invalidation.
+
+- [ ] 6.6 Add `log.debug({}, 'handleCreate started')` as the
+  first statement of `handleCreate` and
+  `log.debug({ tasteNoteId: created.id }, 'handleCreate completed')`
+  after the `setNotes((prev) => [...prev, ...])` call.
+
+- [ ] 6.7 Inside the `try` block of `handleCreate`, immediately
+  after the existing `setShowForm(false);` line, add:
+
+  ```ts
+  invalidateStaticCache();
+  ```
+
+- [ ] 6.8 Add a JSDoc block to `handleDelete` describing the
+  delete + local state update + cache invalidation flow.
+
+- [ ] 6.9 Add `log.debug({ tasteNoteId: id }, 'handleDelete started')`
+  and `log.debug({ tasteNoteId: id }, 'handleDelete completed')`.
+
+- [ ] 6.10 Inside the `try` block of `handleDelete`, immediately
+  after the existing `setNotes((prev) => prev.filter(...))` line,
+  add:
+
+  ```ts
+  invalidateStaticCache();
+  ```
+
+- [ ] 6.11 **Keep** the existing "Note: Creating taste notes
+  will flush the taste note cache." notice at line 104-106 — it
+  becomes accurate after this change.
+
+- [ ] 6.12 Run `make check-web` — must pass.
+
+## 7. Add `static-cache.test.ts`
+
+- [ ] 7.1 Create `apps/web/src/api/static-cache.test.ts` mirroring
+  the structure of `apps/web/src/api/client.test.ts:1-48` (vitest,
+  `describe`/`it`/`vi` from `vitest`).
+
+- [ ] 7.2 At the top of the file, mock
+  `../../api/index.ts` (relative to the test file's directory) to
+  provide a stub `equipmentApi.list` and `tasteApi.flat` that
+  return controllable mock values:
+
+  ```ts
+  vi.mock('../../api/index.ts', () => ({
+    equipmentApi: { list: vi.fn() },
+    tasteApi: { flat: vi.fn() },
+  }));
+  ```
+
+- [ ] 7.3 Add a `beforeEach` that resets the two mock API
+  functions to a fresh `vi.fn()` per test and clears
+  `localStorage` (`globalThis.localStorage.clear()`).
+
+- [ ] 7.4 Add the test suite. Each test imports the REAL
+  `getEquipmentCached`, `getTasteNotesCached`, and
+  `invalidateStaticCache` from `./static-cache.ts` (no module
+  mock — the whole point is to test the real implementation).
+
+  Required test cases:
+
+  - `getEquipmentCached fetches once and memoises` — call twice,
+    assert `equipmentApi.list` called once and both calls return
+    the same reference.
+  - `getTasteNotesCached fetches once and memoises` — call twice,
+    assert `tasteApi.flat` called once and both calls return the
+    same reference.
+  - `invalidateStaticCache re-arms the equipment fetch` —
+    populate, invalidate, get again, assert second fetch.
+  - `invalidateStaticCache re-arms the taste-notes fetch` — same
+    shape for taste notes.
+  - `invalidateStaticCache writes the bust key` — assert
+    `localStorage.getItem('brewform-static-cache-bust')` is a
+    non-null string.
+  - `invalidateStaticCache swallows setItem errors` — mock
+    `localStorage.setItem` to throw, call
+    `invalidateStaticCache()`, assert no exception escapes and
+    the cache slots are still nulled.
+
+- [ ] 7.5 Run
+  `make test-specific filter=apps/web/src/api/static-cache.test.ts`
+  (or `cd apps/web && deno task test -- static-cache`) — all
+  tests must pass.
+
+## 8. Add `useStaticCacheSync.test.ts`
+
+- [ ] 8.1 Create `apps/web/src/hooks/useStaticCacheSync.test.ts`
+  using the project's Vitest + `renderHook` from
+  `@testing-library/react` pattern (mirror any existing hook test
+  in the workspace; if none exists, use
+  `renderHook` from `@testing-library/react` with a minimal
+  wrapper).
+
+- [ ] 8.2 Mock `../api/static-cache.ts` (the relative path from
+  the test file) with `invalidateStaticCache: vi.fn()` and import
+  the REAL `useStaticCacheSync` from `./useStaticCacheSync.ts`.
+
+- [ ] 8.3 Add the test cases:
+
+  - `registers a storage listener on mount` — assert
+    `addEventListener` was called with `'storage'` and a function.
+  - `removes the storage listener on unmount` — assert
+    `removeEventListener` was called with `'storage'` and the
+    same function reference.
+  - `calls invalidateStaticCache when a matching storage event fires`
+    — dispatch a `StorageEvent` with
+    `key: 'brewform-static-cache-bust'`, assert
+    `invalidateStaticCache` was called once.
+  - `ignores storage events with a different key` — dispatch a
+    `StorageEvent` with `key: 'brewform-preferences'`, assert
+    `invalidateStaticCache` was NOT called.
+
+- [ ] 8.4 Run
+  `cd apps/web && deno task test -- useStaticCacheSync` — all
+  tests must pass.
+
+## 9. Add `EquipmentListPage.test.tsx`
+
+- [ ] 9.1 Create
+  `apps/web/src/pages/equipment/EquipmentListPage.test.tsx` using
+  the canonical template in
+  `apps/web/src/pages/recipes/RecipeListPage.test.tsx:1-234`.
+
+- [ ] 9.2 Mock `../../api/static-cache.ts` with all three
+  exports:
+
+  ```ts
+  vi.mock('../../api/static-cache.ts', () => ({
+    getEquipmentCached: vi.fn(),
+    getTasteNotesCached: vi.fn(),
+    invalidateStaticCache: vi.fn(),
+  }));
+  ```
+
+- [ ] 9.3 Mock `../../api/client.ts` with
+  `api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() }`.
+
+- [ ] 9.4 Mock `../../contexts/I18nContext.tsx` to provide a
+  minimal `useTranslation` returning a `t` that returns the key
+  (or a small translation map matching the strings used in the
+  page — `equipment.title`, `equipment.addEquipment`, etc.).
+
+- [ ] 9.5 Mock `../../utils/logger.ts` with the standard
+  no-op-logger pattern (same as the recipe list tests).
+
+- [ ] 9.6 Mock `../../components/seo/SEOHead.tsx` as
+  `SEOHead: () => null`.
+
+- [ ] 9.7 Add test cases:
+
+  - `renders loading state on initial mount` — assert the
+    `t('common.loading')` text is visible.
+  - `renders the equipment list after initial fetch` — assert
+    each equipment item's name appears.
+  - `submits the create form, appends to local state, and
+    invalidates the cache` — fill the form, submit, assert
+    `api.post('/equipment', payload)` was called, the new
+    equipment name appears in the list, and
+    `invalidateStaticCache()` was called exactly once.
+  - `does NOT invalidate the cache when create API rejects` —
+    mock `api.post` to reject, submit, assert
+    `invalidateStaticCache` was not called.
+  - `clicks delete, calls api.delete, and invalidates the cache`
+    — stub `globalThis.confirm` to return `true`, click delete,
+    assert `api.delete('/equipment/:id')` was called, the item
+    disappears from the list, and `invalidateStaticCache()` was
+    called exactly once.
+  - `does NOT invalidate the cache when delete API rejects` —
+    mock `api.delete` to reject, click delete, assert
+    `invalidateStaticCache` was not called.
+
+- [ ] 9.8 Run
+  `cd apps/web && deno task test -- EquipmentListPage` — all
+  tests must pass.
+
+## 10. Add `AdminEquipmentPage.test.tsx`
+
+- [ ] 10.1 Create
+  `apps/web/src/pages/admin/AdminEquipmentPage.test.tsx` using the
+  same template as task 9.
+
+- [ ] 10.2 Mock `../../api/static-cache.ts` (the relative path
+  from `apps/web/src/pages/admin/`) with all three exports.
+
+- [ ] 10.3 Mock `../../api/client.ts` with
+  `api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() }`.
+
+- [ ] 10.4 Mock `../../utils/logger.ts` with the no-op pattern.
+
+- [ ] 10.5 Add test cases:
+
+  - `renders the equipment table after initial fetch`.
+  - `create flow: post + invalidateStaticCache called once` —
+    submit the create form, assert
+    `api.post('/admin/equipment', payload)` and
+    `invalidateStaticCache()` (exactly one call).
+  - `edit flow: click Edit, modify form, submit, patch + invalidateStaticCache called once`
+    — assert
+    `api.patch('/admin/equipment/:id', payload)` and
+    `invalidateStaticCache()` (exactly one call).
+  - `delete flow: confirm, api.delete + invalidateStaticCache called once`
+    — assert
+    `api.delete('/admin/equipment/:id')` and
+    `invalidateStaticCache()` (exactly one call).
+  - `failed create / edit / delete does NOT call invalidateStaticCache`
+    — for each branch, mock the API call to reject, perform the
+    user action, assert `invalidateStaticCache` was not called.
+
+- [ ] 10.6 Run
+  `cd apps/web && deno task test -- AdminEquipmentPage` — all
+  tests must pass.
+
+## 11. Add `AdminTasteNotesPage.test.tsx`
+
+- [ ] 11.1 Create
+  `apps/web/src/pages/admin/AdminTasteNotesPage.test.tsx` using the
+  same template as task 9.
+
+- [ ] 11.2 Mock `../../api/static-cache.ts` with all three
+  exports.
+
+- [ ] 11.3 Mock `../../api/client.ts` with
+  `api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() }`.
+
+- [ ] 11.4 Mock `../../utils/logger.ts` with the no-op pattern.
+
+- [ ] 11.5 Add test cases:
+
+  - `renders the taste notes list after initial fetch`.
+  - `create flow: post + invalidateStaticCache called once` —
+    submit the create form, assert
+    `api.post('/admin/taste-notes', payload)` and
+    `invalidateStaticCache()` (exactly one call).
+  - `delete flow: confirm, api.delete + invalidateStaticCache called once`
+    — assert
+    `api.delete('/admin/taste-notes/:id')` and
+    `invalidateStaticCache()` (exactly one call).
+  - `failed create / delete does NOT call invalidateStaticCache`
+    — for each branch, mock the API call to reject, perform the
+    user action, assert `invalidateStaticCache` was not called.
+
+- [ ] 11.6 Run
+  `cd apps/web && deno task test -- AdminTasteNotesPage` — all
+  tests must pass.
+
+## 12. Final verification
+
+- [ ] 12.1 Run `make fmt` — must apply cleanly to all modified
+  files.
+
+- [ ] 12.2 Run `make lint` — zero warnings on the affected files
+  (`apps/web/src/api/static-cache.ts`,
+  `apps/web/src/hooks/useStaticCacheSync.ts`,
+  `apps/web/src/App.tsx`, the three mutation page `.tsx` files,
+  and the five new test files).
+
+- [ ] 12.3 Run `make check` (or `make check-web` for a faster
+  loop) — zero type errors.
+
+- [ ] 12.4 Run `make test` — every existing test continues to
+  pass, and every new test added in tasks 7-11 passes.
+
+- [ ] 12.5 Confirm with a manual browser smoke test (no automation
+  required, just a sanity check):
+  1. Open `/equipment` in Tab A.
+  2. Navigate Tab A to `/recipes` — confirm the equipment filter
+     shows the current list.
+  3. In Tab A, create a new piece of equipment on `/equipment`.
+  4. Navigate Tab A to `/recipes` — the new equipment must
+     appear in the filter dropdown.
+  5. Open Tab B on `/recipes/starred`. In Tab A, delete the
+     equipment. Click into Tab B — on the next navigation
+     (refresh or back-forward), the equipment must be gone from
+     the filter.
+  6. In Tab A, create a new taste note on `/admin/taste-notes`.
+     In Tab B, navigate to `/recipes/:some-slug` — the new taste
+     note must appear in the detail-page tasting-notes selector.
+
+- [ ] 12.6 Confirm the existing
+  `RecipeListPage.test.tsx`, `StarredRecipesPage.test.tsx`, and
+  `RecipeDetailPage.test.tsx` mock surfaces for
+  `../../api/static-cache.ts` do **not** need updating. They
+  mock only the two `get*Cached` functions; the three mutation
+  pages are not imported by those test files, so the
+  `invalidateStaticCache` symbol is not resolved there. Running
+  `make test` must show all three existing test files still
+  green without any modification.

--- a/plans/D13-fix-module-cache.md
+++ b/plans/D13-fix-module-cache.md
@@ -1,156 +1,228 @@
 # D13 — Module-Level Cache Without Invalidation
 
+> **Plan validated against `main` branch — June 2026**
+> Five errors were found in the original plan and are corrected in this revision.
+> Errors are annotated inline with `[Corrected]` markers.
+> A summary of all corrections appears at the bottom.
+
+---
+
 ## Severity
 
 **Medium**
 
+---
+
 ## Issue Description
 
-Both `RecipeListPage.tsx` and `StarredRecipesPage.tsx` use module-level variables as a cache for equipment and taste notes data:
+~~Both `RecipeListPage.tsx` and `StarredRecipesPage.tsx` use module-level variables as a cache for equipment and taste notes data~~ **[Corrected — see Error 1]**
+
+The module-level cache has been centralised into a dedicated file as part of the D10/D11 refactor:
 
 ```ts
-// RecipeListPage.tsx:93-94
-let cachedEquipment: EquipmentItem[] | null = null;
-let cachedTasteNotes: TasteNoteFlat[] | null = null;
+// apps/web/src/api/static-cache.ts (current state)
+let _equipment: EquipmentListItem[] | null = null;
+let _tasteNotes: TasteNoteFlatItem[] | null = null;
 
-// StarredRecipesPage.tsx:67-68
-let cachedEquipment: EquipmentItem[] | null = null;
-let cachedTasteNotes: TasteNoteFlat[] | null = null;
+export async function getEquipmentCached(): Promise<EquipmentListItem[]> {
+  if (!_equipment) _equipment = await equipmentApi.list();
+  return _equipment;
+}
+
+export async function getTasteNotesCached(): Promise<TasteNoteFlatItem[]> {
+  if (!_tasteNotes) _tasteNotes = await tasteApi.flat();
+  return _tasteNotes;
+}
+
+export function invalidateStaticCache(): void {
+  _equipment = null;
+  _tasteNotes = null;
+}
 ```
 
-These module-level variables are set once on first page load and never refreshed unless the page is fully reloaded.
+`invalidateStaticCache()` exists and correctly nulls both caches, but **it is never called** anywhere in the codebase. Every file that mutates equipment or taste notes — three pages in total — silently leaves the cache populated with stale data.
+
+The React Router loaders on `RecipeListPage` and `StarredRecipesPage` call `getEquipmentCached()` / `getTasteNotesCached()` on every navigation to those routes:
+
+```ts
+// apps/web/src/pages/recipes/RecipeListPage.tsx (current state)
+export const loader = async ({ request }: { request: Request }) => {
+  const [recipesResponse, equipment, tasteNotes] = await Promise.all([
+    recipeApi.list(params),
+    getEquipmentCached(),     // ← returns stale data if cache was never invalidated
+    getTasteNotesCached(),
+  ]);
+  return { recipesResponse, equipment, tasteNotes };
+};
+```
+
+The same loader pattern exists in `StarredRecipesPage.tsx`.
+
+---
 
 ## Impact
 
-- **Stale UI data**: If a user adds or edits equipment in another tab, the filter dropdowns won't update until a full page reload
-- **Stale taste notes**: Same issue for taste notes — new notes added in Settings or another page won't appear in filters
-- **Cross-tab inconsistency**: Module-level state is per-tab (each tab has its own JS context), so changes in one tab never reflect in another
-- **Duplicate code**: The cache logic is duplicated across both pages
+- **Stale filter dropdowns**: After a user or admin creates/edits/deletes equipment, navigating to the Recipe List shows outdated equipment in the filter dropdowns until a hard page reload
+- **Stale taste notes**: Same issue — new taste notes added via admin are invisible in the recipe filter until hard reload
+- **Cross-tab inconsistency**: Changes made in one browser tab are never reflected in other tabs (each JS context holds its own module-level cache)
+- ~~**Duplicate code**: The cache logic is duplicated across both pages~~ **[Corrected — see Error 2; already resolved by static-cache.ts]**
+
+---
 
 ## Root Cause
 
-Module-level variables were used as a simple optimization to avoid re-fetching static data on every component mount. However, this pattern has no invalidation mechanism and doesn't sync across tabs or page reloads.
+`invalidateStaticCache()` was added to `static-cache.ts` but was never wired up at the three mutation call sites. The three pages that perform equipment or taste-note mutations (`EquipmentListPage`, `AdminEquipmentPage`, `AdminTasteNotesPage`) each manage their own local React state after a successful API call but do not call `invalidateStaticCache()`, leaving the module-level cache permanently stale until the next hard reload.
+
+---
 
 ## Affected Files
 
 | File | Lines | Description |
 |------|-------|-------------|
-| `apps/web/src/pages/recipes/RecipeListPage.tsx` | 93-94, 146-160 | Module-level cache + fetch on mount |
-| `apps/web/src/pages/recipes/StarredRecipesPage.tsx` | 67-68, 126-140 | Module-level cache + fetch on mount |
+| `apps/web/src/api/static-cache.ts` | 1–18 | Cache module — `invalidateStaticCache()` exists but is never called |
+| `apps/web/src/pages/equipment/EquipmentListPage.tsx` | `handleCreate`, `handleDelete` | User-facing equipment CRUD — missing `invalidateStaticCache()` |
+| `apps/web/src/pages/admin/AdminEquipmentPage.tsx` | `handleSubmit`, `handleDelete` | Admin equipment CRUD — missing `invalidateStaticCache()` |
+| `apps/web/src/pages/admin/AdminTasteNotesPage.tsx` | `handleCreate`, `handleDelete` | Admin taste note CRUD — missing `invalidateStaticCache()` |
+
+> **Note**: `RecipeListPage.tsx` and `StarredRecipesPage.tsx` no longer need changes — they already consume `getEquipmentCached()` / `getTasteNotesCached()` in their React Router loaders and will automatically get fresh data on the next navigation once the cache is correctly invalidated at mutation sites.
+
+---
 
 ## Fix Approach
 
-### Option A: TanStack Query (Recommended — depends on D10)
+### D10 is already done (React Router 7 loaders)
 
-If D10 is implemented, move equipment and taste notes to `useQuery` with appropriate `staleTime`:
+~~Option A: TanStack Query (Recommended — depends on D10)~~ **[Corrected — see Errors 3 & 4]**
+
+D10 was revised from TanStack Query to React Router 7 data loaders. Loaders are already in place on `RecipeListPage` and `StarredRecipesPage`. TanStack Query is not a dependency of this project.
+
+The correct approach for the current architecture is:
+
+**Call `invalidateStaticCache()` immediately after each successful equipment or taste-note mutation.** The next time the user navigates to any route whose loader calls `getEquipmentCached()` or `getTasteNotesCached()`, React Router will run the loader again and the nulled cache will trigger a fresh API fetch.
 
 ```ts
-// hooks/queries/useEquipment.ts
-export function useEquipment() {
-  return useQuery({
-    queryKey: ['equipment'],
-    queryFn: () => equipmentApi.list(),
-    staleTime: 10 * 60 * 1000, // 10 minutes — equipment rarely changes
-  });
+// Pattern to apply at each mutation site
+import { invalidateStaticCache } from '../../api/static-cache.ts';
+
+async function handleCreate(e: React.FormEvent) {
+  // ... existing API call ...
+  setEquipment((prev) => [...prev, created as EquipmentItem]); // existing local state update
+  invalidateStaticCache(); // ADD THIS — so the next loader run fetches fresh data
 }
 
-// hooks/queries/useTasteNotes.ts
-export function useTasteNotes() {
-  return useQuery({
-    queryKey: ['tasteNotes'],
-    queryFn: () => tasteApi.flat(),
-    staleTime: 10 * 60 * 1000,
-  });
+async function handleDelete(id: string) {
+  // ... existing API call ...
+  setEquipment((prev) => prev.filter((eq) => eq.id !== id)); // existing local state update
+  invalidateStaticCache(); // ADD THIS
 }
 ```
 
-Benefits:
-- Automatic background refetching when stale
-- Cache shared across components (if both pages use the same query key)
-- No module-level state needed
-- Cross-tab sync via `refetchOnWindowFocus`
+No `useRevalidator` is needed in the mutation pages themselves. The recipe list pages' loaders will pick up the fresh data naturally on the next navigation.
 
-### Option B: Cross-Tab Invalidation via Storage Events (If D10 not done yet)
+### Option B: Cross-Tab Invalidation via Storage Events (Optional enhancement)
 
-Add a `storage` event listener to invalidate cache when equipment/taste notes change in another tab:
+If same-tab stale data is considered the primary issue, the fix above is sufficient. For cross-tab consistency, add a `StorageEvent` broadcast when the cache is invalidated:
 
 ```ts
-// In a shared hook or provider
+// apps/web/src/api/static-cache.ts — extend the existing invalidate function
+export function invalidateStaticCache(): void {
+  _equipment = null;
+  _tasteNotes = null;
+  // Broadcast to other tabs
+  try {
+    localStorage.setItem('brewform-static-cache-bust', Date.now().toString());
+  } catch {
+    // ignore — private browsing may block localStorage
+  }
+}
+
+// In a shared hook or at router level, listen for the bust signal:
 useEffect(() => {
-  function handleStorageChange(e: StorageEvent) {
-    if (e.key === 'brewform-equipment-cache') {
-      cachedEquipment = null; // Invalidate
-      // Trigger re-fetch via callback or state
-    }
-    if (e.key === 'brewform-taste-notes-cache') {
-      cachedTasteNotes = null;
+  function handleStorage(e: StorageEvent) {
+    if (e.key === 'brewform-static-cache-bust') {
+      invalidateStaticCache();
+      // Loaders re-run on next navigation; no immediate revalidation needed
     }
   }
-  window.addEventListener('storage', handleStorageChange);
-  return () => window.removeEventListener('storage', handleStorageChange);
-}, []);
-
-// When updating equipment/taste notes in Settings:
-localStorage.setItem('brewform-equipment-cache', Date.now().toString());
-```
-
-### Option C: Simple Refetch on Focus (Minimal)
-
-Add `window.addEventListener('focus', ...)` to refetch when the user returns to the tab:
-
-```ts
-useEffect(() => {
-  function handleFocus() {
-    // Clear cache and refetch
-    cachedEquipment = null;
-    cachedTasteNotes = null;
-    equipmentApi.list().then((data) => { ... });
-    tasteApi.flat().then((data) => { ... });
-  }
-  window.addEventListener('focus', handleFocus);
-  return () => window.removeEventListener('focus', handleFocus);
+  window.addEventListener('storage', handleStorage);
+  return () => window.removeEventListener('storage', handleStorage);
 }, []);
 ```
 
-## Implementation Steps
+> **Note**: The `storage` event fires only in *other* tabs (not the one that wrote), which is the correct cross-tab invalidation behaviour.
 
-### If D10 (TanStack Query) is done:
+---
 
-1. Create `apps/web/src/hooks/queries/useEquipment.ts` with `useQuery`
-2. Create `apps/web/src/hooks/queries/useTasteNotes.ts` with `useQuery`
-3. Replace `cachedEquipment`/`cachedTasteNotes` usage in both pages with hook calls
-4. Remove module-level cache variables and `_resetStaticCache()` export
-5. Run `make check-web`
+## Implementation Steps (D10 done — React Router 7 loaders)
 
-### If D10 is not done:
+1. Open `apps/web/src/pages/equipment/EquipmentListPage.tsx`
+   - Add `import { invalidateStaticCache } from '../../api/static-cache.ts';`
+   - Call `invalidateStaticCache()` at the end of the `try` block in `handleCreate` (after the local state update)
+   - Call `invalidateStaticCache()` at the end of the `try` block in `handleDelete` (after the local state update)
 
-1. Create a shared hook `apps/web/src/hooks/useStaticData.ts` that encapsulates the cache logic
-2. Add `storage` event listener for cross-tab invalidation
-3. Replace direct module-level cache usage in both pages with the hook
-4. When equipment/taste notes are updated elsewhere, dispatch a storage event
-5. Run `make check-web`
+2. Open `apps/web/src/pages/admin/AdminEquipmentPage.tsx`
+   - Add `import { invalidateStaticCache } from '../../api/static-cache.ts';`
+   - Call `invalidateStaticCache()` at the end of the `try` block in `handleSubmit` (covers both create and edit paths, after `resetForm()`)
+   - Call `invalidateStaticCache()` at the end of the `try` block in `handleDelete` (after the local state update)
+
+3. Open `apps/web/src/pages/admin/AdminTasteNotesPage.tsx`
+   - Add `import { invalidateStaticCache } from '../../api/static-cache.ts';`
+   - Call `invalidateStaticCache()` at the end of the `try` block in `handleCreate` (after the local state update)
+   - Call `invalidateStaticCache()` at the end of the `try` block in `handleDelete` (after the local state update)
+
+4. ~~Remove module-level cache variables and `_resetStaticCache()` export~~ **[Corrected — see Error 5; nothing to remove; `invalidateStaticCache()` already exists in `static-cache.ts`]**
+
+5. *(Optional)* Implement Option B cross-tab storage broadcast in `static-cache.ts` and add a listener in `App.tsx` or a shared layout component
+
+6. Run `make check-web`
+
+---
 
 ## Testing Strategy
 
-- Open recipe list page in two tabs
-- In tab A, add a new piece of equipment via Settings
-- Switch to tab B — verify the new equipment appears in filter dropdowns (after refocus with Option C, or automatically with Option A)
-- Verify equipment filter still works after cache invalidation
-- Verify taste notes filter still works after cache invalidation
-- Check that module-level cache variables are removed
+- Navigate to `/equipment` in Tab A and create a new piece of equipment
+- Navigate to `/recipes` in the same tab — verify the new equipment appears immediately in the filter dropdown (confirms same-tab invalidation)
+- *(For Option B)* Create equipment in Tab A, then switch focus to Tab B and navigate to `/recipes` — verify the new equipment appears in the filter dropdown
+- Navigate to `/recipes/starred` — verify the same equipment list is fresh
+- Delete a piece of equipment via `/equipment`, navigate to `/recipes` — verify the deleted item is gone from the filter
+- Repeat the create/delete tests via the admin panel (`/admin/equipment`)
+- Create a new taste note via `/admin/taste-notes`, navigate to `/recipes` — verify the new taste note appears in the taste note filter
+- Run `make check-web` — no type errors
+
+---
 
 ## Risk Assessment
 
-- **Low**: Option A (TanStack Query) is the cleanest solution and handles everything automatically
-- **Medium**: Option B requires coordinating storage events across pages
-- **Low**: Option C is a minimal fix that improves freshness without full cache management
+- **Low**: The fix is mechanical — three files, one import each, one or two `invalidateStaticCache()` calls per mutation handler. No new abstractions, no new files, no new dependencies
+- **Low**: `invalidateStaticCache()` is already tested via the existing mocks in `RecipeListPage.test.tsx` and `StarredRecipesPage.test.tsx` which already mock `../../api/static-cache.ts`
+- **None**: No changes to `static-cache.ts`, `RecipeListPage.tsx`, or `StarredRecipesPage.tsx` are needed
+
+---
 
 ## Dependencies
 
-- **D10** (TanStack Query) — recommended path; Option A is cleanest if D10 is done first
-- **D11** (recipe list deduplication) — the shared hook/cache should be extracted once
+- ~~**D10** (TanStack Query) — recommended path~~ **[Corrected — D10 is done; it chose React Router 7 loaders, not TanStack Query]**
+- ~~**D11** (recipe list deduplication) — the shared hook/cache should be extracted once~~ **[Corrected — D11 is done; cache is already in `static-cache.ts`; no further extraction needed]**
+- **None**: This plan is self-contained and has no blocking dependencies
+
+---
 
 ## References
 
-- TanStack Query staleTime docs: https://tanstack.com/query/v4/docs/guides/stale-data
+- `apps/web/src/api/static-cache.ts` — cache module with the unused `invalidateStaticCache()`
+- `apps/web/src/pages/recipes/RecipeListPage.tsx` — consumes `getEquipmentCached()` / `getTasteNotesCached()` in its loader
+- `apps/web/src/pages/recipes/StarredRecipesPage.tsx` — same loader pattern
 - MDN StorageEvent: https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent
+- React Router `useRevalidator`: https://reactrouter.com/api/hooks/useRevalidator
+
+---
+
+## Summary of Corrections
+
+| # | Location in original plan | Error | Correction |
+|---|--------------------------|-------|------------|
+| 1 | Issue Description / Affected Files | Stated that `RecipeListPage.tsx:93-94` and `StarredRecipesPage.tsx:67-68` contain the module-level cache variables | Those files have been refactored. The cache now lives exclusively in `apps/web/src/api/static-cache.ts`. Neither page file contains module-level cache variables. |
+| 2 | Impact — "Duplicate code" bullet | Listed "Duplicate code: The cache logic is duplicated across both pages" as an active impact | Already resolved. `static-cache.ts` centralises the cache; neither page duplicates it. |
+| 3 | Root Cause | Described fetching as occurring in `useEffect` hooks on component mount | Data is fetched in React Router `loader` functions, not `useEffect` hooks. Component mount is not the fetch trigger. |
+| 4 | Fix Approach — Option A | Proposed creating TanStack Query `useQuery` hooks (`useEquipment`, `useTasteNotes`) as the recommended path | D10 was revised to use React Router 7 data loaders (already in use), not TanStack Query. No `@tanstack/react-query` dependency exists in `apps/web/package.json`. Option A is moot. The correct fix is to call `invalidateStaticCache()` at mutation sites. |
+| 5 | Implementation Steps — Step 4 | Said "Remove module-level cache variables and `_resetStaticCache()` export" | No module-level vars exist in the page files; nothing to remove there. The function is named `invalidateStaticCache()` (not `_resetStaticCache()`), it already exists in `static-cache.ts`, and it must be kept — not removed. |


### PR DESCRIPTION
## Summary

Fixes stale equipment and taste-note filter dropdowns by calling the existing `invalidateStaticCache()` function after every successful mutation, and adds cross-tab cache invalidation via `localStorage`.

## Problem

`apps/web/src/api/static-cache.ts` memoises the equipment list and flat taste-note tree in module-level variables so that React Router loaders (`RecipeListPage`, `StarredRecipesPage`, `RecipeDetailPage`) do not re-fetch on every navigation. However, `invalidateStaticCache()` — which nulls those slots — was **never called** from anywhere in the web workspace. Consequently:

- After creating or deleting equipment on `/equipment` or `/admin/equipment`, navigating back to `/recipes` still showed the pre-mutation snapshot in the filter dropdown.
- After creating or deleting a taste note on `/admin/taste-notes`, the tasting-notes selector on the detail page remained stale.
- The UI notice *"Creating taste notes will flush the taste note cache."* was inaccurate.

## What changed

### Same-tab invalidation
- `invalidateStaticCache()` is now called at the end of every successful mutation handler in:
  - `EquipmentListPage` (`handleCreate`, `handleDelete`)
  - `AdminEquipmentPage` (`handleSubmit` — covers create + edit, `handleDelete`)
  - `AdminTasteNotesPage` (`handleCreate`, `handleDelete`)
- The function is **not** called when the underlying API request rejects, preserving the existing correct cache state.

### Cross-tab invalidation
- `invalidateStaticCache()` now broadcasts a cache-bust marker to other browser tabs:
  ```ts
  localStorage.setItem('brewform-static-cache-bust', String(Date.now()));
  ```
  Wrapped in `try/catch` so Safari private mode (which throws on `setItem`) does not break the same-tab fix.
- New hook `useStaticCacheSync()` listens for the browser `storage` event and calls `invalidateStaticCache()` when the bust key is written by another tab. Mounted once in `App.tsx`.

### Logging & documentation
- Added module-scoped loggers and mount/unmount debug logs to all three mutation pages (per `AGENTS.md` logging requirements).
- Added JSDoc to every new and updated function.
- Added `htmlFor`/`id` associations to form inputs in the three mutation pages for accessibility and testability.

### Tests
- `apps/web/src/api/static-cache.test.ts` — 6 tests covering memoisation, invalidation, localStorage broadcast, and error swallowing.
- `apps/web/src/hooks/useStaticCacheSync.test.ts` — 4 tests covering listener registration/removal and key filtering.
- `apps/web/src/pages/equipment/EquipmentListPage.test.tsx` — 6 tests covering create/delete success and failure.
- `apps/web/src/pages/admin/AdminEquipmentPage.test.tsx` — 7 tests covering create/edit/delete success and failure.
- `apps/web/src/pages/admin/AdminTasteNotesPage.test.tsx` — 5 tests covering create/delete success and failure.

## Files changed

**Modified (5)**
- `apps/web/src/api/static-cache.ts`
- `apps/web/src/App.tsx`
- `apps/web/src/pages/equipment/EquipmentListPage.tsx`
- `apps/web/src/pages/admin/AdminEquipmentPage.tsx`
- `apps/web/src/pages/admin/AdminTasteNotesPage.tsx`

**Added (5)**
- `apps/web/src/hooks/useStaticCacheSync.ts`
- `apps/web/src/api/static-cache.test.ts`
- `apps/web/src/hooks/useStaticCacheSync.test.ts`
- `apps/web/src/pages/equipment/EquipmentListPage.test.tsx`
- `apps/web/src/pages/admin/AdminEquipmentPage.test.tsx`
- `apps/web/src/pages/admin/AdminTasteNotesPage.test.tsx`

## Verification

```bash
make fmt   # passes
make lint  # zero warnings
make check # zero type errors across all workspaces
make test  # 761/761 tests pass
```

## Risk

**Low.** No new dependencies, no backend changes, no database migrations, no breaking API changes. The only behavioural change is calling the previously-unused `invalidateStaticCache()` at the correct time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale cached data issue—equipment and taste notes now refresh automatically after create, edit, or delete operations.

* **New Features**
  * Added automatic cache synchronization across browser tabs for real-time data consistency.

* **Accessibility**
  * Improved form field associations for better screen reader support in equipment and taste note management forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->