### PR TITLE
D16: Fix account deletion flow on Settings page

### DIFF
--- a/apps/web/src/pages/settings/SettingsPage.test.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.test.tsx
@@ -1,0 +1,353 @@
+// ── Module-level mocks (hoisted by Vitest — MUST come before imports) ──
+
+vi.mock('../../contexts/I18nContext.tsx', () => ({
+  I18nProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useTranslation: vi.fn(),
+}));
+
+vi.mock('../../contexts/AuthContext.tsx', () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../contexts/ThemeContext.tsx', () => ({
+  useTheme: vi.fn(),
+}));
+
+vi.mock('../../api/client.ts', () => ({
+  api: { get: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('@/utils/logger.ts', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../../components/seo/SEOHead.tsx', () => ({
+  SEOHead: () => null,
+}));
+
+// ── Imports (after all vi.mock calls) ──
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { useAuth } from '../../contexts/AuthContext.tsx';
+import { useTranslation } from '../../contexts/I18nContext.tsx';
+import { useTheme } from '../../contexts/ThemeContext.tsx';
+import { api } from '../../api/client.ts';
+import { loader, SettingsPage } from './SettingsPage.tsx';
+
+// ── Typed mock references ──
+
+const mockUseAuth = vi.mocked(useAuth);
+const mockUseTranslation = vi.mocked(useTranslation);
+const mockUseTheme = vi.mocked(useTheme);
+const mockApi = vi.mocked(api);
+
+// ── Shared mock state ──
+
+const mockLogout = vi.fn();
+const authenticatedUser = {
+  id: 'user-1',
+  email: 'alice@example.com',
+  emailVerifiedAt: null,
+  username: 'alice',
+  displayName: 'Alice',
+  avatarUrl: null,
+  isAdmin: false,
+  onboardingCompleted: true,
+};
+
+const mockPreferences = {
+  unitSystem: 'metric' as const,
+  temperatureUnit: 'celsius' as const,
+  locale: 'en',
+  timezone: 'UTC',
+  dateFormat: 'YYYY_MM_DD',
+  emailNotifications: {
+    newFollower: true,
+    recipeLiked: true,
+    recipeCommented: false,
+    followedUserPosted: true,
+  },
+};
+
+// ── Translation tables ──
+
+const enT = (key: string) => {
+  const map: Record<string, string> = {
+    'settings.title': 'Settings',
+    'settings.profile': 'Profile',
+    'settings.appearance': 'Appearance',
+    'settings.displayName': 'Display Name',
+    'settings.notSet': 'Not set',
+    'auth.username': 'Username',
+    'auth.email': 'Email',
+    'settings.saving': 'Saving...',
+    'settings.savePreferences': 'Save Preferences',
+    'settings.saveNotifications': 'Save Notifications',
+    'settings.unitSystem.metric': 'Metric (g, ml, °C)',
+    'settings.unitSystem.imperial': 'Imperial (oz, fl oz, °F)',
+    'settings.temperatureUnit.celsius': 'Celsius',
+    'settings.temperatureUnit.fahrenheit': 'Fahrenheit',
+    'settings.emailNotifications': 'Email Notifications',
+    'settings.notif.newFollower': 'New follower',
+    'settings.notif.recipeLiked': 'Recipe liked',
+    'settings.notif.recipeCommented': 'Recipe commented',
+    'settings.notif.followedUserPosted': 'Followed user posted',
+    'settings.dangerZone': 'Danger Zone',
+    'settings.dangerZoneDesc': 'Permanently delete your account and all your data.',
+    'settings.deleteAccountBtn': 'Delete Account',
+    'settings.deleteConfirm': 'Are you sure? This action cannot be undone.',
+    'settings.savedMsg': 'Preferences saved!',
+    'settings.failedMsg': 'Failed to save preferences.',
+    'settings.deleteFailed': 'Account deletion failed.',
+    'settings.dateFormat': 'Date Format',
+    'preferences.title': 'Preferences',
+    'preferences.unitSystem': 'Unit System',
+    'preferences.temperature': 'Temperature Unit',
+    'preferences.theme': 'Theme',
+    'preferences.locale': 'Language',
+    'preferences.timezone': 'Timezone',
+    'preferences.dateFormat': 'Date Format',
+    'theme.light': 'Light Roast',
+    'theme.dark': 'Dark Roast',
+    'theme.coffee': 'Medium Roast',
+  };
+  return map[key] ?? key;
+};
+
+const trT = (key: string) => {
+  const map: Record<string, string> = {
+    'settings.title': 'Ayarlar',
+    'settings.deleteAccountBtn': 'Hesabı Sil',
+    'settings.deleteConfirm': 'Emin misiniz? Bu işlem geri alınamaz.',
+    'settings.deleteFailed': 'Hesap silinemedi.',
+    'settings.savedMsg': 'Tercihler kaydedildi!',
+    'settings.failedMsg': 'Tercihler kaydedilemedi.',
+    'settings.savePreferences': 'Tercihleri Kaydet',
+    'settings.saveNotifications': 'Bildirimleri Kaydet',
+    'settings.saving': 'Kaydediliyor...',
+    'settings.dangerZone': 'Tehlikeli Bölge',
+    'settings.dangerZoneDesc':
+      'Hesabınızı ve tüm verilerinizi kalıcı olarak silin. Bu geri alınamaz.',
+    'preferences.title': 'Tercihler',
+  };
+  return map[key] ?? key;
+};
+
+function renderSettingsPage(
+  options: { locale?: 'en' | 'tr'; auth?: Partial<ReturnType<typeof useAuth>> } = {},
+) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: <div data-testid='home-page'>Home Page</div>,
+      },
+      {
+        path: '/settings',
+        element: <SettingsPage />,
+        loader,
+      },
+    ],
+    { initialEntries: ['/settings'] },
+  );
+
+  const t = options.locale === 'tr' ? trT : enT;
+  mockUseTranslation.mockReturnValue({
+    locale: options.locale ?? 'en',
+    setLocale: vi.fn(),
+    t,
+    availableLocales: ['en', 'tr'],
+  });
+
+  mockUseAuth.mockReturnValue({
+    user: authenticatedUser,
+    isAuthenticated: true,
+    isLoading: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: mockLogout,
+    refreshUser: vi.fn(),
+    ...options.auth,
+  });
+
+  mockUseTheme.mockReturnValue({
+    theme: 'light',
+    setTheme: vi.fn(),
+  });
+
+  mockApi.get.mockResolvedValue(mockPreferences);
+  mockApi.patch.mockResolvedValue({});
+  mockApi.delete.mockResolvedValue({});
+
+  const renderResult = render(<RouterProvider router={router} />);
+
+  return { ...renderResult, router };
+}
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.get.mockResolvedValue(mockPreferences);
+    mockApi.patch.mockResolvedValue({});
+    mockApi.delete.mockResolvedValue({});
+  });
+
+  describe('Delete Account', () => {
+    it('logs out and navigates home on successful deletion', async () => {
+      const user = userEvent.setup();
+      const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+      const { router } = renderSettingsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Delete Account')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Delete Account'));
+
+      await waitFor(() => {
+        expect(mockApi.delete).toHaveBeenCalledWith('/users/me');
+        expect(mockLogout).toHaveBeenCalledOnce();
+        expect(router.state.location.pathname).toBe('/');
+      });
+
+      confirmSpy.mockRestore();
+    });
+
+    it('does nothing when dialog is cancelled', async () => {
+      const user = userEvent.setup();
+      const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(false);
+      renderSettingsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Delete Account')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Delete Account'));
+
+      expect(mockApi.delete).not.toHaveBeenCalled();
+      expect(mockLogout).not.toHaveBeenCalled();
+
+      confirmSpy.mockRestore();
+    });
+
+    it('shows error banner on failure in English', async () => {
+      const user = userEvent.setup();
+      const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+      mockApi.delete.mockRejectedValueOnce(new Error('Network error'));
+
+      renderSettingsPage({ locale: 'en' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Delete Account')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Delete Account'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Account deletion failed.')).toBeInTheDocument();
+      });
+
+      expect(mockLogout).not.toHaveBeenCalled();
+
+      confirmSpy.mockRestore();
+    });
+
+    it('shows error banner on failure in Turkish', async () => {
+      const user = userEvent.setup();
+      const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+      mockApi.delete.mockRejectedValueOnce(new Error('Network error'));
+
+      renderSettingsPage({ locale: 'tr' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Hesabı Sil')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Hesabı Sil'));
+
+      await waitFor(() => {
+        const banner = screen.getByText('Hesap silinemedi.');
+        expect(banner).toBeInTheDocument();
+        expect(banner.style.backgroundColor).toBe('var(--error)');
+      });
+
+      expect(mockLogout).not.toHaveBeenCalled();
+
+      confirmSpy.mockRestore();
+    });
+  });
+
+  describe('Preferences save (messageType regression)', () => {
+    it('shows success banner with green styling', async () => {
+      const user = userEvent.setup();
+      mockApi.patch.mockResolvedValueOnce({});
+
+      renderSettingsPage({ locale: 'en' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Save Preferences')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Save Preferences'));
+
+      await waitFor(() => {
+        const banner = screen.getByText('Preferences saved!');
+        expect(banner).toBeInTheDocument();
+        expect(banner.style.backgroundColor).toBe('var(--success)');
+      });
+    });
+
+    it('shows error banner with red styling', async () => {
+      const user = userEvent.setup();
+      mockApi.patch.mockRejectedValueOnce(new Error('Save failed'));
+
+      renderSettingsPage({ locale: 'tr' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Tercihleri Kaydet')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Tercihleri Kaydet'));
+
+      await waitFor(() => {
+        const banner = screen.getByText('Tercihler kaydedilemedi.');
+        expect(banner).toBeInTheDocument();
+        expect(banner.style.backgroundColor).toBe('var(--error)');
+      });
+    });
+  });
+
+  describe('Deletion error banner styling', () => {
+    it('renders deletion error with red background', async () => {
+      const user = userEvent.setup();
+      const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+      mockApi.delete.mockRejectedValueOnce(new Error('Server error'));
+
+      renderSettingsPage({ locale: 'en' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Delete Account')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Delete Account'));
+
+      await waitFor(() => {
+        const banner = screen.getByText('Account deletion failed.');
+        expect(banner).toBeInTheDocument();
+        expect(banner.style.backgroundColor).toBe('var(--error)');
+      });
+
+      confirmSpy.mockRestore();
+    });
+  });
+});

--- a/apps/web/src/pages/settings/SettingsPage.test.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../../components/seo/SEOHead.tsx', () => ({
 
 // ── Imports (after all vi.mock calls) ──
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -200,6 +200,10 @@ describe('SettingsPage', () => {
     mockApi.get.mockResolvedValue(mockPreferences);
     mockApi.patch.mockResolvedValue({});
     mockApi.delete.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe('Delete Account', () => {

--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -39,6 +39,13 @@ export function SettingsPage() {
   const [message, setMessage] = useState('');
   const [messageType, setMessageType] = useState<'success' | 'error' | null>(null);
 
+  useEffect(() => {
+    log.debug({}, 'SettingsPage mounted');
+    return () => {
+      log.debug({}, 'SettingsPage unmounted');
+    };
+  }, []);
+
   /**
    * Persist preferences to the server and refresh the local user state.
    *
@@ -105,13 +112,6 @@ export function SettingsPage() {
   }
 
   if (!user) return null;
-
-  useEffect(() => {
-    log.debug({}, 'SettingsPage mounted');
-    return () => {
-      log.debug({}, 'SettingsPage unmounted');
-    };
-  }, []);
 
   return (
     <div className='mx-auto max-w-2xl px-6 py-8'>

--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useLoaderData } from 'react-router';
+import { useLoaderData, useNavigate } from 'react-router';
 import { useAuth } from '../../contexts/AuthContext.tsx';
 import { useTheme } from '../../contexts/ThemeContext.tsx';
 import { useTranslation } from '../../contexts/I18nContext.tsx';
@@ -29,13 +29,15 @@ export const loader = async () => {
 };
 
 export function SettingsPage() {
-  const { user, refreshUser } = useAuth();
+  const { user, refreshUser, logout } = useAuth();
   const { theme, setTheme } = useTheme();
   const { locale, setLocale, availableLocales, t } = useTranslation();
+  const navigate = useNavigate();
   const { preferences } = useLoaderData<typeof loader>();
   const [prefs, setPrefs] = useState<Preferences>(preferences);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
+  const [messageType, setMessageType] = useState<'success' | 'error' | null>(null);
 
   /**
    * Persist preferences to the server and refresh the local user state.
@@ -48,6 +50,7 @@ export function SettingsPage() {
     if (!prefs) return;
     setSaving(true);
     setMessage('');
+    setMessageType(null);
     try {
       await api.patch('/preferences', {
         unitSystem: prefs.unitSystem,
@@ -58,8 +61,10 @@ export function SettingsPage() {
         emailNotifications: prefs.emailNotifications,
       } as Record<string, unknown>);
       setMessage(t('settings.savedMsg'));
+      setMessageType('success');
     } catch {
       setMessage(t('settings.failedMsg'));
+      setMessageType('error');
     } finally {
       setSaving(false);
     }
@@ -73,11 +78,29 @@ export function SettingsPage() {
     }
   }
 
+  /**
+   * Delete the current user's account and clean up frontend state.
+   *
+   * Calls {@link logout} to clear {@link AuthContext} (sets user to {@code null}, then
+   * attempts the server-side logout endpoint — expected to fail since the account is
+   * already deleted, but the local state cleanup always runs). Then calls
+   * {@link navigate} to redirect to the public home page ({@code /}).
+   *
+   * On failure the error is logged and a user-facing error message is displayed via the
+   * shared banner. The auth state is preserved so the user can retry.
+   */
   async function handleDeleteAccount() {
     if (!globalThis.confirm(t('settings.deleteConfirm'))) return;
+    setMessage('');
+    setMessageType(null);
     try {
       await api.delete('/users/me');
-    } catch {
+      await logout();
+      navigate('/');
+    } catch (err) {
+      log.error({ err }, 'Account deletion failed');
+      setMessage(t('settings.deleteFailed'));
+      setMessageType('error');
     }
   }
 
@@ -102,9 +125,7 @@ export function SettingsPage() {
         <div
           className='mb-4 rounded p-3 text-sm'
           style={{
-            backgroundColor: message.includes('Failed') || message.includes('kaydedilemedi')
-              ? 'var(--error)'
-              : 'var(--success)',
+            backgroundColor: messageType === 'error' ? 'var(--error)' : 'var(--success)',
             color: 'white',
           }}
         >

--- a/openspec/changes/archive/2026-06-08-d16-fix-account-deletion/design.md
+++ b/openspec/changes/archive/2026-06-08-d16-fix-account-deletion/design.md
@@ -1,0 +1,133 @@
+## Context
+
+`SettingsPage.tsx` is a client-side React component rendered under `<RequireAuth>` at route
+`/settings`. It loads user preferences via a `loader` (which calls `GET /preferences`) and
+renders sections for profile info, appearance, preferences, email notifications, and a danger
+zone with a "Delete Account" button.
+
+The current deletion handler (lines 76-82) calls `api.delete('/users/me')` and does nothing
+else — no state cleanup, no redirect, no error handling. This design doc captures the
+decisions made to close that gap.
+
+## Decisions
+
+### 1. Order of operations: logout → navigate
+
+The handler calls `await logout()` (which sets `AuthContext.user` to `null` via
+`setUser(null)`) and THEN calls `navigate('/')`. This order is intentional:
+
+- `/` is a public route (no `RequireAuth` guard), so navigating with a null user is safe.
+- If we navigated before logout, the HomePage would briefly mount with stale auth state
+  before `setUser(null)` fires.
+- `logout()` is async but the only async part is `authApi.logout()` which is expected to fail
+  after account deletion (the session/cookie is already invalid). The error is caught and
+  ignored; `setUser(null)` always runs.
+
+Alternative considered: calling `navigate('/login')` directly. Rejected because `/login` may
+redirect back if the router has a pending navigation state, and the idiomatic flow for
+post-deletion is the home page.
+
+### 2. Explicit `messageType` state for error-vs-success styling
+
+The current display logic at line 105:
+
+```tsx
+backgroundColor: message.includes('Failed') || message.includes('kaydedilemedi')
+  ? 'var(--error)' : 'var(--success)',
+```
+
+is fragile. It requires every error translation to coincidentally contain the substring
+`"Failed"` (English) or `"kaydedilemedi"` (Turkish). The proposed `settings.deleteFailed`
+translations — `"Account deletion failed."` (en) and `"Hesap silinemedi."` (tr) — match
+neither substring, so both would render with the green success background.
+
+**Decision**: Replace substring matching with an explicit discriminated union:
+
+```ts
+const [messageType, setMessageType] = useState<'success' | 'error' | null>(null);
+```
+
+All message-setting code paths explicitly set the type:
+
+| Code path | `setMessage(...)` | `setMessageType(...)` |
+|-----------|-------------------|----------------------|
+| `savePreferences` start | `''` | `null` |
+| `savePreferences` success | `t('settings.savedMsg')` | `'success'` |
+| `savePreferences` failure | `t('settings.failedMsg')` | `'error'` |
+| `handleDeleteAccount` start | `''` | `null` |
+| `handleDeleteAccount` failure | `t('settings.deleteFailed')` | `'error'` |
+
+The JSX condition becomes:
+
+```tsx
+backgroundColor: messageType === 'error' ? 'var(--error)' : 'var(--success)',
+```
+
+This is language-agnostic and immune to translation changes. It does not change the visual
+behavior for existing flows (`settings.savedMsg` / `settings.failedMsg`).
+
+### 3. Using `api.delete('/users/me')` directly vs `userApi.deleteAccount()`
+
+The web API module at `apps/web/src/api/index.ts:32` already defines:
+
+```ts
+deleteAccount: () => api.delete<{ message: string }>('/users/me'),
+```
+
+Switching to `userApi.deleteAccount()` would add type safety on the response shape and follow
+the module's encapsulation pattern. However, the SettingsPage currently imports only `{ api }`
+from `'../../api/client.ts'`, not from `'../../api/index.ts'`. Switching would require
+changing the import and changing another file — adding surface area beyond the fix.
+
+**Decision**: Keep using `api.delete('/users/me')` directly. The endpoint string is stable and
+the response shape is not consumed (the handler ignores the response and immediately logs out).
+A follow-up refactor can centralize all raw `api.delete('/users/me')` call sites to
+`userApi.deleteAccount()`.
+
+### 4. Clearing stale messages before deletion
+
+`savePreferences` calls `setMessage('')` at the top before making the API call. The current
+`handleDeleteAccount` does not. If a user saves preferences (getting a success/error banner),
+then immediately deletes their account, the stale banner persists during the deletion
+confirmation dialog and briefly after.
+
+**Decision**: Call `setMessage('')` and `setMessageType(null)` at the start of
+`handleDeleteAccount`, matching the `savePreferences` pattern.
+
+### 5. Test approach
+
+**Decision**: Create a new test file at `apps/web/src/pages/settings/SettingsPage.test.tsx`
+using the established Vitest + Testing Library + React Router memory router pattern.
+
+The test file follows the conventions observed across 48 existing web test files:
+
+- **Module-level `vi.mock()` hoisting** for I18nContext, AuthContext, ThemeContext, API client,
+  logger, and SEOHead — all declared before any imports, matching the lazy import pattern.
+- **`createMemoryRouter` + `RouterProvider`** for rendering the page with its loader.
+- **`vi.mocked()`** for typed mock references.
+- **Translation mock** returning a simple `Record<string, string>` lookup for both `en` and
+  `tr` locales.
+- **Auth mock** with `logout: vi.fn()` to assert it was called.
+- **`globalThis.confirm`** stubbed via `vi.spyOn(globalThis, 'confirm')` for accept/cancel
+  scenarios.
+- **`fireEvent.click`** or **`userEvent`** for triggering the Delete Account button.
+- **`waitFor`** for async assertions (navigation, error banner visibility).
+
+The test file is colocated alongside the source (`SettingsPage.test.tsx` next to
+`SettingsPage.tsx`), matching the pattern used by `LoginPage.test.tsx`,
+`RecipeListPage.test.tsx`, and 42 other page/component test files.
+
+## Risks / Trade-offs
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `authApi.logout()` inside `logout()` hits the server with an already-invalidated session (account deleted) | Near-certain | `logout()` catches and ignores the error; `setUser(null)` runs unconditionally |
+| Flash of null content between `setUser(null)` and `navigate('/')` | Low | React 18 batches the state update with the navigation, and `/` is a fast-mounting page |
+| The `messageType` refactor accidentally changes color for existing flows | None | Every existing `setMessage()` call is updated to also set `messageType`; the mapping is 1:1 with the old substring behavior |
+| Turkish error messages could still render green for future additions | None | `messageType` is explicit per call site, not derived from translation content |
+| Test assertions on `navigate('/')` via router state are fragile | Low | React Router's `createMemoryRouter` exposes `state.location.pathname` as a stable API; all 48 existing tests rely on it |
+
+## Open Questions
+
+None. This is a straightforward frontend-only fix with tests covering the new and modified
+behavior.

--- a/openspec/changes/archive/2026-06-08-d16-fix-account-deletion/proposal.md
+++ b/openspec/changes/archive/2026-06-08-d16-fix-account-deletion/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+After a user deletes their account via Settings → Danger Zone → "Delete Account", the
+deletion handler at `apps/web/src/pages/settings/SettingsPage.tsx:76-82` calls
+`api.delete('/users/me')` but never clears auth state or redirects. The user remains on the
+Settings page with stale UI — their data still renders, the nav shows they're logged in, but
+their account no longer exists server-side. Any subsequent API call fails with 401/404, and
+the user has no idea what happened.
+
+The handler also swallows errors silently: the `catch` block is empty, so network failures or
+server errors leave zero feedback.
+
+Additionally, the error-vs-success message color logic at line 105 uses fragile
+language-specific substring matching (`message.includes('Failed') || message.includes('kaydedilemedi')`).
+This pattern cannot distinguish error from success for any message that doesn't happen to
+contain one of those two magic strings — a bug that surfaces immediately when adding new error
+translations.
+
+## What Changes
+
+- **`SettingsPage.tsx`** — Extend the deletion handler to call `logout()` and
+  `navigate('/')` after a successful `DELETE /users/me`. Add proper error handling with
+  structured logging and a user-facing error message. Clear any stale message before starting
+  deletion (consistent with `savePreferences`). Add a JSDoc block documenting the function's
+  behavior and side effects.
+
+- **`SettingsPage.tsx`** — Replace the fragile substring-matching message color logic with an
+  explicit `messageType` state discriminated as `'success' | 'error' | null`. Update all
+  `setMessage()` call sites (`savePreferences` and `handleDeleteAccount`) to also set
+  `messageType`. This makes the logic language-agnostic and prevents the same class of bugs
+  for all future translations.
+
+- **`packages/shared/src/i18n/en.json`** — Add `settings.deleteFailed` key for the English
+  deletion error message.
+
+- **`packages/shared/src/i18n/tr.json`** — Add `settings.deleteFailed` key for the Turkish
+  deletion error message.
+
+- **`apps/web/src/pages/settings/SettingsPage.test.tsx`** — New test file covering the
+  deletion flow (success, failure, cancel), message color logic (both locales), and the
+  `messageType` refactoring. Uses Vitest, Testing Library, and React Router memory router
+  matching the existing test patterns in the codebase.
+
+No backend changes. No schema changes. No new dependencies.
+
+## Capabilities
+
+### New Capability
+
+- **`account-deletion`**: Defines what happens when a user deletes their account through the
+  settings page — auth state cleanup, navigation, error messaging, logging, i18n coverage,
+  and automated test coverage.

--- a/openspec/changes/archive/2026-06-08-d16-fix-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/archive/2026-06-08-d16-fix-account-deletion/specs/account-deletion/spec.md
@@ -1,0 +1,228 @@
+## ADDED Requirements
+
+### Requirement: Post-deletion auth cleanup and redirect
+
+When a user successfully deletes their account via the Settings page, the application SHALL
+clear the local auth state (`AuthContext.user` set to `null`) and redirect the browser to the
+home page (`/`). The logout MUST happen before the navigation so the home page does not mount
+with stale auth state.
+
+The `logout()` function from `AuthContext` SHALL be used for auth cleanup. Even though its
+internal `authApi.logout()` call will likely fail against an already-deleted account's session,
+the function unconditionally calls `setUser(null)` after catching any errors, which is the
+critical side effect.
+
+The redirect target SHALL be `/` (the public home page), not `/login`. The home page is public
+and does not require authentication, so there is no redirect loop risk.
+
+#### Scenario: Successful deletion logs out and redirects
+
+- **GIVEN** a logged-in user on `/settings`
+- **WHEN** the user clicks "Delete Account", confirms the browser dialog, and `DELETE
+  /users/me` returns 200
+- **THEN** `AuthContext.user` is set to `null`
+- **AND** the browser navigates to `/`
+- **AND** the navbar shows Login/Sign Up links (not the user's avatar)
+- **AND** visiting `/settings` again redirects to `/login` (via `RequireAuth`)
+
+#### Scenario: Cancel dialog does nothing
+
+- **GIVEN** a logged-in user on `/settings`
+- **WHEN** the user clicks "Delete Account" and then cancels the `confirm()` dialog
+- **THEN** no API call is made, auth state is unchanged, and the user stays on `/settings`
+
+#### Scenario: Pre-existing message is cleared before deletion
+
+- **GIVEN** a user who previously saved preferences and sees a "Preferences saved!" (or "Failed
+  to save preferences.") banner
+- **WHEN** the user initiates account deletion (clicks the button, before confirmation)
+- **THEN** the banner is cleared (`setMessage('')` and `setMessageType(null)`)
+
+---
+
+### Requirement: Error handling with user-facing message and structured logging
+
+When `DELETE /users/me` fails for any reason (network error, 500, 401), the handler SHALL:
+
+1. Log the error via the existing `log` instance (`log.error({ err }, 'Account deletion
+   failed')`) following the structured logging rules in AGENTS.md.
+2. Display a user-facing error message via the existing banner using the
+   `settings.deleteFailed` translation key.
+3. NOT log out the user or redirect — the account still exists, so the user stays on the
+   Settings page.
+
+The error message SHALL be displayed with the error color (`var(--error)`), determined by the
+`messageType` state being set to `'error'`.
+
+#### Scenario: Network failure shows error message (English)
+
+- **GIVEN** a logged-in user on `/settings` with locale `en`
+- **WHEN** the user confirms deletion and the `DELETE /users/me` request fails (network error)
+- **THEN** a red banner appears with the text "Account deletion failed."
+- **AND** the user remains on `/settings` with their auth state intact
+- **AND** `log.error({ err }, 'Account deletion failed')` is emitted
+
+#### Scenario: Network failure shows error message (Turkish)
+
+- **GIVEN** a logged-in user on `/settings` with locale `tr`
+- **WHEN** the user confirms deletion and the `DELETE /users/me` request fails (network error)
+- **THEN** a red banner appears with the text "Hesap silinemedi."
+- **AND** the user remains on `/settings` with their auth state intact
+
+---
+
+### Requirement: Language-agnostic message color logic
+
+The Settings page error/success banner color SHALL NOT be determined by substring matching on
+the translated message text. Instead, an explicit `messageType` state variable discriminated as
+`'success' | 'error' | null` SHALL be maintained alongside the `message` text state.
+
+Every call to `setMessage()` within the `SettingsPage` component SHALL be paired with a
+corresponding `setMessageType()` call:
+
+| Context | `setMessage('...')` | `setMessageType(...)` |
+|----------|---------------------|----------------------|
+| Clearing message (reset) | `''` | `null` |
+| Preferences saved | `t('settings.savedMsg')` | `'success'` |
+| Preferences save failed | `t('settings.failedMsg')` | `'error'` |
+| Account deletion failed | `t('settings.deleteFailed')` | `'error'` |
+
+The JSX style condition SHALL be:
+
+```tsx
+backgroundColor: messageType === 'error' ? 'var(--error)' : 'var(--success)'
+```
+
+This replaces the current:
+
+```tsx
+backgroundColor: message.includes('Failed') || message.includes('kaydedilemedi')
+  ? 'var(--error)' : 'var(--success)'
+```
+
+#### Scenario: Preferences save success shows green
+
+- **GIVEN** a user on `/settings` with any locale
+- **WHEN** they click "Save Preferences" and the PATCH succeeds
+- **THEN** the banner shows with `var(--success)` background color
+
+#### Scenario: Preferences save failure shows red
+
+- **GIVEN** a user on `/settings` with any locale
+- **WHEN** they click "Save Preferences" and the PATCH fails
+- **THEN** the banner shows with `var(--error)` background color
+
+#### Scenario: Deletion failure shows red (English)
+
+- **GIVEN** a user on `/settings` with locale `en`
+- **WHEN** deletion fails
+- **THEN** the banner shows with `var(--error)` background color
+- **AND** the text is "Account deletion failed."
+
+#### Scenario: Deletion failure shows red (Turkish)
+
+- **GIVEN** a user on `/settings` with locale `tr`
+- **WHEN** deletion fails
+- **THEN** the banner shows with `var(--error)` background color
+- **AND** the text is "Hesap silinemedi."
+
+---
+
+### Requirement: JSDoc on `handleDeleteAccount`
+
+The `handleDeleteAccount` function SHALL carry a JSDoc block documenting its behavior,
+side effects (`logout()` clears auth state, `navigate('/')` redirects to home), and error
+handling path. The format SHALL follow the existing conventions in `SettingsPage.tsx`
+(existing JSDoc on `savePreferences` at line 40) and the codebase pattern of using
+`{@link ...}` inline tags for cross-references.
+
+#### Scenario: JSDoc exists on handleDeleteAccount
+
+- **WHEN** `apps/web/src/pages/settings/SettingsPage.tsx` is inspected
+- **THEN** the `handleDeleteAccount` function has a `/** ... */` JSDoc block above its
+  declaration
+
+---
+
+### Requirement: i18n coverage for deletion error
+
+The translation key `settings.deleteFailed` SHALL exist in both `packages/shared/src/i18n/en.json`
+and `packages/shared/src/i18n/tr.json`.
+
+The English value SHALL be `"Account deletion failed."`.
+
+The Turkish value SHALL be `"Hesap silinemedi."`.
+
+#### Scenario: English translation key exists
+
+- **GIVEN** the file `packages/shared/src/i18n/en.json`
+- **THEN** the key `settings.deleteFailed` exists with value `"Account deletion failed."`
+
+#### Scenario: Turkish translation key exists
+
+- **GIVEN** the file `packages/shared/src/i18n/tr.json`
+- **THEN** the key `settings.deleteFailed` exists with value `"Hesap silinemedi."`
+
+---
+
+### Requirement: Automated test coverage
+
+The deletion flow, message color logic, and `messageType` refactoring SHALL have automated
+test coverage in a new test file at `apps/web/src/pages/settings/SettingsPage.test.tsx`.
+
+The test file SHALL follow the established web test conventions:
+
+- Module-level `vi.mock()` hoisting for all external dependencies (contexts, API client,
+  logger, SEOHead)
+- `createMemoryRouter` + `RouterProvider` for rendering with the page's loader
+- `@testing-library/react` for rendering and queries
+- `@testing-library/user-event` or `fireEvent` for interactions
+- `@testing-library/jest-dom` matchers (via `test-setup.ts`)
+
+#### Scenario: Test file renders without crashing
+
+- **WHEN** `SettingsPage.test.tsx` is loaded by Vitest
+- **THEN** the module-level mocks compile and set up without errors
+
+#### Scenario: Successful deletion test
+
+- **GIVEN** `api.delete` resolves successfully and `globalThis.confirm` returns `true`
+- **WHEN** the Delete Account button is clicked
+- **THEN** `logout` (from `useAuth`) is called exactly once
+- **AND** the router navigates to `/`
+- **AND** `api.delete('/users/me')` is called exactly once
+
+#### Scenario: Failed deletion test
+
+- **GIVEN** `api.delete` rejects with an error and `globalThis.confirm` returns `true`
+- **WHEN** the Delete Account button is clicked and the dialog is confirmed
+- **THEN** the error banner is visible with the correct translated text
+- **AND** the banner has the error styling (`var(--error)` background)
+- **AND** `logout` is NOT called
+- **AND** the router remains on `/settings`
+
+#### Scenario: Cancel dialog test
+
+- **GIVEN** `globalThis.confirm` returns `false`
+- **WHEN** the Delete Account button is clicked
+- **THEN** `api.delete` is NOT called
+- **AND** `logout` is NOT called
+- **AND** the router remains on `/settings`
+
+#### Scenario: Preferences save success banner color (messageType regression)
+
+- **GIVEN** `api.patch` resolves successfully
+- **WHEN** the Save Preferences button is clicked
+- **THEN** the success message is visible with `var(--success)` background styling
+
+#### Scenario: Preferences save failure banner color (messageType regression)
+
+- **GIVEN** `api.patch` rejects
+- **WHEN** the Save Preferences button is clicked
+- **THEN** the error message is visible with `var(--error)` background styling
+
+#### Scenario: Turkish error message displays correctly
+
+- **GIVEN** locale is `tr` and `api.delete` rejects
+- **WHEN** the Delete Account button is clicked and confirmed
+- **THEN** the error banner displays "Hesap silinemedi." with red (`var(--error)`) background

--- a/openspec/changes/archive/2026-06-08-d16-fix-account-deletion/tasks.md
+++ b/openspec/changes/archive/2026-06-08-d16-fix-account-deletion/tasks.md
@@ -1,0 +1,595 @@
+## 1. Add `messageType` state and refactor message color logic
+
+- [x] 1.1 Open `apps/web/src/pages/settings/SettingsPage.tsx`. On line 39 (after
+  `const [message, setMessage] = useState('');`), add:
+
+  ```ts
+  const [messageType, setMessageType] = useState<'success' | 'error' | null>(null);
+  ```
+
+- [x] 1.2 In the `savePreferences` function (lines ~46-73), update each `setMessage()` call
+  to also set `messageType`:
+
+  a. At the start (where `setMessage('')` is called, around line 49): add
+     `setMessageType(null);` on the next line.
+
+  b. In the `try` block (where `setMessage(t('settings.savedMsg'))` is called, around line
+     58): add `setMessageType('success');` on the next line.
+
+  c. In the `catch` block (where `setMessage(t('settings.failedMsg'))` is called, around line
+     60): add `setMessageType('error');` on the next line.
+
+- [x] 1.3 Locate the message display JSX (the `{message && (` block). Replace the
+  `backgroundColor` line from:
+
+  ```tsx
+  backgroundColor: message.includes('Failed') || message.includes('kaydedilemedi')
+    ? 'var(--error)'
+    : 'var(--success)',
+  ```
+
+  to:
+
+  ```tsx
+  backgroundColor: messageType === 'error' ? 'var(--error)' : 'var(--success)',
+  ```
+
+  Note: the full JSX block spans lines ~96-107 (exact lines may shift after edits). Search
+  for `message.includes('Failed')` to find the exact location.
+
+- [x] 1.4 Run `make check` and `make check-web`. Confirm zero new type or lint errors.
+
+## 2. Update `handleDeleteAccount` with logout, navigate, error handling, and JSDoc
+
+- [x] 2.1 On line 2, extend the `react-router` import from:
+
+  ```ts
+  import { useLoaderData } from 'react-router';
+  ```
+
+  to:
+
+  ```ts
+  import { useLoaderData, useNavigate } from 'react-router';
+  ```
+
+- [x] 2.2 On line 32, add `logout` to the `useAuth()` destructuring:
+
+  ```ts
+  // Before:
+  const { user, refreshUser } = useAuth();
+  // After:
+  const { user, refreshUser, logout } = useAuth();
+  ```
+
+- [x] 2.3 After the `useState` declarations (after line 39, before `savePreferences`), add
+  the `useNavigate` hook:
+
+  ```ts
+  const navigate = useNavigate();
+  ```
+
+- [x] 2.4 Add a JSDoc block above `handleDeleteAccount` following the conventions in this
+  file (the existing `savePreferences` JSDoc at lines 40-46) and the codebase's `{@link}`
+  inline tag pattern:
+
+  ```ts
+  /**
+   * Delete the current user's account and clean up frontend state.
+   *
+   * Calls {@link logout} to clear {@link AuthContext} (sets user to {@code null}, then
+   * attempts the server-side logout endpoint — expected to fail since the account is
+   * already deleted, but the local state cleanup always runs). Then calls
+   * {@link navigate} to redirect to the public home page ({@code /}).
+   *
+   * On failure the error is logged and a user-facing error message is displayed via the
+   * shared banner. The auth state is preserved so the user can retry.
+   */
+  ```
+
+  Place this block immediately above `async function handleDeleteAccount()`.
+
+- [x] 2.5 Replace the body of `handleDeleteAccount` with:
+
+  ```ts
+  async function handleDeleteAccount() {
+    if (!globalThis.confirm(t('settings.deleteConfirm'))) return;
+    setMessage('');
+    setMessageType(null);
+    try {
+      await api.delete('/users/me');
+      await logout();
+      navigate('/');
+    } catch (err) {
+      log.error({ err }, 'Account deletion failed');
+      setMessage(t('settings.deleteFailed'));
+      setMessageType('error');
+    }
+  }
+  ```
+
+  Key points:
+  - `setMessage('')` and `setMessageType(null)` clear any stale banner (matching
+    `savePreferences` pattern).
+  - `await logout()` is called after successful deletion. Its internal `authApi.logout()` call
+    will most likely fail (account already deleted), but `setUser(null)` runs unconditionally
+    — which is the side effect we need.
+  - `navigate('/')` targets the public home page.
+  - The `catch` block logs the error with structured logging, then sets the error message and
+    message type.
+  - The user is NOT logged out or redirected on error — the account still exists.
+
+- [x] 2.6 Run `make check` and `make check-web`. Confirm zero new errors.
+
+## 3. Add i18n translation keys
+
+- [x] 3.1 Open `packages/shared/src/i18n/en.json`. The file is a single JSON object. Find the
+  `settings.failedMsg` entry. Add a new key on the next line:
+
+  ```json
+  "settings.deleteFailed": "Account deletion failed.",
+  ```
+
+  Verify: the JSON remains valid (trailing comma before this line if it's not the last key;
+  no trailing comma after if it IS the last key — use the existing file's pattern).
+
+- [x] 3.2 Open `packages/shared/src/i18n/tr.json`. Find `settings.failedMsg`. Add on the
+  next line:
+
+  ```json
+  "settings.deleteFailed": "Hesap silinemedi.",
+  ```
+
+- [x] 3.3 Run `make check` to confirm JSON validity and zero new errors.
+
+## 4. Create test file at `apps/web/src/pages/settings/SettingsPage.test.tsx`
+
+This test file follows the established patterns from the 48 existing `*.test.tsx` files.
+Key conventions:
+- Module-level `vi.mock()` calls BEFORE imports (Vitest hoists them)
+- `vi.mocked()` for typed mock references
+- `@testing-library/jest-dom` matchers auto-loaded via `test-setup.ts` (no explicit import
+  needed; `toBeInTheDocument()`, `toHaveBeenCalled()`, etc. work globally)
+- `createMemoryRouter` + `RouterProvider` for rendering pages with loaders
+- `globalThis.confirm` stubbed via `vi.spyOn(globalThis, 'confirm')`
+- `waitFor` for async assertions (navigation, banner appearance)
+
+> **Caveat — `userEvent` API style**: `@testing-library/user-event` v14+ requires calling
+> `userEvent.setup()` before use. The test snippets in this task use the direct
+> `await userEvent.click(...)` style. If the installed version is v14+, replace each
+> `await userEvent.click(...)` with:
+> ```ts
+> const user = userEvent.setup();
+> await user.click(...);
+> ```
+> Check one existing test (e.g., `LoginPage.test.tsx`) to confirm the convention before
+> writing. This is the only stylistic variability — the test logic, assertions, and mock
+> setup are correct regardless of which style the codebase uses.
+
+- [x] 4.1 Create the file `apps/web/src/pages/settings/SettingsPage.test.tsx` with the
+  following structure. The test file MUST follow this exact pattern — placing all `vi.mock()`
+  calls at module top-level BEFORE any imports:
+
+  ```tsx
+  // ── Module-level mocks (hoisted by Vitest — MUST come before imports) ──
+
+  vi.mock('../../contexts/I18nContext.tsx', () => ({
+    I18nProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useTranslation: vi.fn(),
+  }));
+
+  vi.mock('../../contexts/AuthContext.tsx', () => ({
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useAuth: vi.fn(),
+  }));
+
+  vi.mock('../../contexts/ThemeContext.tsx', () => ({
+    useTheme: vi.fn(),
+  }));
+
+  vi.mock('../../api/client.ts', () => ({
+    api: { get: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  }));
+
+  vi.mock('@/utils/logger.ts', () => ({
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  }));
+
+  vi.mock('../../components/seo/SEOHead.tsx', () => ({
+    SEOHead: () => null,
+  }));
+
+  // ── Imports (after all vi.mock calls) ──
+
+  import { describe, it, expect, vi, beforeEach } from 'vitest';
+  import { render, screen, waitFor } from '@testing-library/react';
+  import userEvent from '@testing-library/user-event';
+  import { createMemoryRouter, RouterProvider } from 'react-router';
+  import { useAuth } from '../../contexts/AuthContext.tsx';
+  import { useTranslation } from '../../contexts/I18nContext.tsx';
+  import { useTheme } from '../../contexts/ThemeContext.tsx';
+  import { api } from '../../api/client.ts';
+  import SettingsPage, { loader } from './SettingsPage.tsx';
+
+  // ── Typed mock references ──
+
+  const mockUseAuth = vi.mocked(useAuth);
+  const mockUseTranslation = vi.mocked(useTranslation);
+  const mockUseTheme = vi.mocked(useTheme);
+  const mockApi = vi.mocked(api);
+
+  // ── Shared mock state ──
+
+  const mockLogout = vi.fn();
+  const authenticatedUser = {
+    id: 'user-1',
+    email: 'alice@example.com',
+    emailVerifiedAt: null,
+    username: 'alice',
+    displayName: 'Alice',
+    avatarUrl: null,
+    isAdmin: false,
+    onboardingCompleted: true,
+  };
+
+  const mockPreferences = {
+    unitSystem: 'metric' as const,
+    temperatureUnit: 'celsius' as const,
+    locale: 'en',
+    timezone: 'UTC',
+    dateFormat: 'YYYY_MM_DD',
+    emailNotifications: {
+      newFollower: true,
+      recipeLiked: true,
+      recipeCommented: false,
+      followedUserPosted: true,
+    },
+  };
+  ```
+
+- [x] 4.2 Add the `beforeEach` hook and translation tables:
+
+  ```tsx
+  const enT = (key: string) => {
+    const map: Record<string, string> = {
+      'settings.title': 'Settings',
+      'settings.profile': 'Profile',
+      'settings.appearance': 'Appearance',
+      'settings.displayName': 'Display Name',
+      'settings.notSet': 'Not set',
+      'auth.username': 'Username',
+      'auth.email': 'Email',
+      'settings.saving': 'Saving...',
+      'settings.savePreferences': 'Save Preferences',
+      'settings.saveNotifications': 'Save Notifications',
+      'settings.unitSystem.metric': 'Metric (g, ml, °C)',
+      'settings.unitSystem.imperial': 'Imperial (oz, fl oz, °F)',
+      'settings.temperatureUnit.celsius': 'Celsius',
+      'settings.temperatureUnit.fahrenheit': 'Fahrenheit',
+      'settings.emailNotifications': 'Email Notifications',
+      'settings.notif.newFollower': 'New follower',
+      'settings.notif.recipeLiked': 'Recipe liked',
+      'settings.notif.recipeCommented': 'Recipe commented',
+      'settings.notif.followedUserPosted': 'Followed user posted',
+      'settings.dangerZone': 'Danger Zone',
+      'settings.dangerZoneDesc': 'Permanently delete your account and all your data.',
+      'settings.deleteAccountBtn': 'Delete Account',
+      'settings.deleteConfirm': 'Are you sure? This action cannot be undone.',
+      'settings.savedMsg': 'Preferences saved!',
+      'settings.failedMsg': 'Failed to save preferences.',
+      'settings.deleteFailed': 'Account deletion failed.',
+      'settings.dateFormat': 'Date Format',
+      'preferences.title': 'Preferences',
+      'preferences.unitSystem': 'Unit System',
+      'preferences.temperature': 'Temperature Unit',
+      'preferences.theme': 'Theme',
+      'preferences.locale': 'Language',
+      'preferences.timezone': 'Timezone',
+      'preferences.dateFormat': 'Date Format',
+      'theme.light': 'Light Roast',
+      'theme.dark': 'Dark Roast',
+      'theme.coffee': 'Medium Roast',
+    };
+    return map[key] ?? key;
+  };
+
+  const trT = (key: string) => {
+    const map: Record<string, string> = {
+      'settings.title': 'Ayarlar',
+      'settings.deleteAccountBtn': 'Hesabı Sil',
+      'settings.deleteConfirm': 'Emin misiniz? Bu işlem geri alınamaz.',
+      'settings.deleteFailed': 'Hesap silinemedi.',
+      'settings.savedMsg': 'Tercihler kaydedildi!',
+      'settings.failedMsg': 'Tercihler kaydedilemedi.',
+      'settings.savePreferences': 'Tercihleri Kaydet',
+      // Other keys fall back to key name (in practice not needed for assertion tests)
+    };
+    return map[key] ?? key;
+  };
+
+  function renderSettingsPage(
+    options: { locale?: 'en' | 'tr'; auth?: Partial<ReturnType<typeof useAuth>> } = {},
+  ) {
+    // Build the router with a home route (target of navigate('/')) and the settings route
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/',
+          element: <div data-testid='home-page'>Home Page</div>,
+        },
+        {
+          path: '/settings',
+          element: <SettingsPage />,
+          loader,
+        },
+      ],
+      { initialEntries: ['/settings'] },
+    );
+
+    // Set up translation mock
+    const t = options.locale === 'tr' ? trT : enT;
+    mockUseTranslation.mockReturnValue({
+      locale: options.locale ?? 'en',
+      setLocale: vi.fn(),
+      t,
+      availableLocales: ['en', 'tr'],
+    });
+
+    // Set up auth mock
+    mockUseAuth.mockReturnValue({
+      user: authenticatedUser,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: mockLogout,
+      refreshUser: vi.fn(),
+      ...options.auth,
+    });
+
+    // Set up theme mock
+    mockUseTheme.mockReturnValue({
+      theme: 'light',
+      setTheme: vi.fn(),
+    });
+
+    // Default API mocks
+    mockApi.get.mockResolvedValue(mockPreferences);
+    mockApi.patch.mockResolvedValue({});
+    mockApi.delete.mockResolvedValue({});
+
+    const renderResult = render(<RouterProvider router={router} />);
+
+    return { ...renderResult, router };
+  }
+  ```
+
+- [x] 4.3 Add a `beforeEach` at the top of the first `describe` block:
+
+  ```tsx
+  describe('SettingsPage', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      // Default API responses
+      mockApi.get.mockResolvedValue(mockPreferences);
+      mockApi.patch.mockResolvedValue({});
+      mockApi.delete.mockResolvedValue({});
+    });
+
+    // ... tests go here
+  });
+  ```
+
+- [x] 4.4 Add the test cases inside the `describe('SettingsPage', () => { ... })` block:
+
+  ```tsx
+    describe('Delete Account', () => {
+      it('logs out and navigates home on successful deletion', async () => {
+        const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+        const { router } = renderSettingsPage();
+
+        await waitFor(() => {
+          expect(screen.getByText('Delete Account')).toBeInTheDocument();
+        });
+
+        await userEvent.click(screen.getByText('Delete Account'));
+
+        await waitFor(() => {
+          expect(mockApi.delete).toHaveBeenCalledWith('/users/me');
+          expect(mockLogout).toHaveBeenCalledOnce();
+          expect(router.state.location.pathname).toBe('/');
+        });
+
+        confirmSpy.mockRestore();
+      });
+
+      it('does nothing when dialog is cancelled', async () => {
+        const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(false);
+        renderSettingsPage();
+
+        await waitFor(() => {
+          expect(screen.getByText('Delete Account')).toBeInTheDocument();
+        });
+
+        await userEvent.click(screen.getByText('Delete Account'));
+
+        expect(mockApi.delete).not.toHaveBeenCalled();
+        expect(mockLogout).not.toHaveBeenCalled();
+
+        confirmSpy.mockRestore();
+      });
+
+      it('shows error banner on failure in English', async () => {
+        const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+        mockApi.delete.mockRejectedValueOnce(new Error('Network error'));
+
+        renderSettingsPage({ locale: 'en' });
+
+        await waitFor(() => {
+          expect(screen.getByText('Delete Account')).toBeInTheDocument();
+        });
+
+        await userEvent.click(screen.getByText('Delete Account'));
+
+        await waitFor(() => {
+          expect(screen.getByText('Account deletion failed.')).toBeInTheDocument();
+        });
+
+        expect(mockLogout).not.toHaveBeenCalled();
+
+        confirmSpy.mockRestore();
+      });
+
+      it('shows error banner on failure in Turkish', async () => {
+        const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+        mockApi.delete.mockRejectedValueOnce(new Error('Network error'));
+
+        renderSettingsPage({ locale: 'tr' });
+
+        await waitFor(() => {
+          expect(screen.getByText('Hesabı Sil')).toBeInTheDocument();
+        });
+
+        await userEvent.click(screen.getByText('Hesabı Sil'));
+
+        await waitFor(() => {
+          expect(screen.getByText('Hesap silinemedi.')).toBeInTheDocument();
+        });
+
+        expect(mockLogout).not.toHaveBeenCalled();
+
+        confirmSpy.mockRestore();
+      });
+    });
+
+    describe('Preferences save (messageType regression)', () => {
+      it('shows success banner with green styling', async () => {
+        mockApi.patch.mockResolvedValueOnce({});
+
+        renderSettingsPage({ locale: 'en' });
+
+        await waitFor(() => {
+          expect(screen.getByText('Save Preferences')).toBeInTheDocument();
+        });
+
+        await userEvent.click(screen.getByText('Save Preferences'));
+
+        await waitFor(() => {
+          const banner = screen.getByText('Preferences saved!');
+          expect(banner).toBeInTheDocument();
+          expect(banner.style.backgroundColor).toBe('var(--success)');
+        });
+      });
+
+      it('shows error banner with red styling', async () => {
+        mockApi.patch.mockRejectedValueOnce(new Error('Save failed'));
+
+        renderSettingsPage({ locale: 'tr' });
+
+        await waitFor(() => {
+          expect(screen.getByText('Tercihleri Kaydet')).toBeInTheDocument();
+        });
+
+        await userEvent.click(screen.getByText('Tercihleri Kaydet'));
+
+        await waitFor(() => {
+          const banner = screen.getByText('Tercihler kaydedilemedi.');
+          expect(banner).toBeInTheDocument();
+          expect(banner.style.backgroundColor).toBe('var(--error)');
+        });
+      });
+    });
+
+    describe('Deletion error banner styling', () => {
+      it('renders deletion error with red background', async () => {
+        const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+        mockApi.delete.mockRejectedValueOnce(new Error('Server error'));
+
+        renderSettingsPage({ locale: 'en' });
+
+        await waitFor(() => {
+          expect(screen.getByText('Delete Account')).toBeInTheDocument();
+        });
+
+        await userEvent.click(screen.getByText('Delete Account'));
+
+        await waitFor(() => {
+          const banner = screen.getByText('Account deletion failed.');
+          expect(banner).toBeInTheDocument();
+          expect(banner.style.backgroundColor).toBe('var(--error)');
+        });
+
+        confirmSpy.mockRestore();
+      });
+    });
+  ```
+
+  The closing `});` for the outer `describe` block must be placed after all test cases.
+
+- [x] 4.5 Run `make test-web` (or `deno task --cwd apps/web test` inside Docker). All tests
+  MUST pass with zero failures.
+
+- [x] 4.6 Run `make check` and `make lint` to confirm zero new errors across all workspaces.
+
+## 5. Create PR description
+
+- [x] 5.1 Create a file `pr_description.md` in the repository root
+  (`/Users/arda.kilicdagi/projects/personal/BrewForm/pr_description.md`) with:
+
+  ```markdown
+  ## Summary
+
+  Fix account deletion not logging out the user or redirecting after account removal.
+
+  ## Problem
+
+  When a user deletes their account via Settings → Danger Zone → "Delete Account":
+  - The API call succeeds, but the user stays on the Settings page with stale auth state
+  - The navbar still shows the user as logged in
+  - Any subsequent action fails with 401/404 errors
+  - Errors are silently swallowed with no user feedback
+
+  ## Changes
+
+  ### `apps/web/src/pages/settings/SettingsPage.tsx`
+  - Added `logout` and `useNavigate` for post-deletion auth cleanup and redirect
+  - After successful deletion: logout (clear auth state) → navigate to home page
+  - On deletion failure: error banner with `settings.deleteFailed` translation + structured log
+  - Added JSDoc documenting `handleDeleteAccount` behavior and side effects
+  - Replaced fragile language-specific substring matching for banner color with explicit
+    `messageType` state (`'success' | 'error' | null`) — fixes a latent bug where non-English
+    error messages could render with green/success styling
+
+  ### `apps/web/src/pages/settings/SettingsPage.test.tsx` (new)
+  - Automated tests for: successful deletion, failed deletion (en + tr), cancel dialog,
+    banner color styling (messageType regression), preferences save (en + tr)
+
+  ### `packages/shared/src/i18n/en.json`
+  - Added `settings.deleteFailed`: "Account deletion failed."
+
+  ### `packages/shared/src/i18n/tr.json`
+  - Added `settings.deleteFailed`: "Hesap silinemedi."
+
+  ## Testing
+
+  `make test-web` — 6 new test cases covering:
+  - Successful deletion → redirected to `/`, logout called
+  - Cancel dialog → no API call, no logout
+  - Network error (English) → red error banner, user stays on page
+  - Network error (Turkish) → red error banner, user stays on page
+  - Preferences save success → green banner (messageType regression)
+  - Preferences save failure → red banner (messageType regression)
+
+  ## Risk
+
+  Low. Frontend-only change. No backend modifications. No schema changes. The `logout()`
+  function gracefully handles the expected failure of its internal API call against an
+  already-deleted account's session.
+  ```
+
+- [x] 5.2 Verify the file is well-formed and renders correctly in GitHub-flavored Markdown.

--- a/openspec/specs/account-deletion/spec.md
+++ b/openspec/specs/account-deletion/spec.md
@@ -1,7 +1,16 @@
 # account-deletion Specification
 
 ## Purpose
-TBD - created by archiving change d16-fix-account-deletion. Update Purpose after archive.
+
+Define the account-deletion capability for authenticated users. The Settings page exposes a
+"Delete Account" action in the Danger Zone that lets a user permanently remove their own
+account, their personal data, and any related sessions. After a successful deletion the
+frontend MUST clear local auth state and redirect to the public home page, leaving no
+half-authenticated UI. Failures (network errors, server errors) MUST be surfaced to the user
+through a translated banner so they can retry, and the user MUST stay authenticated until
+deletion actually succeeds. The capability exists so that "delete my account" reliably means
+"delete my account" — no stale session, no silent failures, no language-specific rendering
+bugs.
 ## Requirements
 ### Requirement: Post-deletion auth cleanup and redirect
 

--- a/openspec/specs/account-deletion/spec.md
+++ b/openspec/specs/account-deletion/spec.md
@@ -1,0 +1,232 @@
+# account-deletion Specification
+
+## Purpose
+TBD - created by archiving change d16-fix-account-deletion. Update Purpose after archive.
+## Requirements
+### Requirement: Post-deletion auth cleanup and redirect
+
+When a user successfully deletes their account via the Settings page, the application SHALL
+clear the local auth state (`AuthContext.user` set to `null`) and redirect the browser to the
+home page (`/`). The logout MUST happen before the navigation so the home page does not mount
+with stale auth state.
+
+The `logout()` function from `AuthContext` SHALL be used for auth cleanup. Even though its
+internal `authApi.logout()` call will likely fail against an already-deleted account's session,
+the function unconditionally calls `setUser(null)` after catching any errors, which is the
+critical side effect.
+
+The redirect target SHALL be `/` (the public home page), not `/login`. The home page is public
+and does not require authentication, so there is no redirect loop risk.
+
+#### Scenario: Successful deletion logs out and redirects
+
+- **GIVEN** a logged-in user on `/settings`
+- **WHEN** the user clicks "Delete Account", confirms the browser dialog, and `DELETE
+  /users/me` returns 200
+- **THEN** `AuthContext.user` is set to `null`
+- **AND** the browser navigates to `/`
+- **AND** the navbar shows Login/Sign Up links (not the user's avatar)
+- **AND** visiting `/settings` again redirects to `/login` (via `RequireAuth`)
+
+#### Scenario: Cancel dialog does nothing
+
+- **GIVEN** a logged-in user on `/settings`
+- **WHEN** the user clicks "Delete Account" and then cancels the `confirm()` dialog
+- **THEN** no API call is made, auth state is unchanged, and the user stays on `/settings`
+
+#### Scenario: Pre-existing message is cleared before deletion
+
+- **GIVEN** a user who previously saved preferences and sees a "Preferences saved!" (or "Failed
+  to save preferences.") banner
+- **WHEN** the user initiates account deletion (clicks the button, before confirmation)
+- **THEN** the banner is cleared (`setMessage('')` and `setMessageType(null)`)
+
+---
+
+### Requirement: Error handling with user-facing message and structured logging
+
+When `DELETE /users/me` fails for any reason (network error, 500, 401), the handler SHALL:
+
+1. Log the error via the existing `log` instance (`log.error({ err }, 'Account deletion
+   failed')`) following the structured logging rules in AGENTS.md.
+2. Display a user-facing error message via the existing banner using the
+   `settings.deleteFailed` translation key.
+3. NOT log out the user or redirect — the account still exists, so the user stays on the
+   Settings page.
+
+The error message SHALL be displayed with the error color (`var(--error)`), determined by the
+`messageType` state being set to `'error'`.
+
+#### Scenario: Network failure shows error message (English)
+
+- **GIVEN** a logged-in user on `/settings` with locale `en`
+- **WHEN** the user confirms deletion and the `DELETE /users/me` request fails (network error)
+- **THEN** a red banner appears with the text "Account deletion failed."
+- **AND** the user remains on `/settings` with their auth state intact
+- **AND** `log.error({ err }, 'Account deletion failed')` is emitted
+
+#### Scenario: Network failure shows error message (Turkish)
+
+- **GIVEN** a logged-in user on `/settings` with locale `tr`
+- **WHEN** the user confirms deletion and the `DELETE /users/me` request fails (network error)
+- **THEN** a red banner appears with the text "Hesap silinemedi."
+- **AND** the user remains on `/settings` with their auth state intact
+
+---
+
+### Requirement: Language-agnostic message color logic
+
+The Settings page error/success banner color SHALL NOT be determined by substring matching on
+the translated message text. Instead, an explicit `messageType` state variable discriminated as
+`'success' | 'error' | null` SHALL be maintained alongside the `message` text state.
+
+Every call to `setMessage()` within the `SettingsPage` component SHALL be paired with a
+corresponding `setMessageType()` call:
+
+| Context | `setMessage('...')` | `setMessageType(...)` |
+|----------|---------------------|----------------------|
+| Clearing message (reset) | `''` | `null` |
+| Preferences saved | `t('settings.savedMsg')` | `'success'` |
+| Preferences save failed | `t('settings.failedMsg')` | `'error'` |
+| Account deletion failed | `t('settings.deleteFailed')` | `'error'` |
+
+The JSX style condition SHALL be:
+
+```tsx
+backgroundColor: messageType === 'error' ? 'var(--error)' : 'var(--success)'
+```
+
+This replaces the current:
+
+```tsx
+backgroundColor: message.includes('Failed') || message.includes('kaydedilemedi')
+  ? 'var(--error)' : 'var(--success)'
+```
+
+#### Scenario: Preferences save success shows green
+
+- **GIVEN** a user on `/settings` with any locale
+- **WHEN** they click "Save Preferences" and the PATCH succeeds
+- **THEN** the banner shows with `var(--success)` background color
+
+#### Scenario: Preferences save failure shows red
+
+- **GIVEN** a user on `/settings` with any locale
+- **WHEN** they click "Save Preferences" and the PATCH fails
+- **THEN** the banner shows with `var(--error)` background color
+
+#### Scenario: Deletion failure shows red (English)
+
+- **GIVEN** a user on `/settings` with locale `en`
+- **WHEN** deletion fails
+- **THEN** the banner shows with `var(--error)` background color
+- **AND** the text is "Account deletion failed."
+
+#### Scenario: Deletion failure shows red (Turkish)
+
+- **GIVEN** a user on `/settings` with locale `tr`
+- **WHEN** deletion fails
+- **THEN** the banner shows with `var(--error)` background color
+- **AND** the text is "Hesap silinemedi."
+
+---
+
+### Requirement: JSDoc on `handleDeleteAccount`
+
+The `handleDeleteAccount` function SHALL carry a JSDoc block documenting its behavior,
+side effects (`logout()` clears auth state, `navigate('/')` redirects to home), and error
+handling path. The format SHALL follow the existing conventions in `SettingsPage.tsx`
+(existing JSDoc on `savePreferences` at line 40) and the codebase pattern of using
+`{@link ...}` inline tags for cross-references.
+
+#### Scenario: JSDoc exists on handleDeleteAccount
+
+- **WHEN** `apps/web/src/pages/settings/SettingsPage.tsx` is inspected
+- **THEN** the `handleDeleteAccount` function has a `/** ... */` JSDoc block above its
+  declaration
+
+---
+
+### Requirement: i18n coverage for deletion error
+
+The translation key `settings.deleteFailed` SHALL exist in both `packages/shared/src/i18n/en.json`
+and `packages/shared/src/i18n/tr.json`.
+
+The English value SHALL be `"Account deletion failed."`.
+
+The Turkish value SHALL be `"Hesap silinemedi."`.
+
+#### Scenario: English translation key exists
+
+- **GIVEN** the file `packages/shared/src/i18n/en.json`
+- **THEN** the key `settings.deleteFailed` exists with value `"Account deletion failed."`
+
+#### Scenario: Turkish translation key exists
+
+- **GIVEN** the file `packages/shared/src/i18n/tr.json`
+- **THEN** the key `settings.deleteFailed` exists with value `"Hesap silinemedi."`
+
+---
+
+### Requirement: Automated test coverage
+
+The deletion flow, message color logic, and `messageType` refactoring SHALL have automated
+test coverage in a new test file at `apps/web/src/pages/settings/SettingsPage.test.tsx`.
+
+The test file SHALL follow the established web test conventions:
+
+- Module-level `vi.mock()` hoisting for all external dependencies (contexts, API client,
+  logger, SEOHead)
+- `createMemoryRouter` + `RouterProvider` for rendering with the page's loader
+- `@testing-library/react` for rendering and queries
+- `@testing-library/user-event` or `fireEvent` for interactions
+- `@testing-library/jest-dom` matchers (via `test-setup.ts`)
+
+#### Scenario: Test file renders without crashing
+
+- **WHEN** `SettingsPage.test.tsx` is loaded by Vitest
+- **THEN** the module-level mocks compile and set up without errors
+
+#### Scenario: Successful deletion test
+
+- **GIVEN** `api.delete` resolves successfully and `globalThis.confirm` returns `true`
+- **WHEN** the Delete Account button is clicked
+- **THEN** `logout` (from `useAuth`) is called exactly once
+- **AND** the router navigates to `/`
+- **AND** `api.delete('/users/me')` is called exactly once
+
+#### Scenario: Failed deletion test
+
+- **GIVEN** `api.delete` rejects with an error and `globalThis.confirm` returns `true`
+- **WHEN** the Delete Account button is clicked and the dialog is confirmed
+- **THEN** the error banner is visible with the correct translated text
+- **AND** the banner has the error styling (`var(--error)` background)
+- **AND** `logout` is NOT called
+- **AND** the router remains on `/settings`
+
+#### Scenario: Cancel dialog test
+
+- **GIVEN** `globalThis.confirm` returns `false`
+- **WHEN** the Delete Account button is clicked
+- **THEN** `api.delete` is NOT called
+- **AND** `logout` is NOT called
+- **AND** the router remains on `/settings`
+
+#### Scenario: Preferences save success banner color (messageType regression)
+
+- **GIVEN** `api.patch` resolves successfully
+- **WHEN** the Save Preferences button is clicked
+- **THEN** the success message is visible with `var(--success)` background styling
+
+#### Scenario: Preferences save failure banner color (messageType regression)
+
+- **GIVEN** `api.patch` rejects
+- **WHEN** the Save Preferences button is clicked
+- **THEN** the error message is visible with `var(--error)` background styling
+
+#### Scenario: Turkish error message displays correctly
+
+- **GIVEN** locale is `tr` and `api.delete` rejects
+- **WHEN** the Delete Account button is clicked and confirmed
+- **THEN** the error banner displays "Hesap silinemedi." with red (`var(--error)`) background
+

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -311,6 +311,7 @@
   "settings.deleteConfirm": "Are you sure? This action cannot be undone.",
   "settings.savedMsg": "Preferences saved!",
   "settings.failedMsg": "Failed to save preferences.",
+  "settings.deleteFailed": "Account deletion failed.",
   "setup.newSetup": "+ New Setup",
   "setup.createSetup": "Create Setup",
   "setup.noSetups": "No setups yet. Create your first brewing setup!",

--- a/packages/shared/src/i18n/tr.json
+++ b/packages/shared/src/i18n/tr.json
@@ -311,6 +311,7 @@
   "settings.deleteConfirm": "Emin misiniz? Bu işlem geri alınamaz.",
   "settings.savedMsg": "Tercihler kaydedildi!",
   "settings.failedMsg": "Tercihler kaydedilemedi.",
+  "settings.deleteFailed": "Hesap silinemedi.",
   "setup.newSetup": "+ Yeni Kurulum",
   "setup.createSetup": "Kurulum Oluştur",
   "setup.noSetups": "Henüz kurulum yok. İlk demleme kurulumunuzu oluşturun!",

--- a/plans/D16-fix-account-deletion.md
+++ b/plans/D16-fix-account-deletion.md
@@ -9,7 +9,7 @@
 After a user successfully deletes their account via the Settings page, they remain "logged in" with stale state. The deletion handler calls the API but doesn't clear the auth state or redirect:
 
 ```ts
-// SettingsPage.tsx:57-63
+// SettingsPage.tsx:76-82
 async function handleDeleteAccount() {
   if (!globalThis.confirm(t('settings.deleteConfirm'))) return;
   try {
@@ -33,16 +33,19 @@ The `handleDeleteAccount` function doesn't call `logout()` from `AuthContext` or
 
 | File | Lines | Description |
 |------|-------|-------------|
-| `apps/web/src/pages/settings/SettingsPage.tsx` | 57-63 | Deletion handler |
-| `apps/web/src/contexts/AuthContext.tsx` | 60-67 | `logout()` function |
+| `apps/web/src/pages/settings/SettingsPage.tsx` | 76–82 | Deletion handler |
+| `apps/web/src/contexts/AuthContext.tsx` | 48–55 | `logout()` function |
+| `packages/shared/src/i18n/en.json` | — | Add `settings.deleteFailed` key |
+| `packages/shared/src/i18n/tr.json` | — | Add `settings.deleteFailed` key |
 
 ## Fix Approach
 
-Call `logout()` and `navigate('/')` after successful deletion.
+Import `useNavigate`, destructure `logout` from `useAuth()`, then call both after a successful deletion. Add a missing `settings.deleteFailed` translation key to both locale files.
 
 ### Current Code
 
 ```ts
+// SettingsPage.tsx:76-82
 async function handleDeleteAccount() {
   if (!globalThis.confirm(t('settings.deleteConfirm'))) return;
   try {
@@ -54,7 +57,19 @@ async function handleDeleteAccount() {
 
 ### Fixed Code
 
+**`apps/web/src/pages/settings/SettingsPage.tsx`** — extend the `react-router` import, destructure `logout`, add `useNavigate`:
+
 ```ts
+// Line 2 — extend existing import
+import { useLoaderData, useNavigate } from 'react-router';
+
+// Line 32 — extend existing useAuth() destructuring
+const { user, refreshUser, logout } = useAuth();
+
+// Add inside component body alongside other hooks
+const navigate = useNavigate();
+
+// Lines 76-82 — updated handler
 async function handleDeleteAccount() {
   if (!globalThis.confirm(t('settings.deleteConfirm'))) return;
   try {
@@ -68,16 +83,29 @@ async function handleDeleteAccount() {
 }
 ```
 
+**`packages/shared/src/i18n/en.json`** — add new key (alongside the existing `settings.failedMsg` entry):
+
+```json
+"settings.deleteFailed": "Account deletion failed."
+```
+
+**`packages/shared/src/i18n/tr.json`** — add new key (alongside the existing `settings.failedMsg` entry):
+
+```json
+"settings.deleteFailed": "Hesap silinemedi."
+```
+
 ## Implementation Steps
 
-1. Read `SettingsPage.tsx` to find the deletion handler (lines 57-63)
-2. Add `useAuth()` destructuring to include `logout` (currently only destructures `user` and `refreshUser`)
-3. Add `useNavigate()` from `react-router` (already imported but not used for deletion)
-4. After `api.delete('/users/me')` succeeds, call `await logout()`
-5. After logout, call `navigate('/')` to redirect to home
-6. Add error handling with user-facing message in the `catch` block
-7. Add a success message before redirect (brief flash is fine since user will be redirected)
-8. Test the deletion flow end-to-end
+1. Read `SettingsPage.tsx` to find the deletion handler (lines 76–82)
+2. Extend the `react-router` import on line 2 from `{ useLoaderData }` to `{ useLoaderData, useNavigate }`
+3. Add `useNavigate` from `react-router` — it is **not** currently imported in `SettingsPage.tsx`; add `const navigate = useNavigate()` inside the component alongside the other hook calls
+4. Add `logout` to the `useAuth()` destructuring on line 32 (currently only destructures `user` and `refreshUser`)
+5. After `api.delete('/users/me')` succeeds, call `await logout()` to clear auth state
+6. After logout, call `navigate('/')` to redirect to home
+7. Add error handling with a user-facing message in the `catch` block using `t('settings.deleteFailed')`
+8. Add the `settings.deleteFailed` translation key to **both** `packages/shared/src/i18n/en.json` and `packages/shared/src/i18n/tr.json` — this key does not currently exist and `t()` falls back to returning the raw key string, so it must be added before the error path is usable
+9. Test the deletion flow end-to-end
 
 ## Testing Strategy
 
@@ -89,12 +117,14 @@ async function handleDeleteAccount() {
 - Try to access `/settings` — verify redirect to login
 - Verify API returns 401 for the deleted user's session
 - Test cancel flow — click "Delete Account" → cancel → verify nothing happens
+- Simulate a network failure on `DELETE /users/me` and verify the `settings.deleteFailed` error message renders correctly in both `en` and `tr` locales
 
 ## Risk Assessment
 
 - **Low**: Simple addition of two function calls after the API call
-- **Low**: `logout()` already handles cookie/session cleanup
+- **Low**: `logout()` already handles cookie/session cleanup; it catches and ignores errors internally, so calling it on a deleted account's session is safe
 - **Low**: No backend changes needed — the delete endpoint already works
+- **Low**: Two new i18n keys with no structural schema changes
 
 ## Dependencies
 


### PR DESCRIPTION
# Fix account deletion flow on Settings page

## Summary

This PR fixes a broken account-deletion flow on the Settings page. Previously, when a user
deleted their account the request succeeded but the UI was left in an inconsistent state —
the user remained on `/settings` with a stale auth session, the navbar still showed them as
logged in, and any subsequent action failed with 401/404 errors. The handler also swallowed
errors silently, leaving users with no feedback when something went wrong.

The fix wires up a proper post-deletion cleanup (logout → redirect home) and surfaces
deletion errors through the existing banner. As a side effect it also removes a fragile
language-specific substring check that determined banner color, replacing it with an
explicit `messageType` discriminator that is robust to future translations.

## What's in this PR

### `apps/web/src/pages/settings/SettingsPage.tsx`

- **Imports**: added `useNavigate` to the `react-router` import.
- **Hooks**: pulled `logout` out of `useAuth()` and added `useNavigate()`.
- **State**: added `messageType: 'success' | 'error' | null`, paired with the existing
  `message` state.
- **`savePreferences`**: every `setMessage(...)` call is now paired with a matching
  `setMessageType(...)` call (clear → `null`, success → `'success'`, error → `'error'`).
- **JSX banner**: replaced the brittle
  `message.includes('Failed') || message.includes('kaydedilemedi')` check with a clean
  `messageType === 'error' ? 'var(--error)' : 'var(--success)'` decision.
- **`handleDeleteAccount`**: now clears any stale banner, calls `api.delete('/users/me')`,
  awaits `logout()` (which unconditionally clears local auth state), and then
  `navigate('/')` to the public home page. On error it logs the failure and shows the
  translated `settings.deleteFailed` banner; auth state and route are intentionally
  preserved so the user can retry.
- **JSDoc**: added a `/** … */` block above `handleDeleteAccount` describing behavior,
  side effects, and the error path, using the same `{@link …}` conventions as
  `savePreferences`.

### `apps/web/src/pages/settings/SettingsPage.test.tsx` (new)

New test file with 7 cases, following the established vitest + Testing Library +
`createMemoryRouter` pattern used across the rest of the web test suite:

1. **Successful deletion** → `api.delete('/users/me')` is called, `logout` runs once,
   router lands on `/`.
2. **Cancel dialog** → no API call, no logout, route unchanged.
3. **Network error (English)** → red "Account deletion failed." banner, no logout, route
   unchanged.
4. **Network error (Turkish)** → red "Hesap silinemedi." banner with `var(--error)`
   background, no logout, route unchanged.
5. **Preferences save success** → green banner with `var(--success)` background.
6. **Preferences save failure (Turkish)** → red banner with `var(--error)` background.
7. **Deletion error banner styling** → red background verification.

The test for the Turkish error message is the regression test that guards the
substring-matching bug: the new "Hesap silinemedi." text contains neither `"Failed"` nor
`"kaydedilemedi"`, so under the old logic it would have rendered green.

### `packages/shared/src/i18n/en.json`

- Added `"settings.deleteFailed": "Account deletion failed."`

### `packages/shared/src/i18n/tr.json`

- Added `"settings.deleteFailed": "Hesap silinemedi."`

## Why the `messageType` refactor?

The previous banner color logic was:

```tsx
backgroundColor: message.includes('Failed') || message.includes('kaydedilemedi')
  ? 'var(--error)'
  : 'var(--success)',
```

This hard-codes the language-specific markers of an "error" message. The new deletion
translation `"Hesap silinemedi."` contains neither substring, so under the old code it
would render green — the opposite of what's intended. The new explicit `messageType` state
is set at every call site, so banner color is now determined by the source of the message
and is immune to translation changes.

## How to verify

1. `make install` (if you haven't already)
2. `make lint` — no new warnings
3. `make test-web` — 788 tests pass, 7 of them new
4. `make test-shared` — shared package tests pass
5. Manual smoke test (in dev):
   - Log in, go to `/settings`, scroll to **Danger Zone**.
   - Click **Delete Account**, confirm the dialog. You should be redirected to `/` and the
     navbar should show **Log In / Sign Up** instead of your avatar.
   - In the API logs you should see the expected `authApi.logout()` 401 — the local state
     cleanup runs regardless.

## Risk & rollback

Low risk. Frontend-only change, no backend, schema, or dependency modifications. The
`logout()` function in `AuthContext` is designed to swallow the expected `authApi.logout()`
failure (the session/cookie is already invalid after the account is deleted) and run
`setUser(null)` unconditionally — this is the side effect we rely on. Rollback is a clean
`git revert`.

## Checklist

- [x] Code follows the repo's conventions (explicit `.ts`/`.tsx` import extensions, JSDoc
      on public functions, structured logger calls, no `console.log`).
- [x] No new dependencies.
- [x] No backend, schema, or migration changes.
- [x] All new behavior is covered by automated tests.
- [x] `make fmt`, `make lint`, `make test-web`, and `make test-shared` pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Account deletion now properly logs you out and redirects to the home page after successful deletion.
  * Failed account deletions now display clear error messages instead of failing silently.
  * Settings page message banners now reliably display success and error states with consistent styling.
  * Added Turkish language support for account deletion error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->