### PR TITLE
Feat/d17: Fix silent error swallowing in client-side data fetching

### DIFF
--- a/apps/web/src/components/taste/TasteAutocomplete.test.tsx
+++ b/apps/web/src/components/taste/TasteAutocomplete.test.tsx
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+vi.mock(
+  '@/utils/logger.ts',
+  () => ({
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  }),
+);
+
 import { TasteAutocomplete } from './TasteAutocomplete.tsx';
 
 // ── Mock API ───────────────────────────────────────────────────────────────

--- a/apps/web/src/components/taste/TasteAutocomplete.tsx
+++ b/apps/web/src/components/taste/TasteAutocomplete.tsx
@@ -1,7 +1,11 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../../api/index.ts';
 import { IntensityDots } from '../recipe/IntensityDots.tsx';
+import { createLogger } from '../../utils/logger.ts';
 
+const log = createLogger('TasteAutocomplete');
+
+/** Represents a single taste note node in the SCAA flavor hierarchy. */
 interface TasteNote {
   id: string;
   name: string;
@@ -9,6 +13,7 @@ interface TasteNote {
   parentId: string | null;
 }
 
+/** Props for the TasteAutocomplete component. */
 interface Props {
   selectedIds: string[];
   onSelectionChange: (ids: string[]) => void;
@@ -17,6 +22,7 @@ interface Props {
   onIntensitiesChange?: (intensities: Record<string, number>) => void;
 }
 
+/** Searchable autocomplete for SCAA taste notes with hierarchical grouping, intensity controls, and keyboard navigation. */
 export function TasteAutocomplete({
   selectedIds,
   onSelectionChange,
@@ -33,7 +39,9 @@ export function TasteAutocomplete({
   useEffect(() => {
     api.get<TasteNote[]>('/taste-notes/flat').then((data) => {
       setAllNotes(data as TasteNote[]);
-    }).catch(() => {});
+    }).catch((err) => {
+      log.error({ err }, 'Failed to fetch taste notes list');
+    });
   }, []);
 
   useEffect(() => {
@@ -152,6 +160,7 @@ export function TasteAutocomplete({
     }
   }, [highlightedId]);
 
+  /** Adds or removes a taste note from the selection. When adding, defaults intensity to 2. */
   function toggleNote(id: string) {
     if (selectedIds.includes(id)) {
       onSelectionChange(selectedIds.filter((sid) => sid !== id));
@@ -169,6 +178,7 @@ export function TasteAutocomplete({
     setQuery('');
   }
 
+  /** Cycles a selected note's intensity through 1 → 2 → 3 → 1. */
   function cycleIntensity(id: string) {
     if (!onIntensitiesChange) return;
     const current = intensities[id] ?? 2;
@@ -176,6 +186,7 @@ export function TasteAutocomplete({
     onIntensitiesChange({ ...intensities, [id]: next });
   }
 
+  /** Handles keyboard navigation (ArrowUp/Down, Enter, Escape) in the autocomplete dropdown. */
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (!isOpen) {
       if (e.key === 'ArrowDown' || e.key === 'Enter') {

--- a/apps/web/src/pages/recipes/RecipeCreatePage.test.tsx
+++ b/apps/web/src/pages/recipes/RecipeCreatePage.test.tsx
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/utils/logger.ts', () => ({
+  createLogger: () => mockLogger,
+}));
+
+vi.mock('react-router', () => ({
+  useNavigate: vi.fn(),
+  useSearchParams: vi.fn(() => [new URLSearchParams(), vi.fn()]),
+}));
+
+vi.mock('../../contexts/I18nContext.tsx', () => ({
+  useTranslation: vi.fn(() => ({ t: (k: string) => k })),
+}));
+
+vi.mock('../../api/client.ts', () => ({
+  ApiError: class ApiError extends Error {
+    details: { field: string; message: string }[];
+    constructor(details: { field: string; message: string }[]) {
+      super('Api Error');
+      this.details = details;
+    }
+  },
+}));
+
+vi.mock('../../api/index.ts', () => ({
+  beanApi: { get: vi.fn() },
+  equipmentApi: { list: vi.fn().mockResolvedValue([]) },
+  recipeApi: { create: vi.fn() },
+  setupApi: { list: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('../../components/seo/SEOHead.tsx', () => ({
+  SEOHead: vi.fn(() => null),
+}));
+
+vi.mock('../../components/taste/TasteAutocomplete.tsx', () => ({
+  TasteAutocomplete: vi.fn(() => null),
+}));
+
+import { RecipeCreatePage } from './RecipeCreatePage.tsx';
+
+describe('RecipeCreatePage — mount/unmount logging', () => {
+  beforeEach(() => {
+    mockLogger.debug.mockClear();
+  });
+
+  it('logs mount message on render', () => {
+    render(<RecipeCreatePage />);
+    expect(mockLogger.debug).toHaveBeenCalledWith({}, 'RecipeCreatePage mounted');
+  });
+
+  it('logs unmount message on cleanup', () => {
+    const { unmount } = render(<RecipeCreatePage />);
+    mockLogger.debug.mockClear();
+    unmount();
+    expect(mockLogger.debug).toHaveBeenCalledWith({}, 'RecipeCreatePage unmounted');
+  });
+});

--- a/apps/web/src/pages/recipes/RecipeCreatePage.tsx
+++ b/apps/web/src/pages/recipes/RecipeCreatePage.tsx
@@ -58,6 +58,13 @@ export function RecipeCreatePage() {
   const [equipError, setEquipError] = useState('');
 
   useEffect(() => {
+    log.debug({}, 'RecipeCreatePage mounted');
+    return () => {
+      log.debug({}, 'RecipeCreatePage unmounted');
+    };
+  }, []);
+
+  useEffect(() => {
     Promise.all([
       equipmentApi.list().then((data) => {
         if (Array.isArray(data) && data.every((item) => typeof item.id === 'string')) {

--- a/apps/web/src/pages/recipes/RecipeCreatePage.tsx
+++ b/apps/web/src/pages/recipes/RecipeCreatePage.tsx
@@ -5,6 +5,7 @@ import { ApiError } from '../../api/client.ts';
 import { beanApi, equipmentApi, recipeApi, setupApi } from '../../api/index.ts';
 import { SEOHead } from '../../components/seo/SEOHead.tsx';
 import { TasteAutocomplete } from '../../components/taste/TasteAutocomplete.tsx';
+import { createLogger } from '../../utils/logger.ts';
 import {
   BREW_METHODS_LIST,
   DRINK_TYPES_LIST,
@@ -14,6 +15,9 @@ import {
 import type { BrewMethod, DrinkType, Visibility } from '@brewform/shared/types';
 import type { EquipmentListItem, SetupListItem } from '../../api/types.ts';
 
+const log = createLogger('RecipeCreatePage');
+
+/** Multi-step form for creating a new brew recipe with bean info, brew parameters, equipment selection, taste notes, and preparation instructions. */
 export function RecipeCreatePage() {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -84,7 +88,9 @@ export function RecipeCreatePage() {
         else if (bean.roaster) setCoffeeBrand(String(bean.roaster));
         if (bean.processing) setCoffeeProcessing(String(bean.processing));
       }
-    }).catch(() => {});
+    }).catch((err) => {
+      log.error({ err, beanId }, 'Failed to pre-fill bean info from URL param');
+    });
   }, []);
 
   // Auto-fill grinder and brewerDetails when setup changes
@@ -106,12 +112,14 @@ export function RecipeCreatePage() {
     }
   }, [brewMethod]);
 
+  /** Toggles an equipment item in the selected equipment set. */
   function toggleEquipment(id: string) {
     setSelectedEquipmentIds((prev) =>
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
     );
   }
 
+  /** Applies brewer details from the selected setup to the form state. */
   function setBrewerDetailsFromSetup(value: string) {
     // brewerDetails is not a separate state field in the form —
     // it's part of the Brew Parameters section as a free-text input.
@@ -124,6 +132,7 @@ export function RecipeCreatePage() {
 
   const [brewerDetails, setBrewerDetails] = useState('');
 
+  /** Validates and submits the recipe creation form. On success navigates to the new recipe page; on failure displays validation or network errors. */
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
@@ -515,6 +524,7 @@ export function RecipeCreatePage() {
   );
 }
 
+/** Card wrapper for form sections with a title header. */
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className='card'>
@@ -524,6 +534,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
+/** Labeled form field container with optional required indicator. */
 function Field(
   { label, required, children }: { label: string; required?: boolean; children: React.ReactNode },
 ) {

--- a/apps/web/src/pages/recipes/RecipeFocusModePage.test.tsx
+++ b/apps/web/src/pages/recipes/RecipeFocusModePage.test.tsx
@@ -15,6 +15,14 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock(
+  '@/utils/logger.ts',
+  () => ({
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  }),
+);
+
 import { RecipeFocusModePage } from './RecipeFocusModePage.tsx';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
@@ -77,6 +85,7 @@ const enT = (key: string) => {
     'common.loading': 'Loading...',
     'recipe.focusMode.backToRecipe': 'Back to Recipe',
     'recipe.focusMode.by': 'By',
+    'recipe.focusMode.loadError': 'Failed to load recipe',
   };
   return map[key] ?? key;
 };
@@ -86,6 +95,7 @@ const trT = (key: string) => {
     'common.loading': 'Yükleniyor...',
     'recipe.focusMode.backToRecipe': 'Tarife Dön',
     'recipe.focusMode.by': 'Yazan',
+    'recipe.focusMode.loadError': 'Tarif yüklenemedi',
   };
   return map[key] ?? key;
 };
@@ -344,5 +354,42 @@ describe('RecipeFocusModePage — canonical + noIndex SEO', () => {
     const calls = mockSEOHead.mock.calls;
     const lastProps = calls[calls.length - 1][0] as { canonical?: string };
     expect(lastProps.canonical).not.toContain('/focus');
+  });
+});
+
+describe('RecipeFocusModePage — error state', () => {
+  it('shows error message when recipeApi.get fails', async () => {
+    mockRecipeApi.get.mockRejectedValue(new Error('Not found'));
+    render(<RecipeFocusModePage />);
+
+    await waitFor(() => expect(screen.getByText('Failed to load recipe')).toBeInTheDocument());
+
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
+
+  it('shows Turkish error message when recipeApi.get fails and locale is tr', async () => {
+    mockUseTranslation.mockReturnValue({ ...defaultTranslation, locale: 'tr', t: trT });
+    mockRecipeApi.get.mockRejectedValue(new Error('Not found'));
+    render(<RecipeFocusModePage />);
+
+    await waitFor(() => expect(screen.getByText('Tarif yüklenemedi')).toBeInTheDocument());
+  });
+
+  it('error state does not appear when recipe fetch succeeds', async () => {
+    render(<RecipeFocusModePage />);
+
+    await waitFor(() => expect(screen.getByText('My Espresso')).toBeInTheDocument());
+
+    expect(screen.queryByText('Failed to load recipe')).not.toBeInTheDocument();
+  });
+
+  it('error div uses error color variable', async () => {
+    mockRecipeApi.get.mockRejectedValue(new Error('Not found'));
+    render(<RecipeFocusModePage />);
+
+    await waitFor(() => expect(screen.getByText('Failed to load recipe')).toBeInTheDocument());
+
+    const errorDiv = screen.getByText('Failed to load recipe').closest('div');
+    expect(errorDiv).toHaveStyle({ color: 'var(--error)' });
   });
 });

--- a/apps/web/src/pages/recipes/RecipeFocusModePage.test.tsx
+++ b/apps/web/src/pages/recipes/RecipeFocusModePage.test.tsx
@@ -16,12 +16,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 
-vi.mock(
-  '@/utils/logger.ts',
-  () => ({
-    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
-  }),
-);
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/utils/logger.ts', () => ({
+  createLogger: () => mockLogger,
+}));
 
 import { RecipeFocusModePage } from './RecipeFocusModePage.tsx';
 
@@ -391,5 +392,23 @@ describe('RecipeFocusModePage — error state', () => {
 
     const errorDiv = screen.getByText('Failed to load recipe').closest('div');
     expect(errorDiv).toHaveStyle({ color: 'var(--error)' });
+  });
+});
+
+describe('RecipeFocusModePage — mount/unmount logging', () => {
+  beforeEach(() => {
+    mockLogger.debug.mockClear();
+  });
+
+  it('logs mount message on render', () => {
+    render(<RecipeFocusModePage />);
+    expect(mockLogger.debug).toHaveBeenCalledWith({}, 'RecipeFocusModePage mounted');
+  });
+
+  it('logs unmount message on cleanup', () => {
+    const { unmount } = render(<RecipeFocusModePage />);
+    mockLogger.debug.mockClear();
+    unmount();
+    expect(mockLogger.debug).toHaveBeenCalledWith({}, 'RecipeFocusModePage unmounted');
   });
 });

--- a/apps/web/src/pages/recipes/RecipeFocusModePage.tsx
+++ b/apps/web/src/pages/recipes/RecipeFocusModePage.tsx
@@ -8,7 +8,11 @@ import { BeanSection } from '../../components/recipe/BeanSection.tsx';
 import { BrewTimeline } from '../../components/recipe/BrewTimeline.tsx';
 import { EquipmentSection } from '../../components/recipe/EquipmentSection.tsx';
 import { TastingNotesSection } from '../../components/recipe/TastingNotesSection.tsx';
+import { createLogger } from '../../utils/logger.ts';
 
+const log = createLogger('RecipeFocusModePage');
+
+/** Renders a focused, distraction-free view of a single brew recipe with stats, bean info, brew timeline, equipment, and tasting notes. */
 export function RecipeFocusModePage() {
   const { slug } = useParams();
   const { t } = useTranslation();
@@ -16,19 +20,36 @@ export function RecipeFocusModePage() {
   const [recipe, setRecipe] = useState<any>(null);
   // deno-lint-ignore no-explicit-any
   const [allTasteNotes, setAllTasteNotes] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     tasteApi.flat().then((data) => {
       setAllTasteNotes(Array.isArray(data) ? data as any[] : []);
-    }).catch(() => {});
+    }).catch((err) => {
+      log.error({ err }, 'Failed to fetch taste notes for focus mode');
+    });
   }, []);
 
   useEffect(() => {
     if (!slug) return;
     recipeApi.get(slug).then((data: Record<string, unknown>) => {
       setRecipe(data);
-    }).catch(() => {});
-  }, [slug]);
+    }).catch((err) => {
+      log.error({ err, slug }, 'Failed to fetch recipe for focus mode');
+      setError(t('recipe.focusMode.loadError'));
+    });
+  }, [slug, t]);
+
+  if (error) {
+    return (
+      <div
+        className='mx-auto max-w-3xl px-4 sm:px-6 py-12 text-center'
+        style={{ color: 'var(--error)' }}
+      >
+        {error}
+      </div>
+    );
+  }
 
   if (!recipe) {
     return (

--- a/apps/web/src/pages/recipes/RecipeFocusModePage.tsx
+++ b/apps/web/src/pages/recipes/RecipeFocusModePage.tsx
@@ -23,6 +23,13 @@ export function RecipeFocusModePage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    log.debug({}, 'RecipeFocusModePage mounted');
+    return () => {
+      log.debug({}, 'RecipeFocusModePage unmounted');
+    };
+  }, []);
+
+  useEffect(() => {
     tasteApi.flat().then((data) => {
       setAllTasteNotes(Array.isArray(data) ? data as any[] : []);
     }).catch((err) => {

--- a/apps/web/src/pages/recipes/RecipeForkPage.tsx
+++ b/apps/web/src/pages/recipes/RecipeForkPage.tsx
@@ -41,6 +41,7 @@ export function RecipeForkPage() {
     }).finally(() => setLoading(false));
   }, [id, t]);
 
+  /** Creates a fork of the source recipe with the current title. On success navigates to the new recipe's edit page; on failure displays the error. */
   async function handleFork() {
     if (!id) return;
     setForking(true);

--- a/openspec/changes/fix-error-swallowing/.openspec.yaml
+++ b/openspec/changes/fix-error-swallowing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/fix-error-swallowing/design.md
+++ b/openspec/changes/fix-error-swallowing/design.md
@@ -1,0 +1,99 @@
+## Context
+
+BrewForm's React Router loader migrations (D10–D16) resolved 11 of 15 empty `.catch(() => {})` occurrences by moving data fetching into loader functions that propagate errors to `errorElement` boundaries or handle them explicitly. Four occurrences remain in three client-side components that still use `useEffect`+`useState` for data fetching:
+
+| File | Line | API Call | Severity |
+|------|------|----------|----------|
+| `RecipeFocusModePage.tsx:30` | 30 | `recipeApi.get(slug)` | **High** — page unusable |
+| `RecipeFocusModePage.tsx:23` | 23 | `tasteApi.flat()` | Low — optional data |
+| `RecipeCreatePage.tsx:87` | 87 | `beanApi.get(beanId)` | Low — optional pre-fill |
+| `TasteAutocomplete.tsx:36` | 36 | `api.get('/taste-notes/flat')` | Low — optional autocomplete |
+
+**Verified**: A codebase-wide regex search for `\.catch\(\(\)\s*=>\s*\{\s*\}` across `apps/web/src/**/*.{ts,tsx}` returns zero results beyond these 4 + the intentional one in AuthContext.
+
+One additional empty catch in `AuthContext.tsx:33` is **intentional** — `refreshUser().catch(() => {})` exists because a failed token refresh is a normal unauthenticated state. The inner `refreshUser` already has a `try/finally` that ensures `setIsLoading(false)` is called. This catch MUST NOT be changed.
+
+The existing `RecipeForkPage` (`apps/web/src/pages/recipes/RecipeForkPage.tsx`) provides the established reference pattern:
+- `createLogger` imported via `@/utils/logger.ts` (path alias)
+- `const log = createLogger('RecipeForkPage')` at module scope
+- `log.error({ err, id }, 'loadSourceRecipe failed')` in catch blocks
+- `setError(t('recipe.fork.loadError'))` for user-facing messages
+- Error banner with `var(--error)` background before main content
+- JSDoc docblock on the exported component function
+- Mount/unmount lifecycle logging with `log.debug`
+
+**Import path convention in `pages/recipes/`**: Three files use `../../utils/logger.ts` (relative: RecipeListPage, StarredRecipesPage, useCoffeeVarietyFilter), one uses `@/utils/logger.ts` (alias: RecipeForkPage). Both resolve to the same file. This change uses **relative** paths for RecipeFocusModePage and RecipeCreatePage to match the majority convention in the directory. TasteAutocomplete (in `components/taste/`) uses `../../utils/logger.ts`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace all 4 silent empty catches with structured `log.error()` calls that include the error object and relevant context (`slug`, `beanId`)
+- Add user-facing error state to RecipeFocusModePage when the recipe fetch (critical data) fails
+- Add `recipe.focusMode.loadError` i18n keys to both `en.json` and `tr.json`
+- Add automated tests for the RecipeFocusModePage error state, following the RecipeForkPage error test pattern
+- Add `createLogger` mocks to the two test files that will need them (RecipeFocusModePage.test.tsx, TasteAutocomplete.test.tsx) following the established 12-file convention
+- Add JSDoc docblocks to all exported functions in the 3 affected source files (14 missing in total, including RecipeForkPage's `handleFork` which was omitted from the reference)
+- Create a `pr_description.md` at the project root
+
+**Non-Goals:**
+- Migrating RecipeFocusModePage to a React Router loader (larger architectural change, deferred)
+- Adding structured logs to the non-empty-but-hardcoded-English catches in RecipeCreatePage:64/71 (destined for D26 "Expand Logging")
+- Changing the intentional empty catch in `AuthContext.tsx:33`
+- Adding user-facing error states for non-critical fetches (they degrade gracefully without UI disruption)
+- Fixing the pre-existing UX issue in TasteAutocomplete where a failed fetch shows "Loading taste notes..." forever instead of an empty state (separate issue; the logging addition at least enables debugging it)
+
+## Decisions
+
+### Decision 1: Two-category severity split
+
+**Choice**: Critical data fetches get user-facing error state + logging; non-critical fetches get logging only.
+
+**Rationale**: A failed recipe fetch blocks the entire page — the user needs to know something went wrong. Failed taste notes or bean pre-fill just means an empty dropdown or a form field the user fills manually — logging suffices for debugging without cluttering the UI.
+
+**Alternatives considered**:
+- Show errors for all 4: Would add noise to the UI for non-blocking failures.
+- Do nothing: Already unacceptable — silent failures block debugging and erode trust.
+
+### Decision 2: i18n key naming
+
+**Choice**: Use `recipe.focusMode.loadError` following the existing `recipe.fork.loadError` pattern.
+
+**Rationale**: The `recipe.*.loadError` namespace is already established (RecipeForkPage uses `recipe.fork.loadError` at `en.json:38`). The plan's original proposal of `errors.loadFailed` doesn't exist. Using `error.500` would be too generic.
+
+### Decision 3: Logger import path
+
+**Choice**: 
+- RecipeFocusModePage + RecipeCreatePage: `../../utils/logger.ts` (relative)
+- TasteAutocomplete: `../../utils/logger.ts` (relative, matches existing `../../api/index.ts` import)
+
+**Rationale**: 3 of 4 files in `pages/recipes/` that use `createLogger` already use relative paths. TasteAutocomplete already uses `../../api/index.ts` — adding `../../utils/logger.ts` is consistent with the file's existing import style.
+
+### Decision 4: Error state UI placement
+
+**Choice**: Add the error check BEFORE the existing `if (!recipe)` loading guard in RecipeFocusModePage's JSX return.
+
+**Rationale**: When the fetch rejects, `setError` is called but `setRecipe` is not — so `recipe` remains null. If error is checked AFTER the loading guard, the loading spinner would display instead of the error message. Error state MUST take priority.
+
+### Decision 5: Test approach — mock `createLogger`
+
+**Choice**: Add `vi.mock('@/utils/logger.ts', ...)` to both RecipeFocusModePage.test.tsx and TasteAutocomplete.test.tsx, following the established 12-file convention.
+
+**Rationale**: 12 of 13 test files whose source imports `createLogger` mock it via `vi.mock`. The one exception (RecipeForkPage.test.tsx) is a pre-existing inconsistency, not a pattern to follow. Mocking ensures clean test output and enables future assertion of logging calls if needed.
+
+**Note**: RecipeForkPage.test.tsx is missing its `createLogger` mock — this is a pre-existing gap. It works because the real `ConsoleLogger` uses `console.*` which Vitest captures. This is out of scope for D17 but worth noting for D26.
+
+### Decision 6: Docblocks on all changed/new exported functions
+
+**Choice**: Add JSDoc docblocks to all 14 missing declarations across the 3 affected files + RecipeForkPage's `handleFork`.
+
+**Rationale**: `RecipeForkPage` already has a JSDoc (serving as baseline), but its `handleFork` is undocumented. `RecipeFocusModePage`, `RecipeCreatePage`, and `TasteAutocomplete` have NO docblocks on their exported components or helper functions. AGENTS.md conventions require JSDoc on public functions. Since we're touching these files for error handling, adding docblocks is a natural companion task.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| RecipeFocusModePage error state might show briefly during slow fetches | `.catch()` only fires on rejection, not during pending promise — timing is not a factor |
+| New i18n keys missing → raw key displayed | `t()` falls back to showing the key string, which is still informative |
+| `createLogger` import breaks tests if not mocked | Both affected test files get `vi.mock('@/utils/logger.ts', ...)` blocks added before component import |
+| TasteAutocomplete "loading" test uses non-resolving promise → `.catch()` never reached | No change needed — behavior unchanged for the never-resolve path |
+| TasteAutocomplete pre-existing UX issue: failed fetch shows "Loading taste notes..." forever (no empty-state fallback after rejection) | Out of scope for D17. The added `log.error` at least enables debugging this issue in production. Could be enhanced in a follow-up. |

--- a/openspec/changes/fix-error-swallowing/proposal.md
+++ b/openspec/changes/fix-error-swallowing/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Four client-side `.catch(() => {})` statements silently swallow errors in the BrewForm web app, leaving users with infinite loading spinners (RecipeFocusModePage) or empty dropdowns (TasteAutocomplete, RecipeCreatePage) with zero diagnostic information. These silent failures erode user trust and make production debugging impossible. A codebase-wide audit confirmed only these 4 empty catches remain (plus one intentional one in AuthContext) — prior router-loader migrations (D10–D16) eliminated the other 11.
+
+## What Changes
+
+- **RecipeFocusModePage** (High severity): Replace empty `recipeApi.get` catch with structured `log.error` + user-facing error state screen. Replace empty `tasteApi.flat` catch with structured `log.error` only (graceful degradation). Add `recipe.focusMode.loadError` i18n keys in en.json and tr.json.
+- **RecipeCreatePage** (Low severity): Replace empty `beanApi.get` catch with structured `log.error` for the optional bean pre-fill flow.
+- **TasteAutocomplete** (Low severity): Replace empty `api.get` catch with structured `log.error` for the taste notes autocomplete list.
+- **Docblocks**: Add JSDoc docblocks to ALL exported functions, components, and interfaces in the 3 affected source files (14 missing total), plus `RecipeForkPage.handleFork` which was omitted from the reference pattern.
+- **Tests**: Add `createLogger` mocks to RecipeFocusModePage.test.tsx and TasteAutocomplete.test.tsx (following the established 12-file convention). Add 4 new automated tests for RecipeFocusModePage error state (failure rendering, Turkish locale, success path, error styling), following the existing RecipeForkPage error test pattern.
+- **PR description**: Create `pr_description.md` at the project root summarizing the change.
+
+## Capabilities
+
+### New Capabilities
+
+- `error-handling`: Client-side structured error logging and user-facing error states for data-fetching failures. Covers the logging pattern (`createLogger` + `log.error({ err, ...context })`), error state rendering for critical fetches, the pattern of silent logging-only for non-critical fetches that degrade gracefully, JSDoc docblock conventions on exported functions, and `createLogger` test mocking conventions.
+
+### Modified Capabilities
+
+None. No existing spec-level requirements are changing. This is a bugfix/additive improvement to frontend error-handling patterns and documentation.
+
+## Impact
+
+- **Affected source files (4)**: `RecipeFocusModePage.tsx`, `RecipeCreatePage.tsx`, `TasteAutocomplete.tsx`, `RecipeForkPage.tsx` (docblock only)
+- **Affected test files (2)**: `RecipeFocusModePage.test.tsx` (logger mock + 4 new tests), `TasteAutocomplete.test.tsx` (logger mock)
+- **Affected i18n (2)**: `packages/shared/src/i18n/en.json`, `packages/shared/src/i18n/tr.json` (additive keys only)
+- **No API changes**, no schema changes, no database migrations, no new dependencies
+- **Risk**: Low — additive changes only; error state only fires on fetch failures that already leave the page broken; docblocks are documentation-only; test mocks follow existing conventions

--- a/openspec/changes/fix-error-swallowing/specs/error-handling/spec.md
+++ b/openspec/changes/fix-error-swallowing/specs/error-handling/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Critical fetch failures show user-facing error
+
+When a client-side data fetch essential for rendering the page fails (e.g., the main recipe data in RecipeFocusModePage), the component SHALL display a user-facing error message via i18n and SHALL log the error with structured context including the error object and relevant identifiers (e.g., the recipe slug).
+
+The error state SHALL take visual priority over the loading state — if both `error` and `!recipe` are true, the error message SHALL be displayed, not the loading spinner.
+
+#### Scenario: Recipe fetch fails in focus mode
+
+- **WHEN** `recipeApi.get(slug)` rejects with an Error on the RecipeFocusModePage
+- **THEN** the UI SHALL display the translated `recipe.focusMode.loadError` message in a centered text block styled with `color: var(--error)`
+- **AND** a structured `log.error({ err, slug })` call SHALL be emitted with message "Failed to fetch recipe for focus mode"
+- **AND** the loading spinner SHALL NOT be displayed
+
+#### Scenario: Recipe fetch succeeds in focus mode
+
+- **WHEN** `recipeApi.get(slug)` resolves successfully on the RecipeFocusModePage
+- **THEN** the error state SHALL NOT be displayed
+- **AND** the recipe content SHALL render normally
+
+### Requirement: Non-critical fetch failures log silently
+
+When a client-side data fetch that is optional or degrades gracefully fails (e.g., taste notes autocomplete list, bean pre-fill from URL param), the component SHALL log the error with structured context and SHALL NOT display any user-facing error message. The component SHALL continue to render its default state (empty list, empty form field, etc.).
+
+#### Scenario: Taste notes fetch fails in focus mode
+
+- **WHEN** `tasteApi.flat()` rejects with an Error on the RecipeFocusModePage
+- **THEN** a structured `log.error({ err })` call SHALL be emitted with message "Failed to fetch taste notes for focus mode"
+- **AND** the page SHALL render normally with taste notes data as an empty array
+- **AND** no user-facing error message SHALL be shown
+
+#### Scenario: Bean pre-fill fetch fails in recipe create page
+
+- **WHEN** `beanApi.get(beanId)` rejects with an Error on the RecipeCreatePage (triggered by `?beanId=<uuid>` URL param)
+- **THEN** a structured `log.error({ err, beanId })` call SHALL be emitted with message "Failed to pre-fill bean info from URL param"
+- **AND** the form SHALL render normally with empty bean-related fields
+- **AND** no user-facing error message SHALL be shown
+
+#### Scenario: Taste notes autocomplete list fetch fails
+
+- **WHEN** `api.get('/taste-notes/flat')` rejects with an Error in the TasteAutocomplete component
+- **THEN** a structured `log.error({ err })` call SHALL be emitted with message "Failed to fetch taste notes list"
+- **AND** the autocomplete SHALL render with an empty suggestions list
+- **AND** the "Loading taste notes..." placeholder SHALL NOT persist (the fetch completed, it just failed)
+- **AND** no user-facing error message SHALL be shown
+
+### Requirement: Structured logging follows project conventions
+
+All new `log.error()` calls SHALL follow the project's logging conventions as defined in AGENTS.md:
+- SHALL include the `err` object as the first argument
+- SHALL include relevant traceable identifiers (e.g., `slug`, `beanId`) in the context object
+- SHALL use a descriptive message string as the second argument
+- SHALL NOT include passwords, tokens, secrets, API keys, or PII
+- SHALL create a module-scoped logger once at the top of the file via `createLogger('ModuleName')`
+
+#### Scenario: Logger is instantiated per component
+
+- **WHEN** a component file imports `createLogger`
+- **THEN** the file SHALL contain exactly one top-level `const log = createLogger(...)` call with a human-readable module name matching the component name
+- **AND** no `console.log`, `console.error`, or `console.warn` calls SHALL be added
+
+### Requirement: i18n keys are provided for both supported locales
+
+Any new user-facing error message SHALL have a corresponding translation key in both `packages/shared/src/i18n/en.json` and `packages/shared/src/i18n/tr.json`. Keys SHALL follow the existing namespace hierarchy (e.g., `recipe.focusMode.*`).
+
+#### Scenario: Error message displays in English
+
+- **WHEN** the locale is set to `en` and `recipe.focusMode.loadError` is rendered
+- **THEN** the user SHALL see "Failed to load recipe"
+
+#### Scenario: Error message displays in Turkish
+
+- **WHEN** the locale is set to `tr` and `recipe.focusMode.loadError` is rendered
+- **THEN** the user SHALL see "Tarif yüklenemedi"
+
+### Requirement: Exported functions have JSDoc docblocks
+
+All exported functions, components, and interfaces in the affected source files SHALL have JSDoc docblocks (`/** ... */`) immediately preceding the declaration. Docblocks for components SHALL describe the component's purpose. Docblocks for helper functions SHALL describe behavior, parameters, and side effects.
+
+This applies to ALL currently undocumented exported declarations in the affected files, not just the ones being modified for error handling.
+
+#### Scenario: Component docblock is present
+
+- **WHEN** a file exports a React component function (e.g., `RecipeFocusModePage`, `RecipeCreatePage`, `TasteAutocomplete`)
+- **THEN** a `/** ... */` JSDoc block SHALL be present immediately before the `export function` declaration
+- **AND** the docblock SHALL describe the component's purpose and any notable behavior
+
+#### Scenario: Helper function docblock is present
+
+- **WHEN** a file exports or contains a named helper function (e.g., `toggleNote`, `handleSubmit`, `handleKeyDown`, `handleFork`)
+- **THEN** a `/** ... */` JSDoc block SHALL be present before the function declaration
+- **AND** the docblock SHALL describe the function's behavior, parameters, and side effects
+
+#### Scenario: Interface docblock is present
+
+- **WHEN** a file defines an exported interface (e.g., `TasteNote`, `Props`)
+- **THEN** a `/** ... */` JSDoc block SHALL be present before the interface declaration
+- **AND** the docblock SHALL describe what the interface represents

--- a/openspec/changes/fix-error-swallowing/tasks.md
+++ b/openspec/changes/fix-error-swallowing/tasks.md
@@ -1,0 +1,144 @@
+## 1. i18n Keys
+
+- [ ] 1.1 Add `"recipe.focusMode.loadError": "Failed to load recipe"` to `packages/shared/src/i18n/en.json` after line 76 (`"recipe.focusMode.notes": "Notes"`) and before line 77 (`"recipe.qrCode": "QR Code"`)
+- [ ] 1.2 Add `"recipe.focusMode.loadError": "Tarif yüklenemedi"` to `packages/shared/src/i18n/tr.json` after line 76 (`"recipe.focusMode.notes": "Notlar"`) and before line 77 (`"recipe.qrCode": "QR Kodu"`)
+
+## 2. RecipeFocusModePage — Imports, State & Docblock
+
+- [ ] 2.1 Import `createLogger` from `../../utils/logger.ts` and add `const log = createLogger('RecipeFocusModePage')` at module scope (after imports, before the component)
+- [ ] 2.2 Add `const [error, setError] = useState<string | null>(null)` alongside existing `recipe` and `allTasteNotes` state declarations
+- [ ] 2.3 Add JSDoc docblock above `export function RecipeFocusModePage()` (line ~12): `/** Renders a focused, distraction-free view of a single brew recipe with stats, bean info, brew timeline, equipment, and tasting notes. */`
+
+## 3. RecipeFocusModePage — Category 1: Critical Recipe Fetch
+
+- [ ] 3.1 Replace the empty `.catch(() => {})` on `recipeApi.get(slug)` (line ~30) with:
+  ```ts
+  .catch((err) => {
+    log.error({ err, slug }, 'Failed to fetch recipe for focus mode');
+    setError(t('recipe.focusMode.loadError'));
+  })
+  ```
+
+- [ ] 3.2 Add error early-return JSX BEFORE the existing `if (!recipe)` loading guard:
+  ```tsx
+  if (error) {
+    return (
+      <div
+        className='mx-auto max-w-3xl px-4 sm:px-6 py-12 text-center'
+        style={{ color: 'var(--error)' }}
+      >
+        {error}
+      </div>
+    );
+  }
+  ```
+
+## 4. RecipeFocusModePage — Category 2: Non-Critical Taste Notes Fetch
+
+- [ ] 4.1 Replace the empty `.catch(() => {})` on `tasteApi.flat()` (line ~23) with:
+  ```ts
+  .catch((err) => {
+    log.error({ err }, 'Failed to fetch taste notes for focus mode');
+  })
+  ```
+
+## 5. RecipeCreatePage — Category 2 & Docblocks
+
+- [ ] 5.1 Import `createLogger` from `../../utils/logger.ts` and add `const log = createLogger('RecipeCreatePage')` at module scope (after imports, before the component)
+- [ ] 5.2 Replace the empty `.catch(() => {})` on `beanApi.get(beanId)` (line ~87) with:
+  ```ts
+  .catch((err) => {
+    log.error({ err, beanId }, 'Failed to pre-fill bean info from URL param');
+  })
+  ```
+- [ ] 5.3 Add JSDoc docblock above `export function RecipeCreatePage()` (line ~17): `/** Multi-step form for creating a new brew recipe with bean info, brew parameters, equipment selection, taste notes, and preparation instructions. */`
+- [ ] 5.4 Add JSDoc docblock above `function toggleEquipment(id)` (line ~109): `/** Toggles an equipment item in the selected equipment set. */`
+- [ ] 5.5 Add JSDoc docblock above `function setBrewerDetailsFromSetup(value)` (line ~115): `/** Applies brewer details from the selected setup to the form state. */`
+- [ ] 5.6 Add JSDoc docblock above `async function handleSubmit(e)` (line ~127): `/** Validates and submits the recipe creation form. On success navigates to the new recipe page; on failure displays validation or network errors. */`
+- [ ] 5.7 Add JSDoc docblock above `function Section(...)` (line ~518): `/** Card wrapper for form sections with a title header. */`
+- [ ] 5.8 Add JSDoc docblock above `function Field(...)` (line ~527): `/** Labeled form field container with optional required indicator. */`
+
+## 6. TasteAutocomplete — Category 2 & Docblocks
+
+- [ ] 6.1 Import `createLogger` from `../../utils/logger.ts` and add `const log = createLogger('TasteAutocomplete')` at module scope
+- [ ] 6.2 Replace the empty `.catch(() => {})` on `api.get('/taste-notes/flat')` (line ~36) with:
+  ```ts
+  .catch((err) => {
+    log.error({ err }, 'Failed to fetch taste notes list');
+  })
+  ```
+- [ ] 6.3 Add JSDoc docblock above `interface TasteNote` (line ~5): `/** Represents a single taste note node in the SCAA flavor hierarchy. */`
+- [ ] 6.4 Add JSDoc docblock above `interface Props` (line ~12): `/** Props for the TasteAutocomplete component. */`
+- [ ] 6.5 Add JSDoc docblock above `export function TasteAutocomplete(...)` (line ~20): `/** Searchable autocomplete for SCAA taste notes with hierarchical grouping, intensity controls, and keyboard navigation. */`
+- [ ] 6.6 Add JSDoc docblock above `function toggleNote(id)` (line ~155): `/** Adds or removes a taste note from the selection. When adding, defaults intensity to 2. */`
+- [ ] 6.7 Add JSDoc docblock above `function cycleIntensity(id)` (line ~172): `/** Cycles a selected note's intensity through 1 → 2 → 3 → 1. */`
+- [ ] 6.8 Add JSDoc docblock above `function handleKeyDown(e)` (line ~179): `/** Handles keyboard navigation (ArrowUp/Down, Enter, Escape) in the autocomplete dropdown. */`
+
+## 7. RecipeForkPage — Docblock Fix
+
+- [ ] 7.1 Add JSDoc docblock above `async function handleFork()` (line ~44): `/** Creates a fork of the source recipe with the current title. On success navigates to the new recipe's edit page; on failure displays the error. */`
+
+## 8. Tests — RecipeFocusModePage Error State
+
+- [ ] 8.1 Add `vi.mock('@/utils/logger.ts', () => ({ createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }))` BEFORE the component import in `RecipeFocusModePage.test.tsx`, following the established 12-file convention
+- [ ] 8.2 Add `'recipe.focusMode.loadError': 'Failed to load recipe'` to the `enT` helper map (after `recipe.focusMode.by`)
+- [ ] 8.3 Add `'recipe.focusMode.loadError': 'Tarif yüklenemedi'` to the `trT` helper map (after `recipe.focusMode.by`)
+- [ ] 8.4 Add test: "shows error message when recipeApi.get fails" — `mockRecipeApi.get.mockRejectedValue(new Error('Not found'))`, render, verify `waitFor` text "Failed to load recipe" appears, verify "Loading..." does NOT appear
+- [ ] 8.5 Add test: "shows Turkish error message when recipeApi.get fails and locale is tr" — set Turkish locale + mock rejection, verify "Tarif yüklenemedi" appears
+- [ ] 8.6 Add test: "error state does not appear when recipe fetch succeeds" — ensure `recipe.focusMode.loadError` text is NOT in document after successful render
+- [ ] 8.7 Add test: "error div uses error color variable" — mock rejection, verify error text is in a div with `style.color === 'var(--error)'`
+- [ ] 8.8 Run `make test-specific filter=apps/web/src/pages/recipes/RecipeFocusModePage.test.tsx` and verify all tests pass (existing + new)
+
+## 9. Tests — TasteAutocomplete Logger Mock
+
+- [ ] 9.1 Add `vi.mock('@/utils/logger.ts', () => ({ createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }))` BEFORE the component import in `TasteAutocomplete.test.tsx` (the source file will now import `createLogger`, so this mock is required)
+- [ ] 9.2 Run `make test-specific filter=apps/web/src/components/taste/TasteAutocomplete.test.tsx` and verify all existing tests still pass
+
+## 10. Verification
+
+- [ ] 10.1 Run `make fmt` to format all changed files
+- [ ] 10.2 Run `make lint` and verify no new warnings
+- [ ] 10.3 Run `make check-web` and verify TypeScript compilation passes with zero errors
+- [ ] 10.4 Run `make test-web` (or `make test`) and verify ALL tests pass, including the new error-state tests
+
+## 11. PR Description
+
+- [ ] 11.1 Create `pr_description.md` at the project root (`/Users/arda.kilicdagi/projects/personal/BrewForm/pr_description.md`) with the following sections:
+
+  **Title**: `# Fix silent error swallowing in client-side data fetching`
+
+  **Summary**: Explain that 4 `.catch(() => {})` blocks were silently swallowing errors, leaving users with infinite spinners or empty UI with zero diagnostics. This PR replaces them with structured logging and (for the critical recipe fetch) a user-facing error screen.
+
+  **What's in this PR**:
+  - `apps/web/src/pages/recipes/RecipeFocusModePage.tsx` — Added structured error logging, error state for recipe fetch failure, JSDoc docblock
+  - `apps/web/src/pages/recipes/RecipeCreatePage.tsx` — Added structured error logging for bean pre-fill failure, JSDoc docblocks on all exported functions
+  - `apps/web/src/components/taste/TasteAutocomplete.tsx` — Added structured error logging for taste notes fetch failure, JSDoc docblocks on all exported functions/interfaces
+  - `apps/web/src/pages/recipes/RecipeForkPage.tsx` — Added JSDoc docblock on `handleFork`
+  - `packages/shared/src/i18n/en.json` — Added `recipe.focusMode.loadError` key
+  - `packages/shared/src/i18n/tr.json` — Added `recipe.focusMode.loadError` key
+  - `apps/web/src/pages/recipes/RecipeFocusModePage.test.tsx` — Added logger mock, i18n keys, 4 new error-state test cases
+  - `apps/web/src/components/taste/TasteAutocomplete.test.tsx` — Added logger mock
+
+  **How to verify**:
+  - `make check-web` — zero TypeScript errors
+  - `make test-web` — all tests pass
+  - Manual: Disconnect network → navigate to `/recipes/<slug>/focus` → verify "Failed to load recipe" error message appears instead of infinite loading
+  - Manual: With network → verify normal page renders
+  - Manual: Disconnect network → open recipe create form with `?beanId=<uuid>` → verify `[RecipeCreatePage]` error entry in browser console
+  - Manual: Disconnect network → open TasteAutocomplete → verify `[TasteAutocomplete]` error entry in browser console
+
+  **Risk & Rollback**:
+  - Low risk — additive changes only, no backend/schema/dependency changes
+  - Error state only fires on fetch failures that already leave the page broken
+  - New i18n keys are additive; `t()` falls back to raw key display if missing
+  - Rollback: clean `git revert`
+
+  **Checklist**:
+  - [x] 4 empty catches replaced with structured error handling
+  - [x] Critical fetch shows user-facing error screen
+  - [x] Non-critical fetches log errors for debugging
+  - [x] i18n keys in both English and Turkish
+  - [x] JSDoc docblocks on all exported functions in affected files
+  - [x] `createLogger` mocks in both affected test files
+  - [x] New automated tests for error state
+  - [x] `make fmt`, `make lint`, `make check-web`, `make test-web` pass

--- a/openspec/changes/fix-error-swallowing/tasks.md
+++ b/openspec/changes/fix-error-swallowing/tasks.md
@@ -1,17 +1,17 @@
 ## 1. i18n Keys
 
-- [ ] 1.1 Add `"recipe.focusMode.loadError": "Failed to load recipe"` to `packages/shared/src/i18n/en.json` after line 76 (`"recipe.focusMode.notes": "Notes"`) and before line 77 (`"recipe.qrCode": "QR Code"`)
-- [ ] 1.2 Add `"recipe.focusMode.loadError": "Tarif yüklenemedi"` to `packages/shared/src/i18n/tr.json` after line 76 (`"recipe.focusMode.notes": "Notlar"`) and before line 77 (`"recipe.qrCode": "QR Kodu"`)
+- [x] 1.1 Add `"recipe.focusMode.loadError": "Failed to load recipe"` to `packages/shared/src/i18n/en.json` after line 76 (`"recipe.focusMode.notes": "Notes"`) and before line 77 (`"recipe.qrCode": "QR Code"`)
+- [x] 1.2 Add `"recipe.focusMode.loadError": "Tarif yüklenemedi"` to `packages/shared/src/i18n/tr.json` after line 76 (`"recipe.focusMode.notes": "Notlar"`) and before line 77 (`"recipe.qrCode": "QR Kodu"`)
 
 ## 2. RecipeFocusModePage — Imports, State & Docblock
 
-- [ ] 2.1 Import `createLogger` from `../../utils/logger.ts` and add `const log = createLogger('RecipeFocusModePage')` at module scope (after imports, before the component)
-- [ ] 2.2 Add `const [error, setError] = useState<string | null>(null)` alongside existing `recipe` and `allTasteNotes` state declarations
-- [ ] 2.3 Add JSDoc docblock above `export function RecipeFocusModePage()` (line ~12): `/** Renders a focused, distraction-free view of a single brew recipe with stats, bean info, brew timeline, equipment, and tasting notes. */`
+- [x] 2.1 Import `createLogger` from `../../utils/logger.ts` and add `const log = createLogger('RecipeFocusModePage')` at module scope (after imports, before the component)
+- [x] 2.2 Add `const [error, setError] = useState<string | null>(null)` alongside existing `recipe` and `allTasteNotes` state declarations
+- [x] 2.3 Add JSDoc docblock above `export function RecipeFocusModePage()` (line ~12): `/** Renders a focused, distraction-free view of a single brew recipe with stats, bean info, brew timeline, equipment, and tasting notes. */`
 
 ## 3. RecipeFocusModePage — Category 1: Critical Recipe Fetch
 
-- [ ] 3.1 Replace the empty `.catch(() => {})` on `recipeApi.get(slug)` (line ~30) with:
+- [x] 3.1 Replace the empty `.catch(() => {})` on `recipeApi.get(slug)` (line ~30) with:
   ```ts
   .catch((err) => {
     log.error({ err, slug }, 'Failed to fetch recipe for focus mode');
@@ -19,7 +19,7 @@
   })
   ```
 
-- [ ] 3.2 Add error early-return JSX BEFORE the existing `if (!recipe)` loading guard:
+- [x] 3.2 Add error early-return JSX BEFORE the existing `if (!recipe)` loading guard:
   ```tsx
   if (error) {
     return (
@@ -35,7 +35,7 @@
 
 ## 4. RecipeFocusModePage — Category 2: Non-Critical Taste Notes Fetch
 
-- [ ] 4.1 Replace the empty `.catch(() => {})` on `tasteApi.flat()` (line ~23) with:
+- [x] 4.1 Replace the empty `.catch(() => {})` on `tasteApi.flat()` (line ~23) with:
   ```ts
   .catch((err) => {
     log.error({ err }, 'Failed to fetch taste notes for focus mode');
@@ -44,66 +44,66 @@
 
 ## 5. RecipeCreatePage — Category 2 & Docblocks
 
-- [ ] 5.1 Import `createLogger` from `../../utils/logger.ts` and add `const log = createLogger('RecipeCreatePage')` at module scope (after imports, before the component)
-- [ ] 5.2 Replace the empty `.catch(() => {})` on `beanApi.get(beanId)` (line ~87) with:
+- [x] 5.1 Import `createLogger` from `../../utils/logger.ts` and add `const log = createLogger('RecipeCreatePage')` at module scope (after imports, before the component)
+- [x] 5.2 Replace the empty `.catch(() => {})` on `beanApi.get(beanId)` (line ~87) with:
   ```ts
   .catch((err) => {
     log.error({ err, beanId }, 'Failed to pre-fill bean info from URL param');
   })
   ```
-- [ ] 5.3 Add JSDoc docblock above `export function RecipeCreatePage()` (line ~17): `/** Multi-step form for creating a new brew recipe with bean info, brew parameters, equipment selection, taste notes, and preparation instructions. */`
-- [ ] 5.4 Add JSDoc docblock above `function toggleEquipment(id)` (line ~109): `/** Toggles an equipment item in the selected equipment set. */`
-- [ ] 5.5 Add JSDoc docblock above `function setBrewerDetailsFromSetup(value)` (line ~115): `/** Applies brewer details from the selected setup to the form state. */`
-- [ ] 5.6 Add JSDoc docblock above `async function handleSubmit(e)` (line ~127): `/** Validates and submits the recipe creation form. On success navigates to the new recipe page; on failure displays validation or network errors. */`
-- [ ] 5.7 Add JSDoc docblock above `function Section(...)` (line ~518): `/** Card wrapper for form sections with a title header. */`
-- [ ] 5.8 Add JSDoc docblock above `function Field(...)` (line ~527): `/** Labeled form field container with optional required indicator. */`
+- [x] 5.3 Add JSDoc docblock above `export function RecipeCreatePage()` (line ~17): `/** Multi-step form for creating a new brew recipe with bean info, brew parameters, equipment selection, taste notes, and preparation instructions. */`
+- [x] 5.4 Add JSDoc docblock above `function toggleEquipment(id)` (line ~109): `/** Toggles an equipment item in the selected equipment set. */`
+- [x] 5.5 Add JSDoc docblock above `function setBrewerDetailsFromSetup(value)` (line ~115): `/** Applies brewer details from the selected setup to the form state. */`
+- [x] 5.6 Add JSDoc docblock above `async function handleSubmit(e)` (line ~127): `/** Validates and submits the recipe creation form. On success navigates to the new recipe page; on failure displays validation or network errors. */`
+- [x] 5.7 Add JSDoc docblock above `function Section(...)` (line ~518): `/** Card wrapper for form sections with a title header. */`
+- [x] 5.8 Add JSDoc docblock above `function Field(...)` (line ~527): `/** Labeled form field container with optional required indicator. */`
 
 ## 6. TasteAutocomplete — Category 2 & Docblocks
 
-- [ ] 6.1 Import `createLogger` from `../../utils/logger.ts` and add `const log = createLogger('TasteAutocomplete')` at module scope
-- [ ] 6.2 Replace the empty `.catch(() => {})` on `api.get('/taste-notes/flat')` (line ~36) with:
+- [x] 6.1 Import `createLogger` from `../../utils/logger.ts` and add `const log = createLogger('TasteAutocomplete')` at module scope
+- [x] 6.2 Replace the empty `.catch(() => {})` on `api.get('/taste-notes/flat')` (line ~36) with:
   ```ts
   .catch((err) => {
     log.error({ err }, 'Failed to fetch taste notes list');
   })
   ```
-- [ ] 6.3 Add JSDoc docblock above `interface TasteNote` (line ~5): `/** Represents a single taste note node in the SCAA flavor hierarchy. */`
-- [ ] 6.4 Add JSDoc docblock above `interface Props` (line ~12): `/** Props for the TasteAutocomplete component. */`
-- [ ] 6.5 Add JSDoc docblock above `export function TasteAutocomplete(...)` (line ~20): `/** Searchable autocomplete for SCAA taste notes with hierarchical grouping, intensity controls, and keyboard navigation. */`
-- [ ] 6.6 Add JSDoc docblock above `function toggleNote(id)` (line ~155): `/** Adds or removes a taste note from the selection. When adding, defaults intensity to 2. */`
-- [ ] 6.7 Add JSDoc docblock above `function cycleIntensity(id)` (line ~172): `/** Cycles a selected note's intensity through 1 → 2 → 3 → 1. */`
-- [ ] 6.8 Add JSDoc docblock above `function handleKeyDown(e)` (line ~179): `/** Handles keyboard navigation (ArrowUp/Down, Enter, Escape) in the autocomplete dropdown. */`
+- [x] 6.3 Add JSDoc docblock above `interface TasteNote` (line ~5): `/** Represents a single taste note node in the SCAA flavor hierarchy. */`
+- [x] 6.4 Add JSDoc docblock above `interface Props` (line ~12): `/** Props for the TasteAutocomplete component. */`
+- [x] 6.5 Add JSDoc docblock above `export function TasteAutocomplete(...)` (line ~20): `/** Searchable autocomplete for SCAA taste notes with hierarchical grouping, intensity controls, and keyboard navigation. */`
+- [x] 6.6 Add JSDoc docblock above `function toggleNote(id)` (line ~155): `/** Adds or removes a taste note from the selection. When adding, defaults intensity to 2. */`
+- [x] 6.7 Add JSDoc docblock above `function cycleIntensity(id)` (line ~172): `/** Cycles a selected note's intensity through 1 → 2 → 3 → 1. */`
+- [x] 6.8 Add JSDoc docblock above `function handleKeyDown(e)` (line ~179): `/** Handles keyboard navigation (ArrowUp/Down, Enter, Escape) in the autocomplete dropdown. */`
 
 ## 7. RecipeForkPage — Docblock Fix
 
-- [ ] 7.1 Add JSDoc docblock above `async function handleFork()` (line ~44): `/** Creates a fork of the source recipe with the current title. On success navigates to the new recipe's edit page; on failure displays the error. */`
+- [x] 7.1 Add JSDoc docblock above `async function handleFork()` (line ~44): `/** Creates a fork of the source recipe with the current title. On success navigates to the new recipe's edit page; on failure displays the error. */`
 
 ## 8. Tests — RecipeFocusModePage Error State
 
-- [ ] 8.1 Add `vi.mock('@/utils/logger.ts', () => ({ createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }))` BEFORE the component import in `RecipeFocusModePage.test.tsx`, following the established 12-file convention
-- [ ] 8.2 Add `'recipe.focusMode.loadError': 'Failed to load recipe'` to the `enT` helper map (after `recipe.focusMode.by`)
-- [ ] 8.3 Add `'recipe.focusMode.loadError': 'Tarif yüklenemedi'` to the `trT` helper map (after `recipe.focusMode.by`)
-- [ ] 8.4 Add test: "shows error message when recipeApi.get fails" — `mockRecipeApi.get.mockRejectedValue(new Error('Not found'))`, render, verify `waitFor` text "Failed to load recipe" appears, verify "Loading..." does NOT appear
-- [ ] 8.5 Add test: "shows Turkish error message when recipeApi.get fails and locale is tr" — set Turkish locale + mock rejection, verify "Tarif yüklenemedi" appears
-- [ ] 8.6 Add test: "error state does not appear when recipe fetch succeeds" — ensure `recipe.focusMode.loadError` text is NOT in document after successful render
-- [ ] 8.7 Add test: "error div uses error color variable" — mock rejection, verify error text is in a div with `style.color === 'var(--error)'`
-- [ ] 8.8 Run `make test-specific filter=apps/web/src/pages/recipes/RecipeFocusModePage.test.tsx` and verify all tests pass (existing + new)
+- [x] 8.1 Add `vi.mock('@/utils/logger.ts', () => ({ createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }))` BEFORE the component import in `RecipeFocusModePage.test.tsx`, following the established 12-file convention
+- [x] 8.2 Add `'recipe.focusMode.loadError': 'Failed to load recipe'` to the `enT` helper map (after `recipe.focusMode.by`)
+- [x] 8.3 Add `'recipe.focusMode.loadError': 'Tarif yüklenemedi'` to the `trT` helper map (after `recipe.focusMode.by`)
+- [x] 8.4 Add test: "shows error message when recipeApi.get fails" — `mockRecipeApi.get.mockRejectedValue(new Error('Not found'))`, render, verify `waitFor` text "Failed to load recipe" appears, verify "Loading..." does NOT appear
+- [x] 8.5 Add test: "shows Turkish error message when recipeApi.get fails and locale is tr" — set Turkish locale + mock rejection, verify "Tarif yüklenemedi" appears
+- [x] 8.6 Add test: "error state does not appear when recipe fetch succeeds" — ensure `recipe.focusMode.loadError` text is NOT in document after successful render
+- [x] 8.7 Add test: "error div uses error color variable" — mock rejection, verify error text is in a div with `style.color === 'var(--error)'`
+- [x] 8.8 Run `make test-specific filter=apps/web/src/pages/recipes/RecipeFocusModePage.test.tsx` and verify all tests pass (existing + new)
 
 ## 9. Tests — TasteAutocomplete Logger Mock
 
-- [ ] 9.1 Add `vi.mock('@/utils/logger.ts', () => ({ createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }))` BEFORE the component import in `TasteAutocomplete.test.tsx` (the source file will now import `createLogger`, so this mock is required)
-- [ ] 9.2 Run `make test-specific filter=apps/web/src/components/taste/TasteAutocomplete.test.tsx` and verify all existing tests still pass
+- [x] 9.1 Add `vi.mock('@/utils/logger.ts', () => ({ createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }))` BEFORE the component import in `TasteAutocomplete.test.tsx` (the source file will now import `createLogger`, so this mock is required)
+- [x] 9.2 Run `make test-specific filter=apps/web/src/components/taste/TasteAutocomplete.test.tsx` and verify all existing tests still pass
 
 ## 10. Verification
 
-- [ ] 10.1 Run `make fmt` to format all changed files
-- [ ] 10.2 Run `make lint` and verify no new warnings
-- [ ] 10.3 Run `make check-web` and verify TypeScript compilation passes with zero errors
-- [ ] 10.4 Run `make test-web` (or `make test`) and verify ALL tests pass, including the new error-state tests
+- [x] 10.1 Run `make fmt` to format all changed files
+- [x] 10.2 Run `make lint` and verify no new warnings
+- [x] 10.3 Run `make check-web` and verify TypeScript compilation passes with zero errors
+- [x] 10.4 Run `make test-web` (or `make test`) and verify ALL tests pass, including the new error-state tests
 
 ## 11. PR Description
 
-- [ ] 11.1 Create `pr_description.md` at the project root (`/Users/arda.kilicdagi/projects/personal/BrewForm/pr_description.md`) with the following sections:
+- [x] 11.1 Create `pr_description.md` at the project root (`/Users/arda.kilicdagi/projects/personal/BrewForm/pr_description.md`) with the following sections:
 
   **Title**: `# Fix silent error swallowing in client-side data fetching`
 

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -74,6 +74,7 @@
   "recipe.focusMode.ratio": "Ratio",
   "recipe.focusMode.rating": "Rating",
   "recipe.focusMode.notes": "Notes",
+  "recipe.focusMode.loadError": "Failed to load recipe",
   "recipe.qrCode": "QR Code",
   "recipe.share": "Share",
   "recipe.forkedFrom": "Forked from",

--- a/packages/shared/src/i18n/tr.json
+++ b/packages/shared/src/i18n/tr.json
@@ -74,6 +74,7 @@
   "recipe.focusMode.ratio": "Oran",
   "recipe.focusMode.rating": "Puan",
   "recipe.focusMode.notes": "Notlar",
+  "recipe.focusMode.loadError": "Tarif yüklenemedi",
   "recipe.qrCode": "QR Kodu",
   "recipe.share": "Paylaş",
   "recipe.forkedFrom": "Şuradan çatallandı",

--- a/plans/D17-fix-error-swallowing.md
+++ b/plans/D17-fix-error-swallowing.md
@@ -1,152 +1,261 @@
-# D17 — Silent Error Swallowing (15 Occurrences)
+# D17 — Silent Error Swallowing (4 Remaining Occurrences)
 
 ## Severity
 
 **Medium**
 
-## Issue Description
+## Audit Notes (vs. original plan)
 
-The frontend has 15+ occurrences of `.catch(() => {})` that silently swallow errors. When data fetching fails, users see no feedback — the UI just shows an empty state or stuck loading indicator.
+The original plan identified 15 empty `.catch(() => {})` occurrences. A full codebase audit
+against the current `main` branch reveals that **11 of those 15 have already been resolved**
+through the React Router loader migrations carried out in D10–D16. Those pages now use
+`loader` functions registered in `router.tsx`; data fetching errors either propagate to the
+`errorElement` boundary or are explicitly handled inside the loader, so client-side empty
+catches no longer exist in them.
 
-### All Occurrences
+**Occurrences that are gone (loader-migrated):**
 
-| File | Line | Context | Severity |
-|------|------|---------|----------|
-| `RecipeListPage.tsx` | 151 | Equipment list fetch | Low |
-| `RecipeListPage.tsx` | 158 | Taste notes fetch | Low |
-| `RecipeListPage.tsx` | 169 | Coffee variety search | Low |
-| `RecipeListPage.tsx` | 193 | Coffee variety name lookup | Low |
-| `RecipeDetailPage.tsx` | 64 | Taste notes flat fetch | Low |
-| `StarredRecipesPage.tsx` | 131 | Equipment list fetch | Low |
-| `StarredRecipesPage.tsx` | 138 | Taste notes fetch | Low |
-| `SettingsPage.tsx` | 33 | Preferences fetch | Medium |
-| `HomePage.tsx` | 34 | Recipe lists fetch (latest + popular) | Medium |
-| `UserProfilePage.tsx` | 232 | User profile fetch | Medium |
-| `CommentSection.tsx` | 110 | Comments fetch | Medium |
-| `RecipeFocusModePage.tsx` | 23 | Recipe fetch | Medium |
-| `RecipeFocusModePage.tsx` | 30 | Taste notes fetch | Low |
-| `RecipeCreatePage.tsx` | 87 | Setup list fetch | Low |
-| `TasteAutocomplete.tsx` | 36 | Taste notes search | Low |
+| File (original claim) | How it was fixed |
+|-----------------------|-----------------|
+| `RecipeListPage.tsx` × 5 | Full React Router loader (`getEquipmentCached`, `getTasteNotesCached`, `recipeApi.list`) |
+| `StarredRecipesPage.tsx` × 3 | Full React Router loader, 401 → `redirect('/login')` |
+| `SettingsPage.tsx:33` | Loader fetches preferences, wired in `router.tsx` |
+| `HomePage.tsx:34` | Loader fetches latest + popular recipes |
+| `UserProfilePage.tsx:232` | Loader fetches profile + follow data |
+| `CommentSection.tsx:110` | Now receives `initialComments` prop from `RecipeDetailPage` loader; uses `useFetcher` for mutations |
+| `RecipeDetailPage.tsx:64` | Loader fetches `tasteNotes` via `getTasteNotesCached()` in parallel |
+
+One additional empty catch (`AuthContext.tsx:33`) is **intentional** and must not be changed:
+`refreshUser().catch(() => {})` exists because a failed refresh simply means the user has
+no valid session token, and that is a normal (non-error) state on every unauthenticated page
+load. The inner `refreshUser` already has a `try/finally` that ensures `setIsLoading(false)`
+is called in all cases.
+
+---
+
+## Remaining Occurrences (4 total, 3 files)
+
+| File | Line | Actual context | Severity |
+|------|------|---------------|----------|
+| `RecipeFocusModePage.tsx` | 30 | `recipeApi.get(slug)` — recipe fetch (entire page) | **High** |
+| `RecipeFocusModePage.tsx` | 23 | `tasteApi.flat()` — taste-notes fetch | Low |
+| `RecipeCreatePage.tsx` | 87 | `beanApi.get(beanId)` — bean info pre-fill from `?beanId=` URL param | Low |
+| `TasteAutocomplete.tsx` | 36 | `api.get('/taste-notes/flat')` — taste-notes search list | Low |
+
+> **Original plan error — descriptions swapped for `RecipeFocusModePage`:**
+> The original plan listed line 23 as "Recipe fetch (Medium/Critical)" and line 30 as
+> "Taste notes fetch (Low/Non-critical)". These are **reversed**. In the actual source,
+> `tasteApi.flat()` closes at line 23 and `recipeApi.get(slug)` closes at line 30.
+> The category assignments have been corrected accordingly.
+>
+> **Original plan error — wrong context for `RecipeCreatePage:87`:**
+> The original plan labelled line 87 as "Setup list fetch". In reality lines 64/71 are the
+> equipment and setup list fetches (with non-empty catches); line 87 is the `beanApi.get(beanId)`
+> call that pre-fills bean fields from an optional `?beanId=` URL param — a convenience
+> feature whose silent failure is more tolerable, but still worth logging.
+
+---
 
 ## Impact
 
-- **UX**: Users see empty/stuck states with no explanation when API calls fail
-- **Debugging**: No error information is available in the browser console for failed requests
-- **Trust**: Silent failures erode user trust — they don't know if data is missing or if something is broken
+- **UX (`RecipeFocusModePage` recipe fetch)**: When `recipeApi.get` fails the page is stuck
+  showing "Loading…" forever, with no way for the user to understand why or retry.
+- **Debugging**: No error information appears in the browser console for any of the four
+  failures, making production debugging impossible.
+- **Trust**: Silent failures erode user confidence — the UI just hangs or shows empty
+  dropdowns with no explanation.
 
-## Root Cause
-
-`.catch(() => {})` was used as a quick way to suppress unhandled promise rejections during development. The pattern was copy-pasted across pages without considering user-facing error handling.
+---
 
 ## Affected Files
 
-| File | Occurrences |
-|------|-------------|
-| `apps/web/src/pages/recipes/RecipeListPage.tsx` | 5 |
-| `apps/web/src/pages/recipes/StarredRecipesPage.tsx` | 3 |
-| `apps/web/src/pages/settings/SettingsPage.tsx` | 1 |
-| `apps/web/src/pages/HomePage.tsx` | 1 |
-| `apps/web/src/pages/users/UserProfilePage.tsx` | 1 |
-| `apps/web/src/components/recipe/CommentSection.tsx` | 1 |
-| `apps/web/src/pages/recipes/RecipeDetailPage.tsx` | 1 |
+| File | Occurrences remaining |
+|------|----------------------|
 | `apps/web/src/pages/recipes/RecipeFocusModePage.tsx` | 2 |
 | `apps/web/src/pages/recipes/RecipeCreatePage.tsx` | 1 |
 | `apps/web/src/components/taste/TasteAutocomplete.tsx` | 1 |
 
+---
+
 ## Fix Approach
 
-Categorize each occurrence and apply the appropriate fix.
+### Category 1: Critical Data — Show Error State
 
-### Category 1: Critical Data (Show Error State)
-
-These are data loads that the page cannot function without:
+One occurrence where the page cannot render without the data:
 
 | File | Line | Data |
 |------|------|------|
-| `HomePage.tsx` | 34 | Recipe lists (main content) |
-| `UserProfilePage.tsx` | 232 | User profile (entire page) |
-| `SettingsPage.tsx` | 33 | Preferences (settings form) |
-| `CommentSection.tsx` | 110 | Comments (section content) |
-| `RecipeFocusModePage.tsx` | 23 | Recipe (entire page) |
+| `RecipeFocusModePage.tsx` | 30 | Recipe (entire page depends on it) |
 
-**Fix**: Add error state and display an error message:
+**What to do:**
+
+1. Add `error` state and import `createLogger`.
+2. Set the error in the catch block with a structured log.
+3. Add an early-return error screen before the existing `if (!recipe)` guard.
+4. Add the new i18n key `recipe.focusMode.loadError` to **both** locale files (see
+   §[i18n keys](#i18n-keys) below).
 
 ```ts
+// Add imports
+import { createLogger } from '../../utils/logger.ts';
+
+const log = createLogger('RecipeFocusModePage');
+
+// Add state
 const [error, setError] = useState<string | null>(null);
 
-// In the catch block:
-.catch((err) => {
-  log.error({ err }, 'Failed to fetch data');
-  setError(t('errors.loadFailed'));
+// Replace the recipe-fetch catch:
+recipeApi.get(slug).then((data: Record<string, unknown>) => {
+  setRecipe(data);
+}).catch((err) => {
+  log.error({ err, slug }, 'Failed to fetch recipe for focus mode');
+  setError(t('recipe.focusMode.loadError'));
 });
 
-// In the JSX:
+// Add before the existing `if (!recipe)` guard in JSX:
 if (error) {
-  return <div className="text-center py-12 text-[color:var(--error)]">{error}</div>;
+  return (
+    <div
+      className='mx-auto max-w-3xl px-4 sm:px-6 py-12 text-center'
+      style={{ color: 'var(--error)' }}
+    >
+      {error}
+    </div>
+  );
 }
 ```
 
-### Category 2: Non-Critical Data (Log Only)
+### Category 2: Non-Critical Data — Log Only
 
-These are supplementary data loads where failure degrades gracefully:
+Three occurrences where failure degrades gracefully (empty dropdowns / missing pre-fill):
 
 | File | Line | Data |
 |------|------|------|
-| `RecipeListPage.tsx` | 151, 158 | Equipment + taste notes (filter dropdowns empty) |
-| `RecipeListPage.tsx` | 169, 193 | Coffee variety search/name |
-| `StarredRecipesPage.tsx` | 131, 138 | Equipment + taste notes |
-| `RecipeDetailPage.tsx` | 64 | Taste notes flat |
-| `RecipeFocusModePage.tsx` | 30 | Taste notes |
-| `RecipeCreatePage.tsx` | 87 | Setup list |
-| `TasteAutocomplete.tsx` | 36 | Taste note search |
+| `RecipeFocusModePage.tsx` | 23 | `tasteApi.flat()` — taste notes (renders fine without them) |
+| `RecipeCreatePage.tsx` | 87 | `beanApi.get(beanId)` — bean pre-fill (only runs if `?beanId=` is present; user can fill manually) |
+| `TasteAutocomplete.tsx` | 36 | `api.get('/taste-notes/flat')` — autocomplete list (component renders; just no suggestions) |
 
-**Fix**: Replace `.catch(() => {})` with `.catch((err) => log.error({ err }, 'description'))`:
+**Fix** — replace `.catch(() => {})` with a structured log in each:
 
 ```ts
-.catch((err) => {
-  log.error({ err }, 'Failed to fetch equipment list');
+// RecipeFocusModePage.tsx line 23 (logger already added for Category 1):
+}).catch((err) => {
+  log.error({ err }, 'Failed to fetch taste notes for focus mode');
+});
+
+// RecipeCreatePage.tsx line 87 (add createLogger import + log instance):
+import { createLogger } from '../../utils/logger.ts';
+const log = createLogger('RecipeCreatePage');
+
+}).catch((err) => {
+  log.error({ err, beanId }, 'Failed to pre-fill bean info from URL param');
+});
+
+// TasteAutocomplete.tsx line 36 (add createLogger import + log instance):
+import { createLogger } from '../../utils/logger.ts';
+const log = createLogger('TasteAutocomplete');
+
+}).catch((err) => {
+  log.error({ err }, 'Failed to fetch taste notes list');
 });
 ```
 
-### Category 3: CommentSection Special Case
+---
 
-The `CommentSection.tsx` line 110 is a special case — the comments load failure should show an error state within the section:
+## i18n Keys
 
-```ts
-.catch((err) => {
-  log.error({ err }, 'Failed to fetch comments');
-  setStatusMessage(t('comment.loadError'));
-});
+A new translation key is required for the `RecipeFocusModePage` error screen.
+Add it to **both** locale files, following the existing `recipe.fork.loadError` pattern:
+
+**`packages/shared/src/i18n/en.json`** (add after `recipe.focusMode.notes`):
+```json
+"recipe.focusMode.loadError": "Failed to load recipe"
 ```
+
+**`packages/shared/src/i18n/tr.json`** (add after `recipe.focusMode.notes`):
+```json
+"recipe.focusMode.loadError": "Tarif yüklenemedi"
+```
+
+> Note: The original plan used `t('errors.loadFailed')`, which does not exist in either
+> locale file. The correct namespace is `error.*` (no trailing 's'). Rather than reusing
+> the overly generic `error.500` ("Something went wrong"), the new key above follows the
+> established `recipe.*.loadError` pattern already used by `RecipeForkPage`.
+
+---
 
 ## Implementation Steps
 
-1. Audit all `.catch(() => {})` occurrences (15 found — see table above)
-2. For each occurrence, categorize as Critical or Non-Critical
-3. For Critical (5 occurrences):
-   - Add `error` state variable
-   - Add `log.error()` call in catch block
-   - Add error message display in JSX
-4. For Non-Critical (10 occurrences):
-   - Replace `.catch(() => {})` with `.catch((err) => log.error({ err }, 'description'))`
-5. Ensure all files import `createLogger` and create a logger instance
-6. Run `make check-web`
+1. Add `recipe.focusMode.loadError` to `en.json` and `tr.json`.
+2. In `RecipeFocusModePage.tsx`:
+   - Import `createLogger` from `../../utils/logger.ts`.
+   - Create `const log = createLogger('RecipeFocusModePage')`.
+   - Add `const [error, setError] = useState<string | null>(null)`.
+   - Replace the `recipeApi.get` empty catch (line 30) with log + `setError` (Category 1 fix).
+   - Replace the `tasteApi.flat` empty catch (line 23) with `log.error` only (Category 2 fix).
+   - Add the error early-return before the `if (!recipe)` guard in JSX.
+3. In `RecipeCreatePage.tsx`:
+   - Import `createLogger` and create `const log = createLogger('RecipeCreatePage')`.
+   - Replace the `beanApi.get` empty catch (line 87) with `log.error` (Category 2 fix).
+4. In `TasteAutocomplete.tsx`:
+   - Import `createLogger` and create `const log = createLogger('TasteAutocomplete')`.
+   - Replace the `api.get` empty catch (line 36) with `log.error` (Category 2 fix).
+5. Run `make check-web`.
+
+---
 
 ## Testing Strategy
 
-- Disconnect network in DevTools → navigate to HomePage → verify error message appears
-- Disconnect network → navigate to UserProfilePage → verify error message appears
-- Disconnect network → navigate to SettingsPage → verify error message appears
-- Disconnect network → open a recipe → verify CommentSection shows error
-- Check browser console for structured error logs from non-critical failures
-- Verify equipment/taste notes filter dropdowns still work when API is available
+- Disconnect network in DevTools → navigate to `/recipes/<slug>/focus` →
+  verify the error message ("Failed to load recipe") appears instead of an infinite
+  loading state.
+- With network connected → navigate to `/recipes/<slug>/focus` → verify the page
+  renders normally (error state is not shown).
+- Disconnect network → open any recipe create form → observe browser console for a
+  structured `[RecipeCreatePage]` error entry (no user-facing change since bean pre-fill
+  is silent-by-design when no `?beanId=` param is set; test with a valid `?beanId=<uuid>`
+  URL to confirm the catch fires).
+- Disconnect network → open a recipe form with `TasteAutocomplete` → observe browser
+  console for a structured `[TasteAutocomplete]` error entry; autocomplete renders but
+  shows no suggestions.
+
+---
+
+## Additional Observations (Out of Scope for D17)
+
+**`RecipeCreatePage.tsx` lines 64 and 71** already have non-empty catches:
+
+```ts
+.catch(() => setEquipError('Failed to load equipment'))  // line 64
+.catch(() => setEquipError('Failed to load setups'))      // line 71
+```
+
+These show a user-facing error but use a hardcoded English string and have no `log.error()`.
+They are not silent failures, so they fall outside D17's scope, but the missing structured
+log should be addressed in **D26** (Expand Logging), which already lists `RecipeCreatePage`
+as a P1 target.
+
+**`RecipeFocusModePage`** is the only remaining page-level component that still uses
+`useEffect`+`useState` for data fetching rather than a React Router `loader`. A full loader
+migration (matching `RecipeDetailPage`) would be architecturally cleaner and eliminate these
+catches entirely, but that is a larger change outside D17's scope.
+
+---
 
 ## Risk Assessment
 
-- **Low**: Adding error logging is non-breaking
-- **Low**: Adding error states to critical pages is additive
-- **Medium**: Must verify error states render correctly with existing UI patterns
+- **Low**: Adding `log.error()` is fully non-breaking.
+- **Low**: The error state addition to `RecipeFocusModePage` is additive; it only fires on
+  real fetch failures that currently leave the page broken anyway.
+- **Low**: New i18n keys are additive; missing keys fall back gracefully in the i18n context.
+
+---
 
 ## Dependencies
 
-- None (standalone fix, but pairs well with D10 TanStack Query which handles errors natively)
+- None for the core fix.
+- Overlaps with **D26** (Expand Logging) for `RecipeCreatePage` structured logging;
+  D17's `log.error()` additions in that file are a strict subset of D26's broader work.
+- Note: The original plan mentioned pairing with "D10 TanStack Query" — D10 was implemented
+  as React Router loader/action/`useFetcher` adoption (not TanStack Query); the reference is
+  no longer meaningful.


### PR DESCRIPTION
# Fix silent error swallowing in client-side data fetching

## Summary

Four client-side `.catch(() => {})` blocks were silently swallowing errors in the BrewForm web app, leaving users with infinite loading spinners (RecipeFocusModePage) or empty dropdowns (TasteAutocomplete, RecipeCreatePage) with zero diagnostic information. These silent failures eroded user trust and made production debugging impossible.

This PR replaces all 4 empty catches with structured logging (`createLogger` + `log.error({ err, ...context })`) and adds a user-facing error screen for the critical recipe fetch in RecipeFocusModePage. Non-critical fetches (taste notes, bean pre-fill) now log errors for debugging without cluttering the UI.

## What's in this PR

- `apps/web/src/pages/recipes/RecipeFocusModePage.tsx` — Added structured error logging (`createLogger`), error state for recipe fetch failure, JSDoc docblock on the exported component, and `useState` for error tracking
- `apps/web/src/pages/recipes/RecipeCreatePage.tsx` — Added structured error logging for bean pre-fill failure, JSDoc docblocks on all exported functions and helper components (`toggleEquipment`, `setBrewerDetailsFromSetup`, `handleSubmit`, `Section`, `Field`)
- `apps/web/src/components/taste/TasteAutocomplete.tsx` — Added structured error logging for taste notes fetch failure, JSDoc docblocks on all exported functions/interfaces (`TasteNote`, `Props`, `TasteAutocomplete`, `toggleNote`, `cycleIntensity`, `handleKeyDown`)
- `apps/web/src/pages/recipes/RecipeForkPage.tsx` — Added JSDoc docblock on `handleFork`
- `packages/shared/src/i18n/en.json` — Added `recipe.focusMode.loadError` key
- `packages/shared/src/i18n/tr.json` — Added `recipe.focusMode.loadError` key
- `apps/web/src/pages/recipes/RecipeFocusModePage.test.tsx` — Added `createLogger` mock, i18n keys, and 4 new error-state test cases (failure rendering, Turkish locale, success path, error styling)
- `apps/web/src/components/taste/TasteAutocomplete.test.tsx` — Added `createLogger` mock

## How to verify

- `make check-web` — zero TypeScript errors
- `make test-web` — all tests pass (792 tests, 58 test files)
- Manual: Disconnect network → navigate to `/recipes/<slug>/focus` → verify "Failed to load recipe" error message appears instead of infinite loading
- Manual: With network → verify normal page renders
- Manual: Disconnect network → open recipe create form with `?beanId=<uuid>` → verify `[RecipeCreatePage]` error entry in browser console
- Manual: Disconnect network → open TasteAutocomplete → verify `[TasteAutocomplete]` error entry in browser console

## Risk & Rollback

- **Low risk** — additive changes only, no backend/schema/dependency changes
- Error state only fires on fetch failures that already leave the page broken
- New i18n keys are additive; `t()` falls back to raw key display if missing
- Rollback: clean `git revert`

## Checklist

- [x] 4 empty catches replaced with structured error handling
- [x] Critical fetch shows user-facing error screen
- [x] Non-critical fetches log errors for debugging
- [x] i18n keys in both English and Turkish
- [x] JSDoc docblocks on all exported functions in affected files
- [x] `createLogger` mocks in both affected test files
- [x] New automated tests for error state
- [x] `make fmt`, `make lint`, `make check-web`, `make test-web` pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recipe Focus Mode now displays a user-friendly error message when recipe loading fails.

* **Bug Fixes**
  * Replaced silent error handling with proper error logging and reporting across multiple components.
  * Critical fetch failures now surface errors to users instead of failing silently.

* **Documentation**
  * Added error-handling standards and specifications for improved reliability across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->