### PR TITLE
feat: d25: D25 — Complete OpenAPI Documentation for All Route Modules

### DIFF
--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -50,3 +50,26 @@ Never call `Deno.openKv()` directly. Use `CacheProvider` interface injected via 
 - Error logs must include the `err` object for stack trace correlation
 - Env vars: LOG_LEVEL=info, LOG_FORMAT=json (API); VITE_LOG_LEVEL=info (web)
 - See TODO_logs.md for modules still needing coverage
+
+## OpenAPI Documentation
+
+- **Every new route (or request/response shape change) must add OpenAPI metadata** so the spec at
+  `/api/v1/openapi.json` and the Scalar UI at `/api/v1/docs` stay complete — mandatory, like logging.
+- Prepend `describeRoute({ tags, summary, description, security, parameters, requestBody, responses })`
+  (from `hono-openapi`) to every route in `index.ts`.
+- **Keep `zValidator(...)` as the request validator (ADR-012); never import `hono-openapi`'s `validator`.**
+  Metadata is additive — no runtime/status/body changes.
+- Responses: `resolver(successEnvelope(XOutputSchema))` / `resolver(paginatedEnvelope(XOutputSchema))`,
+  and `resolver(ErrorEnvelopeSchema)` for each documented error (always `401` on auth-guarded routes).
+- Request bodies: `jsonRequestBody(InputSchema)` from `apps/api/src/utils/openapi/index.ts`
+  (`z.toJSONSchema` on the same schema `zValidator` uses) — NOT `resolver()` (v1.3.0 resolver only
+  handles responses).
+- **Never `import 'zod-openapi/extend'`** — the subpath does not exist in `zod-openapi` v5 and breaks
+  the build; `resolver()` reads Zod v4 metadata natively.
+- Envelope helpers: `packages/shared/src/schemas/response.ts` (`ErrorEnvelopeSchema`, `PaginationMetaSchema`,
+  `successEnvelope`, `paginatedEnvelope`). Entity output schemas: `packages/shared/src/schemas/responses/`
+  (`<Entity>OutputSchema`), derived from the ACTUAL `service.ts` return shape, each additive + co-located test.
+- Register any new tag in the `tags` array in `apps/api/src/routes/openapi.ts`. Non-JSON routes document
+  their real content type (text/html, application/xml, image/*), not a JSON envelope.
+- The coverage test `apps/api/src/routes/openapi.coverage.test.ts` enforces full documentation, tagging,
+  and zero orphan tags.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,37 @@ Every domain module follows 3-layer pattern: `model.ts` → `service.ts` → `in
 - All Hono routes use typed `<AppEnv>` context (userId, user, cache, requestId).
 - Middleware stack order: cors → requestId → rateLimit(100/min) → cache injection → error handler → routes.
 
+## OpenAPI documentation
+
+Every new route (or change to a route's request/response shape) MUST include OpenAPI
+metadata so the generated spec at `/api/v1/openapi.json` and the Scalar UI at `/api/v1/docs`
+stay complete. This is mandatory, like logging — a route without `describeRoute()` is incomplete.
+
+- Prepend `describeRoute({ ... })` (from `hono-openapi`) to every route with: `tags`, `summary`,
+  `description`, `security: [{ bearerAuth: [] }]` on auth-guarded routes, path/query `parameters`,
+  a `requestBody`, and typed `responses`.
+- **Keep `@hono/zod-validator`'s `zValidator(...)` as the request validator (ADR-012).** Never
+  import `hono-openapi`'s `validator`. OpenAPI metadata is additive and must not change runtime
+  behavior, status codes, or response bodies.
+- **Responses:** wrap the entity's Output Schema in an envelope and pass it through `resolver()`:
+  `resolver(successEnvelope(XOutputSchema))`, `resolver(paginatedEnvelope(XOutputSchema))`, and
+  `resolver(ErrorEnvelopeSchema)` for every documented error (always `401` on auth-guarded routes,
+  plus `404`/`403`/`400`/`409` where the handler maps them).
+- **Request bodies:** use `jsonRequestBody(InputSchema)` from `apps/api/src/utils/openapi/index.ts`
+  (it runs Zod v4 `z.toJSONSchema` on the SAME schema `zValidator` uses). Do NOT use `resolver()`
+  for request bodies — in `hono-openapi` v1.3.0 `resolver()` only converts response schemas.
+- **Do NOT** `import 'zod-openapi/extend'` — that subpath does not exist in `zod-openapi` v5 and
+  breaks the build; `resolver()` reads metadata natively from Zod v4 schemas.
+- **Response/entity schemas** live in `packages/shared/src/schemas/responses/` (`<Entity>OutputSchema`),
+  the envelope helpers in `packages/shared/src/schemas/response.ts`. Derive output schemas from the
+  ACTUAL `service.ts` return shape (joined objects, computed/count fields, flags), add each as an
+  additive export with a co-located unit test, and register any new tag in the `tags` array in
+  `apps/api/src/routes/openapi.ts`.
+- Non-JSON routes document their true content type (e.g. `text/html`, `application/xml`, `image/*`)
+  and are NOT wrapped in a JSON success envelope.
+- The introspection coverage test `apps/api/src/routes/openapi.coverage.test.ts` enforces that every
+  in-scope route is documented, tagged, and free of orphan tags — run `make test-api` after adding routes.
+
 ## Database rules
 
 - **No raw SQL** — Drizzle ORM only. No JSONB/UUID columns. No Postgres-specific operators.

--- a/apps/api/src/modules/badge/index.ts
+++ b/apps/api/src/modules/badge/index.ts
@@ -42,7 +42,7 @@ badge.get(
   '/user/:userId',
   describeRoute({
     tags: ['Badges'],
-    summary: 'List a user\'s badges',
+    summary: "List a user's badges",
     description: 'Returns the badges awarded to the given user.',
     parameters: [
       { name: 'userId', in: 'path', required: true, schema: { type: 'string' } },
@@ -69,7 +69,7 @@ badge.post(
   '/evaluate/:userId',
   describeRoute({
     tags: ['Badges'],
-    summary: 'Evaluate a user\'s badges',
+    summary: "Evaluate a user's badges",
     description: 'Admin-only: re-evaluates and awards badges for the given user.',
     security: [{ bearerAuth: [] }],
     parameters: [

--- a/apps/api/src/modules/badge/index.ts
+++ b/apps/api/src/modules/badge/index.ts
@@ -1,4 +1,13 @@
 import { Hono } from 'hono';
+import { describeRoute, resolver } from 'hono-openapi';
+import { z } from 'zod';
+import {
+  BadgeOutputSchema,
+  ErrorEnvelopeSchema,
+  MessageResponseSchema,
+  successEnvelope,
+  UserBadgeOutputSchema,
+} from '@brewform/shared/schemas';
 import { adminMiddleware, authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { success } from '../../utils/response/index.ts';
@@ -6,21 +15,90 @@ import type { AppEnv } from '../../types/hono.ts';
 
 const badge = new Hono<AppEnv>();
 
-badge.get('/', async (c) => {
-  const badges = await service.listBadges();
-  return success(c, badges);
-});
+badge.get(
+  '/',
+  describeRoute({
+    tags: ['Badges'],
+    summary: 'List badges',
+    description: 'Returns all achievement badges.',
+    responses: {
+      200: {
+        description: 'List of badges',
+        content: {
+          'application/json': {
+            schema: resolver(successEnvelope(z.array(BadgeOutputSchema))),
+          },
+        },
+      },
+    },
+  }),
+  async (c) => {
+    const badges = await service.listBadges();
+    return success(c, badges);
+  },
+);
 
-badge.get('/user/:userId', async (c) => {
-  const userId = c.req.param('userId')!;
-  const badges = await service.getUserBadges(userId);
-  return success(c, badges);
-});
+badge.get(
+  '/user/:userId',
+  describeRoute({
+    tags: ['Badges'],
+    summary: 'List a user\'s badges',
+    description: 'Returns the badges awarded to the given user.',
+    parameters: [
+      { name: 'userId', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'List of user badges',
+        content: {
+          'application/json': {
+            schema: resolver(successEnvelope(z.array(UserBadgeOutputSchema))),
+          },
+        },
+      },
+    },
+  }),
+  async (c) => {
+    const userId = c.req.param('userId')!;
+    const badges = await service.getUserBadges(userId);
+    return success(c, badges);
+  },
+);
 
-badge.post('/evaluate/:userId', authMiddleware, adminMiddleware, async (c) => {
-  const userId = c.req.param('userId')!;
-  await service.evaluateBadges(userId);
-  return success(c, { message: 'Badge evaluation completed' });
-});
+badge.post(
+  '/evaluate/:userId',
+  describeRoute({
+    tags: ['Badges'],
+    summary: 'Evaluate a user\'s badges',
+    description: 'Admin-only: re-evaluates and awards badges for the given user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'userId', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Badge evaluation completed',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(MessageResponseSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Forbidden (requires admin)',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  adminMiddleware,
+  async (c) => {
+    const userId = c.req.param('userId')!;
+    await service.evaluateBadges(userId);
+    return success(c, { message: 'Badge evaluation completed' });
+  },
+);
 
 export default badge;

--- a/apps/api/src/modules/bean/index.ts
+++ b/apps/api/src/modules/bean/index.ts
@@ -1,71 +1,216 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
 import { BeanCreateSchema, BeanUpdateSchema, PaginationSchema } from '@brewform/shared/schemas';
+import {
+  BeanOutputSchema,
+  ErrorEnvelopeSchema,
+  MessageResponseSchema,
+  paginatedEnvelope,
+  successEnvelope,
+} from '@brewform/shared/schemas';
 import { authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { error, paginated, success } from '../../utils/response/index.ts';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
 const bean = new Hono<AppEnv>();
 
-bean.get('/', authMiddleware, zValidator('query', PaginationSchema), async (c) => {
-  const userId = c.get('userId') as string;
-  const { page, perPage } = c.req.valid('query');
-  const result = await service.listBeans(userId, page, perPage);
-  return paginated(c, result.beans, {
-    page,
-    perPage,
-    total: result.total,
-    totalPages: Math.ceil(result.total / perPage),
-  });
-});
+bean.get(
+  '/',
+  describeRoute({
+    tags: ['Beans'],
+    summary: 'List beans',
+    description: 'Paginated list of coffee beans owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    ],
+    responses: {
+      200: {
+        description: 'Paginated list of beans',
+        content: {
+          'application/json': { schema: resolver(paginatedEnvelope(BeanOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  zValidator('query', PaginationSchema),
+  async (c) => {
+    const userId = c.get('userId') as string;
+    const { page, perPage } = c.req.valid('query');
+    const result = await service.listBeans(userId, page, perPage);
+    return paginated(c, result.beans, {
+      page,
+      perPage,
+      total: result.total,
+      totalPages: Math.ceil(result.total / perPage),
+    });
+  },
+);
 
-bean.get('/:id', async (c) => {
-  const id = c.req.param('id')!;
-  try {
-    const b = await service.getBean(id);
-    return success(c, b);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'BEAN_NOT_FOUND') return error(c, 'NOT_FOUND', 'Bean not found', 404);
-    throw err;
-  }
-});
+bean.get(
+  '/:id',
+  describeRoute({
+    tags: ['Beans'],
+    summary: 'Get a bean by id',
+    description: 'Returns a single coffee bean by its id.',
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Bean payload',
+        content: { 'application/json': { schema: resolver(successEnvelope(BeanOutputSchema)) } },
+      },
+      404: {
+        description: 'Bean not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  async (c) => {
+    const id = c.req.param('id')!;
+    try {
+      const b = await service.getBean(id);
+      return success(c, b);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'BEAN_NOT_FOUND') return error(c, 'NOT_FOUND', 'Bean not found', 404);
+      throw err;
+    }
+  },
+);
 
-bean.post('/', authMiddleware, zValidator('json', BeanCreateSchema), async (c) => {
-  const userId = c.get('userId') as string;
-  const body = c.req.valid('json');
-  const b = await service.createBean(userId, body);
-  return success(c, b, 201);
-});
+bean.post(
+  '/',
+  describeRoute({
+    tags: ['Beans'],
+    summary: 'Create a bean',
+    description: 'Creates a coffee bean owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(BeanCreateSchema),
+    responses: {
+      201: {
+        description: 'Bean created',
+        content: { 'application/json': { schema: resolver(successEnvelope(BeanOutputSchema)) } },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  zValidator('json', BeanCreateSchema),
+  async (c) => {
+    const userId = c.get('userId') as string;
+    const body = c.req.valid('json');
+    const b = await service.createBean(userId, body);
+    return success(c, b, 201);
+  },
+);
 
-bean.patch('/:id', authMiddleware, zValidator('json', BeanUpdateSchema), async (c) => {
-  const id = c.req.param('id')!;
-  const userId = c.get('userId') as string;
-  const body = c.req.valid('json');
-  try {
-    const b = await service.updateBean(userId, id, body);
-    return success(c, b);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'BEAN_NOT_FOUND') return error(c, 'NOT_FOUND', 'Bean not found', 404);
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your bean', 403);
-    throw err;
-  }
-});
+bean.patch(
+  '/:id',
+  describeRoute({
+    tags: ['Beans'],
+    summary: 'Update a bean',
+    description: 'Updates a coffee bean owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    requestBody: jsonRequestBody(BeanUpdateSchema),
+    responses: {
+      200: {
+        description: 'Bean updated',
+        content: { 'application/json': { schema: resolver(successEnvelope(BeanOutputSchema)) } },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Not your bean',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Bean not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  zValidator('json', BeanUpdateSchema),
+  async (c) => {
+    const id = c.req.param('id')!;
+    const userId = c.get('userId') as string;
+    const body = c.req.valid('json');
+    try {
+      const b = await service.updateBean(userId, id, body);
+      return success(c, b);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'BEAN_NOT_FOUND') return error(c, 'NOT_FOUND', 'Bean not found', 404);
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your bean', 403);
+      throw err;
+    }
+  },
+);
 
-bean.delete('/:id', authMiddleware, async (c) => {
-  const id = c.req.param('id')!;
-  const userId = c.get('userId') as string;
-  try {
-    await service.deleteBean(userId, id);
-    return success(c, { message: 'Bean deleted' });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'BEAN_NOT_FOUND') return error(c, 'NOT_FOUND', 'Bean not found', 404);
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your bean', 403);
-    throw err;
-  }
-});
+bean.delete(
+  '/:id',
+  describeRoute({
+    tags: ['Beans'],
+    summary: 'Delete a bean',
+    description: 'Deletes a coffee bean owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Bean deleted',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(MessageResponseSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Not your bean',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Bean not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const id = c.req.param('id')!;
+    const userId = c.get('userId') as string;
+    try {
+      await service.deleteBean(userId, id);
+      return success(c, { message: 'Bean deleted' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'BEAN_NOT_FOUND') return error(c, 'NOT_FOUND', 'Bean not found', 404);
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your bean', 403);
+      throw err;
+    }
+  },
+);
 
 export default bean;

--- a/apps/api/src/modules/coffee-variety/index.ts
+++ b/apps/api/src/modules/coffee-variety/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import type { Context, Next } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
 import { z } from 'zod';
 import type { AppEnv } from '../../types/hono.ts';
 import { authMiddleware } from '../../middleware/auth.ts';
@@ -10,8 +11,16 @@ import {
   CoffeeVarietyUpdateSchema,
   SearchQuerySchema,
 } from '@brewform/shared/schemas';
+import {
+  CoffeeVarietyOutputSchema,
+  ErrorEnvelopeSchema,
+  paginatedEnvelope,
+  RecipeWithVersionsOutputSchema,
+  successEnvelope,
+} from '@brewform/shared/schemas';
 import * as service from './service.ts';
 import { error, paginated, success } from '../../utils/response/index.ts';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 
 export const deps = { authMiddleware, service };
 
@@ -27,109 +36,301 @@ const CoffeeVarietyRecipesQuerySchema = z.object({
 
 const router = new Hono<AppEnv>();
 
-router.get('/', zValidator('query', CoffeeVarietyFilterSchema), async (c) => {
-  const query = c.req.valid('query');
-  const result = await deps.service.listCoffeeVarieties(query);
-  return paginated(c, result.data, {
-    page: query.page ?? 1,
-    perPage: query.perPage ?? 20,
-    total: result.total,
-    totalPages: Math.ceil(result.total / (query.perPage ?? 20)),
-  });
-});
+router.get(
+  '/',
+  describeRoute({
+    tags: ['Coffee Varieties'],
+    summary: 'List coffee varieties',
+    description: 'Paginated, filterable list of coffee varieties.',
+    responses: {
+      200: {
+        description: 'Paginated list of coffee varieties',
+        content: {
+          'application/json': {
+            schema: resolver(paginatedEnvelope(CoffeeVarietyOutputSchema)),
+          },
+        },
+      },
+    },
+  }),
+  zValidator('query', CoffeeVarietyFilterSchema),
+  async (c) => {
+    const query = c.req.valid('query');
+    const result = await deps.service.listCoffeeVarieties(query);
+    return paginated(c, result.data, {
+      page: query.page ?? 1,
+      perPage: query.perPage ?? 20,
+      total: result.total,
+      totalPages: Math.ceil(result.total / (query.perPage ?? 20)),
+    });
+  },
+);
 
-router.get('/search', zValidator('query', SearchQuerySchema), async (c) => {
-  const { q } = c.req.valid('query');
-  const result = await deps.service.listCoffeeVarieties({ search: q, page: 1, perPage: 20 });
-  return success(c, result.data);
-});
+router.get(
+  '/search',
+  describeRoute({
+    tags: ['Coffee Varieties'],
+    summary: 'Search coffee varieties',
+    description: 'Returns coffee varieties matching the search query.',
+    parameters: [
+      { name: 'q', in: 'query', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'List of matching coffee varieties',
+        content: {
+          'application/json': {
+            schema: resolver(successEnvelope(z.array(CoffeeVarietyOutputSchema))),
+          },
+        },
+      },
+    },
+  }),
+  zValidator('query', SearchQuerySchema),
+  async (c) => {
+    const { q } = c.req.valid('query');
+    const result = await deps.service.listCoffeeVarieties({ search: q, page: 1, perPage: 20 });
+    return success(c, result.data);
+  },
+);
 
-router.post('/', authGuard, zValidator('json', CoffeeVarietyCreateSchema), async (c) => {
-  const body = c.req.valid('json');
-  const userId = c.get('userId')!;
-  try {
-    const result = await deps.service.createCoffeeVariety(body, userId);
-    return success(c, result, 201);
-  } catch (e: unknown) {
-    return error(c, 'BAD_REQUEST', e instanceof Error ? e.message : String(e), 400);
-  }
-});
+router.post(
+  '/',
+  describeRoute({
+    tags: ['Coffee Varieties'],
+    summary: 'Create a coffee variety',
+    description: 'Creates a coffee variety.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(CoffeeVarietyCreateSchema),
+    responses: {
+      201: {
+        description: 'Coffee variety created',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(CoffeeVarietyOutputSchema)) },
+        },
+      },
+      400: {
+        description: 'Bad request',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authGuard,
+  zValidator('json', CoffeeVarietyCreateSchema),
+  async (c) => {
+    const body = c.req.valid('json');
+    const userId = c.get('userId')!;
+    try {
+      const result = await deps.service.createCoffeeVariety(body, userId);
+      return success(c, result, 201);
+    } catch (e: unknown) {
+      return error(c, 'BAD_REQUEST', e instanceof Error ? e.message : String(e), 400);
+    }
+  },
+);
 
-router.get('/:id', async (c) => {
-  const variety = await deps.service.getCoffeeVarietyById(c.req.param('id')!);
-  if (!variety) {
-    return error(c, 'NOT_FOUND', 'Coffee variety not found', 404);
-  }
-  return success(c, variety);
-});
-
-router.patch('/:id', authGuard, zValidator('json', CoffeeVarietyUpdateSchema), async (c) => {
-  const body = c.req.valid('json');
-  const userId = c.get('userId')!;
-  const user = c.get('user') as { isAdmin: boolean } | null;
-  const isAdmin = user?.isAdmin ?? false;
-  try {
-    const result = await deps.service.updateCoffeeVariety(
-      c.req.param('id')!,
-      body,
-      userId,
-      undefined,
-      isAdmin,
-    );
-    return success(c, result);
-  } catch (e: unknown) {
-    const message = e instanceof Error ? e.message : String(e);
-    if (message === 'COFFEE_VARIETY_NOT_FOUND') {
+router.get(
+  '/:id',
+  describeRoute({
+    tags: ['Coffee Varieties'],
+    summary: 'Get a coffee variety by id',
+    description: 'Returns a single coffee variety by its id.',
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Coffee variety payload',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(CoffeeVarietyOutputSchema)) },
+        },
+      },
+      404: {
+        description: 'Coffee variety not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  async (c) => {
+    const variety = await deps.service.getCoffeeVarietyById(c.req.param('id')!);
+    if (!variety) {
       return error(c, 'NOT_FOUND', 'Coffee variety not found', 404);
     }
-    if (message === 'SYSTEM_VARIETY_IMMUTABLE') {
-      return error(c, 'FORBIDDEN', 'Cannot modify system varieties', 403);
-    }
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your coffee variety', 403);
-    return error(c, 'BAD_REQUEST', message, 400);
-  }
-});
+    return success(c, variety);
+  },
+);
 
-router.delete('/:id', authGuard, async (c) => {
-  const userId = c.get('userId')!;
-  const user = c.get('user') as { isAdmin: boolean } | null;
-  const isAdmin = user?.isAdmin ?? false;
-  try {
-    const result = await deps.service.deleteCoffeeVariety(
-      c.req.param('id')!,
-      userId,
-      undefined,
-      isAdmin,
+router.patch(
+  '/:id',
+  describeRoute({
+    tags: ['Coffee Varieties'],
+    summary: 'Update a coffee variety',
+    description: 'Updates a coffee variety owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    requestBody: jsonRequestBody(CoffeeVarietyUpdateSchema),
+    responses: {
+      200: {
+        description: 'Coffee variety updated',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(CoffeeVarietyOutputSchema)) },
+        },
+      },
+      400: {
+        description: 'Bad request',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Forbidden',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Coffee variety not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authGuard,
+  zValidator('json', CoffeeVarietyUpdateSchema),
+  async (c) => {
+    const body = c.req.valid('json');
+    const userId = c.get('userId')!;
+    const user = c.get('user') as { isAdmin: boolean } | null;
+    const isAdmin = user?.isAdmin ?? false;
+    try {
+      const result = await deps.service.updateCoffeeVariety(
+        c.req.param('id')!,
+        body,
+        userId,
+        undefined,
+        isAdmin,
+      );
+      return success(c, result);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (message === 'COFFEE_VARIETY_NOT_FOUND') {
+        return error(c, 'NOT_FOUND', 'Coffee variety not found', 404);
+      }
+      if (message === 'SYSTEM_VARIETY_IMMUTABLE') {
+        return error(c, 'FORBIDDEN', 'Cannot modify system varieties', 403);
+      }
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your coffee variety', 403);
+      return error(c, 'BAD_REQUEST', message, 400);
+    }
+  },
+);
+
+router.delete(
+  '/:id',
+  describeRoute({
+    tags: ['Coffee Varieties'],
+    summary: 'Delete a coffee variety',
+    description: 'Deletes a coffee variety owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Coffee variety deleted',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(CoffeeVarietyOutputSchema)) },
+        },
+      },
+      400: {
+        description: 'Bad request',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Forbidden',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Coffee variety not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authGuard,
+  async (c) => {
+    const userId = c.get('userId')!;
+    const user = c.get('user') as { isAdmin: boolean } | null;
+    const isAdmin = user?.isAdmin ?? false;
+    try {
+      const result = await deps.service.deleteCoffeeVariety(
+        c.req.param('id')!,
+        userId,
+        undefined,
+        isAdmin,
+      );
+      return success(c, result);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (message === 'COFFEE_VARIETY_NOT_FOUND') {
+        return error(c, 'NOT_FOUND', 'Coffee variety not found', 404);
+      }
+      if (message === 'SYSTEM_VARIETY_IMMUTABLE') {
+        return error(c, 'FORBIDDEN', 'Cannot delete system varieties', 403);
+      }
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your coffee variety', 403);
+      return error(c, 'BAD_REQUEST', message, 400);
+    }
+  },
+);
+
+router.get(
+  '/:id/recipes',
+  describeRoute({
+    tags: ['Coffee Varieties'],
+    summary: 'List recipes using a coffee variety',
+    description: 'Paginated list of recipes that use the given coffee variety.',
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    ],
+    responses: {
+      200: {
+        description: 'Paginated list of recipes using the variety',
+        content: {
+          'application/json': {
+            schema: resolver(paginatedEnvelope(RecipeWithVersionsOutputSchema)),
+          },
+        },
+      },
+    },
+  }),
+  zValidator('query', CoffeeVarietyRecipesQuerySchema),
+  async (c) => {
+    const query = c.req.valid('query');
+    const page = query.page;
+    const perPage = query.perPage;
+    const result = await deps.service.getRecipesForVariety(
+      c.req.param('id'),
+      page,
+      perPage,
     );
-    return success(c, result);
-  } catch (e: unknown) {
-    const message = e instanceof Error ? e.message : String(e);
-    if (message === 'COFFEE_VARIETY_NOT_FOUND') {
-      return error(c, 'NOT_FOUND', 'Coffee variety not found', 404);
-    }
-    if (message === 'SYSTEM_VARIETY_IMMUTABLE') {
-      return error(c, 'FORBIDDEN', 'Cannot delete system varieties', 403);
-    }
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your coffee variety', 403);
-    return error(c, 'BAD_REQUEST', message, 400);
-  }
-});
-
-router.get('/:id/recipes', zValidator('query', CoffeeVarietyRecipesQuerySchema), async (c) => {
-  const query = c.req.valid('query');
-  const page = query.page;
-  const perPage = query.perPage;
-  const result = await deps.service.getRecipesForVariety(
-    c.req.param('id'),
-    page,
-    perPage,
-  );
-  return paginated(c, result.data, {
-    page,
-    perPage,
-    total: result.total,
-    totalPages: Math.ceil(result.total / perPage),
-  });
-});
+    return paginated(c, result.data, {
+      page,
+      perPage,
+      total: result.total,
+      totalPages: Math.ceil(result.total / perPage),
+    });
+  },
+);
 
 export default router;

--- a/apps/api/src/modules/comment/index.ts
+++ b/apps/api/src/modules/comment/index.ts
@@ -1,15 +1,59 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
 import { CommentCreateSchema, PaginationSchema } from '@brewform/shared/schemas';
+import {
+  CommentOutputSchema,
+  CommentWithRepliesOutputSchema,
+  ErrorEnvelopeSchema,
+  MessageResponseSchema,
+  paginatedEnvelope,
+  successEnvelope,
+} from '@brewform/shared/schemas';
 import { authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { error, isEmailVerified, paginated, success } from '../../utils/response/index.ts';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
 const comment = new Hono<AppEnv>();
 
 comment.post(
   '/recipe/:recipeId',
+  describeRoute({
+    tags: ['Comments'],
+    summary: 'Create a comment on a recipe',
+    description: 'Creates a comment (or reply) on a recipe. Requires a verified email.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'recipeId', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    requestBody: jsonRequestBody(CommentCreateSchema),
+    responses: {
+      201: {
+        description: 'Comment created',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(CommentOutputSchema)) },
+        },
+      },
+      400: {
+        description: 'Comment thread depth limit exceeded',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Email not verified, or only the recipe author may reply',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Parent comment not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
   authMiddleware,
   zValidator('json', CommentCreateSchema),
   async (c) => {
@@ -56,32 +100,89 @@ comment.post(
   },
 );
 
-comment.get('/recipe/:recipeId', zValidator('query', PaginationSchema), async (c) => {
-  const recipeId = c.req.param('recipeId')!;
-  const { page, perPage } = c.req.valid('query');
-  const result = await service.listComments(recipeId, page, perPage);
-  return paginated(c, result.comments, {
-    page,
-    perPage,
-    total: result.total,
-    totalPages: Math.ceil(result.total / perPage),
-  });
-});
+comment.get(
+  '/recipe/:recipeId',
+  describeRoute({
+    tags: ['Comments'],
+    summary: 'List comments for a recipe',
+    description: 'Paginated list of top-level comments with their replies.',
+    parameters: [
+      { name: 'recipeId', in: 'path', required: true, schema: { type: 'string' } },
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    ],
+    responses: {
+      200: {
+        description: 'Paginated list of comments with replies',
+        content: {
+          'application/json': {
+            schema: resolver(paginatedEnvelope(CommentWithRepliesOutputSchema)),
+          },
+        },
+      },
+    },
+  }),
+  zValidator('query', PaginationSchema),
+  async (c) => {
+    const recipeId = c.req.param('recipeId')!;
+    const { page, perPage } = c.req.valid('query');
+    const result = await service.listComments(recipeId, page, perPage);
+    return paginated(c, result.comments, {
+      page,
+      perPage,
+      total: result.total,
+      totalPages: Math.ceil(result.total / perPage),
+    });
+  },
+);
 
-comment.delete('/:id', authMiddleware, async (c) => {
-  const id = c.req.param('id')!;
-  const userId = c.get('userId') as string;
-  const user = c.get('user') as { isAdmin: boolean } | null;
-  const isAdmin = user?.isAdmin ?? false;
-  try {
-    await service.deleteComment(userId, id, isAdmin);
-    return success(c, { message: 'Comment deleted' });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'COMMENT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Comment not found', 404);
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your comment', 403);
-    throw err;
-  }
-});
+comment.delete(
+  '/:id',
+  describeRoute({
+    tags: ['Comments'],
+    summary: 'Delete a comment',
+    description: 'Deletes a comment owned by the authenticated user (or by an admin).',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Comment deleted',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(MessageResponseSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Not your comment',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Comment not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const id = c.req.param('id')!;
+    const userId = c.get('userId') as string;
+    const user = c.get('user') as { isAdmin: boolean } | null;
+    const isAdmin = user?.isAdmin ?? false;
+    try {
+      await service.deleteComment(userId, id, isAdmin);
+      return success(c, { message: 'Comment deleted' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'COMMENT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Comment not found', 404);
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your comment', 403);
+      throw err;
+    }
+  },
+);
 
 export default comment;

--- a/apps/api/src/modules/contact/index.ts
+++ b/apps/api/src/modules/contact/index.ts
@@ -53,6 +53,10 @@ contact.post(
         description: 'Failed to send the message',
         content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
       },
+      429: {
+        description: 'Rate limit exceeded (3 requests per 15 minutes)',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
     },
   }),
   zValidator('json', contactSchema),

--- a/apps/api/src/modules/contact/index.ts
+++ b/apps/api/src/modules/contact/index.ts
@@ -1,11 +1,14 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
 import { z } from 'zod';
+import { ErrorEnvelopeSchema, MessageResponseSchema, successEnvelope } from '@brewform/shared/schemas';
 import type { AppEnv } from '../../types/hono.ts';
 import { rateLimitMiddleware } from '../../middleware/rateLimit.ts';
 import { config } from '../../config/index.ts';
 import { getTransporter } from '../../utils/notify/index.ts';
 import { error, success } from '../../utils/response/index.ts';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import { createLogger } from '../../utils/logger/index.ts';
 
 const logger = createLogger('contact');
@@ -28,7 +31,28 @@ contact.use(
   }),
 );
 
-contact.post('/', zValidator('json', contactSchema), async (c) => {
+contact.post(
+  '/',
+  describeRoute({
+    tags: ['Contact'],
+    summary: 'Submit a contact message',
+    description: 'Submits a contact-form message. Rate-limited to 3 requests per 15 minutes.',
+    requestBody: jsonRequestBody(contactSchema),
+    responses: {
+      200: {
+        description: 'Message accepted',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(MessageResponseSchema)) },
+        },
+      },
+      500: {
+        description: 'Failed to send the message',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  zValidator('json', contactSchema),
+  async (c) => {
   const data = c.req.valid('json');
 
   logger.info(

--- a/apps/api/src/modules/contact/index.ts
+++ b/apps/api/src/modules/contact/index.ts
@@ -2,7 +2,11 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { describeRoute, resolver } from 'hono-openapi';
 import { z } from 'zod';
-import { ErrorEnvelopeSchema, MessageResponseSchema, successEnvelope } from '@brewform/shared/schemas';
+import {
+  ErrorEnvelopeSchema,
+  MessageResponseSchema,
+  successEnvelope,
+} from '@brewform/shared/schemas';
 import type { AppEnv } from '../../types/hono.ts';
 import { rateLimitMiddleware } from '../../middleware/rateLimit.ts';
 import { config } from '../../config/index.ts';
@@ -53,31 +57,32 @@ contact.post(
   }),
   zValidator('json', contactSchema),
   async (c) => {
-  const data = c.req.valid('json');
+    const data = c.req.valid('json');
 
-  logger.info(
-    { subject: data.subject },
-    'Contact form submission',
-  );
+    logger.info(
+      { subject: data.subject },
+      'Contact form submission',
+    );
 
-  if (config.APP_ENV === 'test') {
-    logger.info('Email skipped (test environment)');
-    return success(c, { message: 'Thank you for your message. We will get back to you soon.' });
-  }
+    if (config.APP_ENV === 'test') {
+      logger.info('Email skipped (test environment)');
+      return success(c, { message: 'Thank you for your message. We will get back to you soon.' });
+    }
 
-  try {
-    await getTransporter().sendMail({
-      from: config.EMAIL_FROM,
-      to: config.ADMIN_EMAIL,
-      subject: `[BrewForm Contact] ${data.subject}`,
-      text: `From: ${data.name} <${data.email}>\n\n${data.message}`,
-    });
+    try {
+      await getTransporter().sendMail({
+        from: config.EMAIL_FROM,
+        to: config.ADMIN_EMAIL,
+        subject: `[BrewForm Contact] ${data.subject}`,
+        text: `From: ${data.name} <${data.email}>\n\n${data.message}`,
+      });
 
-    return success(c, { message: 'Thank you for your message. We will get back to you soon.' });
-  } catch (err) {
-    logger.error({ err }, 'Failed to send contact email');
-    return error(c, 'INTERNAL_ERROR', 'Failed to send message. Please try again later.', 500);
-  }
-});
+      return success(c, { message: 'Thank you for your message. We will get back to you soon.' });
+    } catch (err) {
+      logger.error({ err }, 'Failed to send contact email');
+      return error(c, 'INTERNAL_ERROR', 'Failed to send message. Please try again later.', 500);
+    }
+  },
+);
 
 export default contact;

--- a/apps/api/src/modules/equipment/index.ts
+++ b/apps/api/src/modules/equipment/index.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono';
 import type { Context, Next } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
+import { z } from 'zod';
 import {
   EquipmentCreateSchema,
   EquipmentDeleteRequestSchema,
@@ -9,9 +11,19 @@ import {
   PaginationSchema,
   SearchQuerySchema,
 } from '@brewform/shared/schemas';
+import {
+  EquipmentDeleteRequestResponseSchema,
+  EquipmentOutputSchema,
+  EquipmentRecipesResponseSchema,
+  ErrorEnvelopeSchema,
+  MessageResponseSchema,
+  paginatedEnvelope,
+  successEnvelope,
+} from '@brewform/shared/schemas';
 import { authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { error, paginated, success, zodValidationHook } from '../../utils/response/index.ts';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
 export const deps = { authMiddleware, service };
@@ -23,39 +35,150 @@ async function authGuard(c: Context, next: Next) {
 
 const equipment = new Hono<AppEnv>();
 
-equipment.get('/', zValidator('query', EquipmentFilterSchema), async (c) => {
-  const query = c.req.valid('query');
-  const result = await deps.service.listEquipmentWithFilters(query);
-  return paginated(c, result.items, {
-    page: query.page,
-    perPage: query.perPage,
-    total: result.total,
-    totalPages: Math.ceil(result.total / query.perPage),
-  });
-});
+equipment.get(
+  '/',
+  describeRoute({
+    tags: ['Equipment'],
+    summary: 'List equipment',
+    description: 'Paginated, filterable list of brewing equipment.',
+    responses: {
+      200: {
+        description: 'Paginated list of equipment',
+        content: {
+          'application/json': { schema: resolver(paginatedEnvelope(EquipmentOutputSchema)) },
+        },
+      },
+    },
+  }),
+  zValidator('query', EquipmentFilterSchema),
+  async (c) => {
+    const query = c.req.valid('query');
+    const result = await deps.service.listEquipmentWithFilters(query);
+    return paginated(c, result.items, {
+      page: query.page,
+      perPage: query.perPage,
+      total: result.total,
+      totalPages: Math.ceil(result.total / query.perPage),
+    });
+  },
+);
 
-equipment.get('/search', zValidator('query', SearchQuerySchema), async (c) => {
-  const { q } = c.req.valid('query');
-  const results = await deps.service.searchEquipment(q);
-  return success(c, results);
-});
+equipment.get(
+  '/search',
+  describeRoute({
+    tags: ['Equipment'],
+    summary: 'Search equipment',
+    description: 'Returns equipment matching the search query.',
+    parameters: [
+      { name: 'q', in: 'query', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'List of matching equipment',
+        content: {
+          'application/json': {
+            schema: resolver(successEnvelope(z.array(EquipmentOutputSchema))),
+          },
+        },
+      },
+    },
+  }),
+  zValidator('query', SearchQuerySchema),
+  async (c) => {
+    const { q } = c.req.valid('query');
+    const results = await deps.service.searchEquipment(q);
+    return success(c, results);
+  },
+);
 
-equipment.post('/', authGuard, zValidator('json', EquipmentCreateSchema), async (c) => {
-  const userId = c.get('userId') as string;
-  const body = c.req.valid('json');
-  const item = await deps.service.createEquipment(userId, body);
-  return success(c, item, 201);
-});
+equipment.post(
+  '/',
+  describeRoute({
+    tags: ['Equipment'],
+    summary: 'Create equipment',
+    description: 'Creates a brewing-equipment entry.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(EquipmentCreateSchema),
+    responses: {
+      201: {
+        description: 'Equipment created',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(EquipmentOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authGuard,
+  zValidator('json', EquipmentCreateSchema),
+  async (c) => {
+    const userId = c.get('userId') as string;
+    const body = c.req.valid('json');
+    const item = await deps.service.createEquipment(userId, body);
+    return success(c, item, 201);
+  },
+);
 
-equipment.get('/:id/recipes', zValidator('query', PaginationSchema), async (c) => {
-  const id = c.req.param('id')!;
-  const { page, perPage } = c.req.valid('query');
-  const result = await deps.service.getRecipesForEquipment(id, page, perPage);
-  return c.json({ success: true, ...result });
-});
+equipment.get(
+  '/:id/recipes',
+  describeRoute({
+    tags: ['Equipment'],
+    summary: 'List recipes using a piece of equipment',
+    description: 'Returns recipes that use the given equipment along with a total count.',
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    ],
+    responses: {
+      200: {
+        description: 'Recipes using the equipment (non-standard envelope, no meta)',
+        content: {
+          'application/json': { schema: resolver(EquipmentRecipesResponseSchema) },
+        },
+      },
+    },
+  }),
+  zValidator('query', PaginationSchema),
+  async (c) => {
+    const id = c.req.param('id')!;
+    const { page, perPage } = c.req.valid('query');
+    const result = await deps.service.getRecipesForEquipment(id, page, perPage);
+    return c.json({ success: true, ...result });
+  },
+);
 
 equipment.post(
   '/:id/delete-request',
+  describeRoute({
+    tags: ['Equipment'],
+    summary: 'Request equipment deletion',
+    description: 'Submits a deletion request for the given equipment.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+      { name: 'reason', in: 'query', required: false, schema: { type: 'string' } },
+    ],
+    responses: {
+      201: {
+        description: 'Deletion request created (non-standard envelope, no meta)',
+        content: {
+          'application/json': { schema: resolver(EquipmentDeleteRequestResponseSchema) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Equipment not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
   authGuard,
   zValidator('query', EquipmentDeleteRequestSchema, zodValidationHook),
   async (c) => {
@@ -78,45 +201,136 @@ equipment.post(
   },
 );
 
-equipment.get('/:id', async (c) => {
-  const id = c.req.param('id')!;
-  try {
-    const item = await deps.service.getEquipment(id);
-    return success(c, item);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'EQUIPMENT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Equipment not found', 404);
-    throw err;
-  }
-});
+equipment.get(
+  '/:id',
+  describeRoute({
+    tags: ['Equipment'],
+    summary: 'Get equipment by id',
+    description: 'Returns a single piece of equipment by its id.',
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Equipment payload',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(EquipmentOutputSchema)) },
+        },
+      },
+      404: {
+        description: 'Equipment not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  async (c) => {
+    const id = c.req.param('id')!;
+    try {
+      const item = await deps.service.getEquipment(id);
+      return success(c, item);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'EQUIPMENT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Equipment not found', 404);
+      throw err;
+    }
+  },
+);
 
-equipment.patch('/:id', authGuard, zValidator('json', EquipmentUpdateSchema), async (c) => {
-  const id = c.req.param('id')!;
-  const userId = c.get('userId') as string;
-  const body = c.req.valid('json');
-  try {
-    const item = await deps.service.updateEquipment(userId, id, body);
-    return success(c, item);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'EQUIPMENT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Equipment not found', 404);
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your equipment', 403);
-    throw err;
-  }
-});
+equipment.patch(
+  '/:id',
+  describeRoute({
+    tags: ['Equipment'],
+    summary: 'Update equipment',
+    description: 'Updates a piece of equipment owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    requestBody: jsonRequestBody(EquipmentUpdateSchema),
+    responses: {
+      200: {
+        description: 'Equipment updated',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(EquipmentOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Not your equipment',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Equipment not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authGuard,
+  zValidator('json', EquipmentUpdateSchema),
+  async (c) => {
+    const id = c.req.param('id')!;
+    const userId = c.get('userId') as string;
+    const body = c.req.valid('json');
+    try {
+      const item = await deps.service.updateEquipment(userId, id, body);
+      return success(c, item);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'EQUIPMENT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Equipment not found', 404);
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your equipment', 403);
+      throw err;
+    }
+  },
+);
 
-equipment.delete('/:id', authGuard, async (c) => {
-  const id = c.req.param('id')!;
-  const userId = c.get('userId') as string;
-  try {
-    await deps.service.deleteEquipment(userId, id);
-    return success(c, { message: 'Equipment deleted' });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'EQUIPMENT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Equipment not found', 404);
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your equipment', 403);
-    throw err;
-  }
-});
+equipment.delete(
+  '/:id',
+  describeRoute({
+    tags: ['Equipment'],
+    summary: 'Delete equipment',
+    description: 'Deletes a piece of equipment owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Equipment deleted',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(MessageResponseSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Not your equipment',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Equipment not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authGuard,
+  async (c) => {
+    const id = c.req.param('id')!;
+    const userId = c.get('userId') as string;
+    try {
+      await deps.service.deleteEquipment(userId, id);
+      return success(c, { message: 'Equipment deleted' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'EQUIPMENT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Equipment not found', 404);
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your equipment', 403);
+      throw err;
+    }
+  },
+);
 
 export default equipment;

--- a/apps/api/src/modules/equipment/index.ts
+++ b/apps/api/src/modules/equipment/index.ts
@@ -230,7 +230,9 @@ equipment.get(
       return success(c, item);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      if (message === 'EQUIPMENT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Equipment not found', 404);
+      if (message === 'EQUIPMENT_NOT_FOUND') {
+        return error(c, 'NOT_FOUND', 'Equipment not found', 404);
+      }
       throw err;
     }
   },
@@ -279,7 +281,9 @@ equipment.patch(
       return success(c, item);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      if (message === 'EQUIPMENT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Equipment not found', 404);
+      if (message === 'EQUIPMENT_NOT_FOUND') {
+        return error(c, 'NOT_FOUND', 'Equipment not found', 404);
+      }
       if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your equipment', 403);
       throw err;
     }
@@ -326,7 +330,9 @@ equipment.delete(
       return success(c, { message: 'Equipment deleted' });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      if (message === 'EQUIPMENT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Equipment not found', 404);
+      if (message === 'EQUIPMENT_NOT_FOUND') {
+        return error(c, 'NOT_FOUND', 'Equipment not found', 404);
+      }
       if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your equipment', 403);
       throw err;
     }

--- a/apps/api/src/modules/follow/index.ts
+++ b/apps/api/src/modules/follow/index.ts
@@ -1,6 +1,17 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
 import { PaginationSchema } from '@brewform/shared/schemas';
+import {
+  ErrorEnvelopeSchema,
+  FeedRecipeOutputSchema,
+  FollowerListItemOutputSchema,
+  FollowingListItemOutputSchema,
+  FollowOutputSchema,
+  MessageResponseSchema,
+  paginatedEnvelope,
+  successEnvelope,
+} from '@brewform/shared/schemas';
 import { authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { error, paginated, success } from '../../utils/response/index.ts';
@@ -8,73 +19,210 @@ import type { AppEnv } from '../../types/hono.ts';
 
 const follow = new Hono<AppEnv>();
 
-follow.post('/:userId', authMiddleware, async (c) => {
-  const followingId = c.req.param('userId')!;
-  const followerId = c.get('userId') as string;
-  try {
-    const result = await service.followUser(followerId, followingId);
-    return success(c, result, 201);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'CANNOT_FOLLOW_SELF') {
-      return error(c, 'BAD_REQUEST', 'Cannot follow yourself', 400);
+follow.post(
+  '/:userId',
+  describeRoute({
+    tags: ['Follow'],
+    summary: 'Follow a user',
+    description: 'Creates a follow relationship from the authenticated user to the target user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'userId', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      201: {
+        description: 'Follow created',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(FollowOutputSchema)) },
+        },
+      },
+      400: {
+        description: 'Cannot follow yourself',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      409: {
+        description: 'Already following this user',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const followingId = c.req.param('userId')!;
+    const followerId = c.get('userId') as string;
+    try {
+      const result = await service.followUser(followerId, followingId);
+      return success(c, result, 201);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'CANNOT_FOLLOW_SELF') {
+        return error(c, 'BAD_REQUEST', 'Cannot follow yourself', 400);
+      }
+      if (message === 'ALREADY_FOLLOWING') {
+        return error(c, 'CONFLICT', 'Already following this user', 409);
+      }
+      throw err;
     }
-    if (message === 'ALREADY_FOLLOWING') {
-      return error(c, 'CONFLICT', 'Already following this user', 409);
+  },
+);
+
+follow.delete(
+  '/:userId',
+  describeRoute({
+    tags: ['Follow'],
+    summary: 'Unfollow a user',
+    description: 'Removes the follow relationship from the authenticated user to the target user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'userId', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Unfollowed',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(MessageResponseSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Follow relationship not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const followingId = c.req.param('userId')!;
+    const followerId = c.get('userId') as string;
+    try {
+      await service.unfollowUser(followerId, followingId);
+      return success(c, { message: 'Unfollowed' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'FOLLOW_NOT_FOUND') {
+        return error(c, 'NOT_FOUND', 'Follow relationship not found', 404);
+      }
+      throw err;
     }
-    throw err;
-  }
-});
+  },
+);
 
-follow.delete('/:userId', authMiddleware, async (c) => {
-  const followingId = c.req.param('userId')!;
-  const followerId = c.get('userId') as string;
-  try {
-    await service.unfollowUser(followerId, followingId);
-    return success(c, { message: 'Unfollowed' });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'FOLLOW_NOT_FOUND') {
-      return error(c, 'NOT_FOUND', 'Follow relationship not found', 404);
-    }
-    throw err;
-  }
-});
+follow.get(
+  '/:userId/followers',
+  describeRoute({
+    tags: ['Follow'],
+    summary: 'List followers',
+    description: 'Paginated list of users following the given user.',
+    parameters: [
+      { name: 'userId', in: 'path', required: true, schema: { type: 'string' } },
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    ],
+    responses: {
+      200: {
+        description: 'Paginated list of followers',
+        content: {
+          'application/json': {
+            schema: resolver(paginatedEnvelope(FollowerListItemOutputSchema)),
+          },
+        },
+      },
+    },
+  }),
+  zValidator('query', PaginationSchema),
+  async (c) => {
+    const userId = c.req.param('userId')!;
+    const { page, perPage } = c.req.valid('query');
+    const result = await service.getFollowers(userId, page, perPage);
+    return paginated(c, result.followers, {
+      page,
+      perPage,
+      total: result.total,
+      totalPages: Math.ceil(result.total / perPage),
+    });
+  },
+);
 
-follow.get('/:userId/followers', zValidator('query', PaginationSchema), async (c) => {
-  const userId = c.req.param('userId')!;
-  const { page, perPage } = c.req.valid('query');
-  const result = await service.getFollowers(userId, page, perPage);
-  return paginated(c, result.followers, {
-    page,
-    perPage,
-    total: result.total,
-    totalPages: Math.ceil(result.total / perPage),
-  });
-});
+follow.get(
+  '/:userId/following',
+  describeRoute({
+    tags: ['Follow'],
+    summary: 'List following',
+    description: 'Paginated list of users the given user is following.',
+    parameters: [
+      { name: 'userId', in: 'path', required: true, schema: { type: 'string' } },
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    ],
+    responses: {
+      200: {
+        description: 'Paginated list of following',
+        content: {
+          'application/json': {
+            schema: resolver(paginatedEnvelope(FollowingListItemOutputSchema)),
+          },
+        },
+      },
+    },
+  }),
+  zValidator('query', PaginationSchema),
+  async (c) => {
+    const userId = c.req.param('userId')!;
+    const { page, perPage } = c.req.valid('query');
+    const result = await service.getFollowing(userId, page, perPage);
+    return paginated(c, result.following, {
+      page,
+      perPage,
+      total: result.total,
+      totalPages: Math.ceil(result.total / perPage),
+    });
+  },
+);
 
-follow.get('/:userId/following', zValidator('query', PaginationSchema), async (c) => {
-  const userId = c.req.param('userId')!;
-  const { page, perPage } = c.req.valid('query');
-  const result = await service.getFollowing(userId, page, perPage);
-  return paginated(c, result.following, {
-    page,
-    perPage,
-    total: result.total,
-    totalPages: Math.ceil(result.total / perPage),
-  });
-});
-
-follow.get('/feed', authMiddleware, zValidator('query', PaginationSchema), async (c) => {
-  const userId = c.get('userId') as string;
-  const { page, perPage } = c.req.valid('query');
-  const result = await service.getFeed(userId, page, perPage);
-  return paginated(c, result.recipes, {
-    page,
-    perPage,
-    total: result.total,
-    totalPages: Math.ceil(result.total / perPage),
-  });
-});
+follow.get(
+  '/feed',
+  describeRoute({
+    tags: ['Follow'],
+    summary: 'Get the followed-users feed',
+    description: 'Paginated feed of recipes from users the authenticated user follows.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    ],
+    responses: {
+      200: {
+        description: 'Paginated feed of recipes',
+        content: {
+          'application/json': { schema: resolver(paginatedEnvelope(FeedRecipeOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  zValidator('query', PaginationSchema),
+  async (c) => {
+    const userId = c.get('userId') as string;
+    const { page, perPage } = c.req.valid('query');
+    const result = await service.getFeed(userId, page, perPage);
+    return paginated(c, result.recipes, {
+      page,
+      perPage,
+      total: result.total,
+      totalPages: Math.ceil(result.total / perPage),
+    });
+  },
+);
 
 export default follow;

--- a/apps/api/src/modules/photo/index.ts
+++ b/apps/api/src/modules/photo/index.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
 import { Hono } from 'hono';
+import { describeRoute, resolver } from 'hono-openapi';
+import {
+  ErrorEnvelopeSchema,
+  MessageResponseSchema,
+  PhotoOutputSchema,
+  successEnvelope,
+} from '@brewform/shared/schemas';
 import { authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { error, success } from '../../utils/response/index.ts';
@@ -13,79 +20,189 @@ const PhotoFormSchema = z.object({
   sortOrder: z.coerce.number().int().min(0).default(0),
 });
 
-photo.post('/', authMiddleware, async (c) => {
-  const userId = c.get('userId') as string;
-  const formData = await c.req.formData();
-
-  const fileField = formData.get('file') ?? formData.get('photo');
-  const thumbnailField = formData.get('thumbnail');
-
-  if (!fileField || !(fileField instanceof File)) {
-    return error(c, 'VALIDATION_ERROR', 'File is required', 400);
-  }
-
-  const parsed = PhotoFormSchema.safeParse({
-    recipeId: formData.get('recipeId'),
-    alt: formData.get('alt') || undefined,
-    sortOrder: formData.get('sortOrder') || undefined,
-  });
-
-  if (!parsed.success) {
-    const details = parsed.error.issues.map((issue) => ({
-      field: issue.path.join('.'),
-      message: issue.message,
-    }));
-    return error(c, 'VALIDATION_ERROR', 'Validation failed', 400, details);
-  }
-
-  const { recipeId, alt, sortOrder } = parsed.data;
-
-  const data = new Uint8Array(await fileField.arrayBuffer());
-  const thumbnail = thumbnailField instanceof File && thumbnailField.size > 0
-    ? new Uint8Array(await thumbnailField.arrayBuffer())
-    : null;
-
-  try {
-    const result = await service.uploadPhoto(
-      userId,
-      recipeId,
-      {
-        name: fileField.name,
-        type: fileField.type,
-        size: fileField.size,
-        data,
+photo.post(
+  '/',
+  describeRoute({
+    tags: ['Photos'],
+    summary: 'Upload a recipe photo',
+    description:
+      'Uploads a photo for a recipe via multipart/form-data. The file is parsed manually (not via zValidator).',
+    security: [{ bearerAuth: [] }],
+    requestBody: {
+      content: {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            required: ['file', 'recipeId'],
+            properties: {
+              file: { type: 'string', format: 'binary', description: 'The photo file' },
+              thumbnail: {
+                type: 'string',
+                format: 'binary',
+                description: 'Optional pre-generated thumbnail',
+              },
+              recipeId: { type: 'string', format: 'uuid' },
+              alt: { type: 'string', maxLength: 200 },
+              sortOrder: { type: 'integer', minimum: 0 },
+            },
+          },
+        },
       },
-      thumbnail,
-      alt,
-      sortOrder,
-    );
-    return success(c, result, 201);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'RECIPE_NOT_FOUND') return error(c, 'NOT_FOUND', 'Recipe not found', 404);
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your recipe', 403);
-    return error(c, 'UPLOAD_ERROR', message, 400);
-  }
-});
+    },
+    responses: {
+      201: {
+        description: 'Photo uploaded',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(PhotoOutputSchema)) },
+        },
+      },
+      400: {
+        description: 'Validation or upload error',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Not your recipe',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Recipe not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const userId = c.get('userId') as string;
+    const formData = await c.req.formData();
 
-photo.get('/recipe/:recipeId', async (c) => {
-  const recipeId = c.req.param('recipeId')!;
-  const photos = await service.listPhotos(recipeId);
-  return success(c, photos);
-});
+    const fileField = formData.get('file') ?? formData.get('photo');
+    const thumbnailField = formData.get('thumbnail');
 
-photo.delete('/:id', authMiddleware, async (c) => {
-  const id = c.req.param('id')!;
-  const userId = c.get('userId') as string;
-  try {
-    await service.deletePhoto(userId, id);
-    return success(c, { message: 'Photo deleted' });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'PHOTO_NOT_FOUND') return error(c, 'NOT_FOUND', 'Photo not found', 404);
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Forbidden', 403);
-    throw err;
-  }
-});
+    if (!fileField || !(fileField instanceof File)) {
+      return error(c, 'VALIDATION_ERROR', 'File is required', 400);
+    }
+
+    const parsed = PhotoFormSchema.safeParse({
+      recipeId: formData.get('recipeId'),
+      alt: formData.get('alt') || undefined,
+      sortOrder: formData.get('sortOrder') || undefined,
+    });
+
+    if (!parsed.success) {
+      const details = parsed.error.issues.map((issue) => ({
+        field: issue.path.join('.'),
+        message: issue.message,
+      }));
+      return error(c, 'VALIDATION_ERROR', 'Validation failed', 400, details);
+    }
+
+    const { recipeId, alt, sortOrder } = parsed.data;
+
+    const data = new Uint8Array(await fileField.arrayBuffer());
+    const thumbnail = thumbnailField instanceof File && thumbnailField.size > 0
+      ? new Uint8Array(await thumbnailField.arrayBuffer())
+      : null;
+
+    try {
+      const result = await service.uploadPhoto(
+        userId,
+        recipeId,
+        {
+          name: fileField.name,
+          type: fileField.type,
+          size: fileField.size,
+          data,
+        },
+        thumbnail,
+        alt,
+        sortOrder,
+      );
+      return success(c, result, 201);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'RECIPE_NOT_FOUND') return error(c, 'NOT_FOUND', 'Recipe not found', 404);
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your recipe', 403);
+      return error(c, 'UPLOAD_ERROR', message, 400);
+    }
+  },
+);
+
+photo.get(
+  '/recipe/:recipeId',
+  describeRoute({
+    tags: ['Photos'],
+    summary: 'List photos for a recipe',
+    description: 'Returns all photos attached to the given recipe.',
+    parameters: [
+      { name: 'recipeId', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'List of photos',
+        content: {
+          'application/json': {
+            schema: resolver(successEnvelope(z.array(PhotoOutputSchema))),
+          },
+        },
+      },
+    },
+  }),
+  async (c) => {
+    const recipeId = c.req.param('recipeId')!;
+    const photos = await service.listPhotos(recipeId);
+    return success(c, photos);
+  },
+);
+
+photo.delete(
+  '/:id',
+  describeRoute({
+    tags: ['Photos'],
+    summary: 'Delete a photo',
+    description: 'Deletes a photo owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Photo deleted',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(MessageResponseSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Forbidden',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Photo not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const id = c.req.param('id')!;
+    const userId = c.get('userId') as string;
+    try {
+      await service.deletePhoto(userId, id);
+      return success(c, { message: 'Photo deleted' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'PHOTO_NOT_FOUND') return error(c, 'NOT_FOUND', 'Photo not found', 404);
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Forbidden', 403);
+      throw err;
+    }
+  },
+);
 
 export default photo;

--- a/apps/api/src/modules/preference/index.ts
+++ b/apps/api/src/modules/preference/index.ts
@@ -20,7 +20,7 @@ preference.get(
   describeRoute({
     tags: ['Preferences'],
     summary: 'Get preferences',
-    description: 'Returns the authenticated user\'s preferences.',
+    description: "Returns the authenticated user's preferences.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
@@ -60,7 +60,7 @@ preference.patch(
   describeRoute({
     tags: ['Preferences'],
     summary: 'Update preferences',
-    description: 'Updates the authenticated user\'s preferences.',
+    description: "Updates the authenticated user's preferences.",
     security: [{ bearerAuth: [] }],
     requestBody: jsonRequestBody(UserPreferencesSchema),
     responses: {

--- a/apps/api/src/modules/preference/index.ts
+++ b/apps/api/src/modules/preference/index.ts
@@ -1,47 +1,104 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
 import { UserPreferencesSchema } from '@brewform/shared/schemas';
+import {
+  ErrorEnvelopeSchema,
+  successEnvelope,
+  UserPreferencesOutputSchema,
+} from '@brewform/shared/schemas';
 import { authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { error, success } from '../../utils/response/index.ts';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
 const preference = new Hono<AppEnv>();
 
-preference.get('/', authMiddleware, async (c) => {
-  const userId = c.get('userId') as string;
-  try {
-    const prefs = await service.getPreferences(userId);
-    return success(c, prefs);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'PREFERENCES_NOT_FOUND') {
-      return error(c, 'NOT_FOUND', 'Preferences not found', 404);
+preference.get(
+  '/',
+  describeRoute({
+    tags: ['Preferences'],
+    summary: 'Get preferences',
+    description: 'Returns the authenticated user\'s preferences.',
+    security: [{ bearerAuth: [] }],
+    responses: {
+      200: {
+        description: 'User preferences',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(UserPreferencesOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Preferences not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const userId = c.get('userId') as string;
+    try {
+      const prefs = await service.getPreferences(userId);
+      return success(c, prefs);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'PREFERENCES_NOT_FOUND') {
+        return error(c, 'NOT_FOUND', 'Preferences not found', 404);
+      }
+      throw err;
     }
-    throw err;
-  }
-});
+  },
+);
 
-preference.patch('/', authMiddleware, zValidator('json', UserPreferencesSchema), async (c) => {
-  const userId = c.get('userId') as string;
-  const body = c.req.valid('json');
+preference.patch(
+  '/',
+  describeRoute({
+    tags: ['Preferences'],
+    summary: 'Update preferences',
+    description: 'Updates the authenticated user\'s preferences.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(UserPreferencesSchema),
+    responses: {
+      200: {
+        description: 'Updated user preferences',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(UserPreferencesOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  zValidator('json', UserPreferencesSchema),
+  async (c) => {
+    const userId = c.get('userId') as string;
+    const body = c.req.valid('json');
 
-  const flatData: any = {};
-  if (body.unitSystem !== undefined) flatData.unitSystem = body.unitSystem;
-  if (body.temperatureUnit !== undefined) flatData.temperatureUnit = body.temperatureUnit;
-  if (body.theme !== undefined) flatData.theme = body.theme;
-  if (body.locale !== undefined) flatData.locale = body.locale;
-  if (body.timezone !== undefined) flatData.timezone = body.timezone;
-  if (body.dateFormat !== undefined) flatData.dateFormat = body.dateFormat;
-  if (body.emailNotifications !== undefined) {
-    flatData.newFollower = body.emailNotifications.newFollower;
-    flatData.recipeLiked = body.emailNotifications.recipeLiked;
-    flatData.recipeCommented = body.emailNotifications.recipeCommented;
-    flatData.followedUserPosted = body.emailNotifications.followedUserPosted;
-  }
+    const flatData: any = {};
+    if (body.unitSystem !== undefined) flatData.unitSystem = body.unitSystem;
+    if (body.temperatureUnit !== undefined) flatData.temperatureUnit = body.temperatureUnit;
+    if (body.theme !== undefined) flatData.theme = body.theme;
+    if (body.locale !== undefined) flatData.locale = body.locale;
+    if (body.timezone !== undefined) flatData.timezone = body.timezone;
+    if (body.dateFormat !== undefined) flatData.dateFormat = body.dateFormat;
+    if (body.emailNotifications !== undefined) {
+      flatData.newFollower = body.emailNotifications.newFollower;
+      flatData.recipeLiked = body.emailNotifications.recipeLiked;
+      flatData.recipeCommented = body.emailNotifications.recipeCommented;
+      flatData.followedUserPosted = body.emailNotifications.followedUserPosted;
+    }
 
-  const prefs = await service.updatePreferences(userId, flatData);
-  return success(c, prefs);
-});
+    const prefs = await service.updatePreferences(userId, flatData);
+    return success(c, prefs);
+  },
+);
 
 export default preference;

--- a/apps/api/src/modules/qrcode/index.ts
+++ b/apps/api/src/modules/qrcode/index.ts
@@ -1,9 +1,10 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
 import { z } from 'zod';
 import { config } from '../../config/index.ts';
 import * as service from './service.ts';
-import { QrCodeFilenameSchema } from '@brewform/shared/schemas';
+import { ErrorEnvelopeSchema, QrCodeFilenameSchema } from '@brewform/shared/schemas';
 import { error, zodValidationHook } from '../../utils/response/index.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
@@ -15,6 +16,39 @@ const FilenameParamSchema = z.object({
 
 qrcode.get(
   '/recipe/:filename',
+  describeRoute({
+    tags: ['QR Codes'],
+    summary: 'Get a recipe QR code image',
+    description:
+      'Generates a QR code image for a public recipe. The filename encodes the recipe slug and ' +
+      'desired format (`<slug>.png` or `<slug>.svg`); the response is the raw image, not a JSON envelope.',
+    parameters: [
+      {
+        name: 'filename',
+        in: 'path',
+        required: true,
+        schema: { type: 'string' },
+        description: 'Recipe slug plus extension, e.g. `my-recipe.png` or `my-recipe.svg`.',
+      },
+    ],
+    responses: {
+      200: {
+        description: 'QR code image (PNG or SVG, depending on the requested extension)',
+        content: {
+          'image/png': { schema: { type: 'string', format: 'binary' } },
+          'image/svg+xml': { schema: { type: 'string', format: 'binary' } },
+        },
+      },
+      403: {
+        description: 'Recipe is not publicly available',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Recipe not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
   zValidator('param', FilenameParamSchema, zodValidationHook),
   async (c) => {
     const { filename } = c.req.valid('param');

--- a/apps/api/src/modules/report/index.ts
+++ b/apps/api/src/modules/report/index.ts
@@ -1,15 +1,42 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
 import { ReportCreateSchema, ReportFilterSchema } from '@brewform/shared/schemas';
+import {
+  ErrorEnvelopeSchema,
+  paginatedEnvelope,
+  ReportOutputSchema,
+  successEnvelope,
+} from '@brewform/shared/schemas';
 import { adminMiddleware, authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { error, paginated, success, zodValidationHook } from '../../utils/response/index.ts';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
 const report = new Hono<AppEnv>();
 
 report.post(
   '/',
+  describeRoute({
+    tags: ['Reports'],
+    summary: 'Create a report',
+    description: 'Submits a moderation report against a recipe or comment.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(ReportCreateSchema),
+    responses: {
+      201: {
+        description: 'Report created',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(ReportOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
   authMiddleware,
   zValidator('json', ReportCreateSchema, zodValidationHook),
   async (c) => {
@@ -24,6 +51,33 @@ report.post(
 
 report.get(
   '/',
+  describeRoute({
+    tags: ['Reports'],
+    summary: 'List reports',
+    description: 'Paginated list of moderation reports. Admin only.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'status', in: 'query', required: false, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Paginated list of reports',
+        content: {
+          'application/json': { schema: resolver(paginatedEnvelope(ReportOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Forbidden (admin only)',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
   authMiddleware,
   adminMiddleware,
   zValidator('query', ReportFilterSchema, zodValidationHook),
@@ -39,20 +93,58 @@ report.get(
   },
 );
 
-report.patch('/:id/resolve', authMiddleware, adminMiddleware, async (c) => {
-  const id = c.req.param('id')!;
-  const userId = c.get('userId') as string;
-  try {
-    const result = await service.resolveReport(id, userId);
-    return success(c, result);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'REPORT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Report not found', 404);
-    if (message === 'REPORT_ALREADY_RESOLVED') {
-      return error(c, 'CONFLICT', 'Report already resolved', 409);
+report.patch(
+  '/:id/resolve',
+  describeRoute({
+    tags: ['Reports'],
+    summary: 'Resolve a report',
+    description: 'Marks a moderation report as resolved. Admin only.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Report resolved',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(ReportOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Forbidden (admin only)',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Report not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      409: {
+        description: 'Report already resolved',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  adminMiddleware,
+  async (c) => {
+    const id = c.req.param('id')!;
+    const userId = c.get('userId') as string;
+    try {
+      const result = await service.resolveReport(id, userId);
+      return success(c, result);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'REPORT_NOT_FOUND') return error(c, 'NOT_FOUND', 'Report not found', 404);
+      if (message === 'REPORT_ALREADY_RESOLVED') {
+        return error(c, 'CONFLICT', 'Report already resolved', 409);
+      }
+      throw err;
     }
-    throw err;
-  }
-});
+  },
+);
 
 export default report;

--- a/apps/api/src/modules/setup/index.ts
+++ b/apps/api/src/modules/setup/index.ts
@@ -1,85 +1,269 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
 import { PaginationSchema, SetupCreateSchema, SetupUpdateSchema } from '@brewform/shared/schemas';
+import {
+  ErrorEnvelopeSchema,
+  MessageResponseSchema,
+  paginatedEnvelope,
+  SetupOutputSchema,
+  successEnvelope,
+} from '@brewform/shared/schemas';
 import { authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { error, paginated, success } from '../../utils/response/index.ts';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
 const setup = new Hono<AppEnv>();
 
-setup.get('/', authMiddleware, zValidator('query', PaginationSchema), async (c) => {
-  const userId = c.get('userId') as string;
-  const { page, perPage } = c.req.valid('query');
-  const result = await service.listSetups(userId, page, perPage);
-  return paginated(c, result.setups, {
-    page,
-    perPage,
-    total: result.total,
-    totalPages: Math.ceil(result.total / perPage),
-  });
-});
+setup.get(
+  '/',
+  describeRoute({
+    tags: ['Setups'],
+    summary: 'List setups',
+    description: 'Paginated list of brewing-equipment setups owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    ],
+    responses: {
+      200: {
+        description: 'Paginated list of setups',
+        content: {
+          'application/json': { schema: resolver(paginatedEnvelope(SetupOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  zValidator('query', PaginationSchema),
+  async (c) => {
+    const userId = c.get('userId') as string;
+    const { page, perPage } = c.req.valid('query');
+    const result = await service.listSetups(userId, page, perPage);
+    return paginated(c, result.setups, {
+      page,
+      perPage,
+      total: result.total,
+      totalPages: Math.ceil(result.total / perPage),
+    });
+  },
+);
 
-setup.post('/', authMiddleware, zValidator('json', SetupCreateSchema), async (c) => {
-  const userId = c.get('userId') as string;
-  const body = c.req.valid('json');
-  const result = await service.createSetup(userId, body);
-  return success(c, result, 201);
-});
+setup.post(
+  '/',
+  describeRoute({
+    tags: ['Setups'],
+    summary: 'Create a setup',
+    description: 'Creates a brewing-equipment setup owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(SetupCreateSchema),
+    responses: {
+      201: {
+        description: 'Setup created',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(SetupOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  zValidator('json', SetupCreateSchema),
+  async (c) => {
+    const userId = c.get('userId') as string;
+    const body = c.req.valid('json');
+    const result = await service.createSetup(userId, body);
+    return success(c, result, 201);
+  },
+);
 
-setup.get('/:id', async (c) => {
-  const id = c.req.param('id')!;
-  try {
-    const s = await service.getSetup(id);
-    return success(c, s);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'SETUP_NOT_FOUND') return error(c, 'NOT_FOUND', 'Setup not found', 404);
-    throw err;
-  }
-});
+setup.get(
+  '/:id',
+  describeRoute({
+    tags: ['Setups'],
+    summary: 'Get a setup by id',
+    description: 'Returns a single brewing-equipment setup by its id.',
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Setup payload',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(SetupOutputSchema)) },
+        },
+      },
+      404: {
+        description: 'Setup not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  async (c) => {
+    const id = c.req.param('id')!;
+    try {
+      const s = await service.getSetup(id);
+      return success(c, s);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'SETUP_NOT_FOUND') return error(c, 'NOT_FOUND', 'Setup not found', 404);
+      throw err;
+    }
+  },
+);
 
-setup.patch('/:id', authMiddleware, zValidator('json', SetupUpdateSchema), async (c) => {
-  const id = c.req.param('id')!;
-  const userId = c.get('userId') as string;
-  const body = c.req.valid('json');
-  try {
-    const s = await service.updateSetup(userId, id, body);
-    return success(c, s);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'SETUP_NOT_FOUND') return error(c, 'NOT_FOUND', 'Setup not found', 404);
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your setup', 403);
-    throw err;
-  }
-});
+setup.patch(
+  '/:id',
+  describeRoute({
+    tags: ['Setups'],
+    summary: 'Update a setup',
+    description: 'Updates a brewing-equipment setup owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    requestBody: jsonRequestBody(SetupUpdateSchema),
+    responses: {
+      200: {
+        description: 'Setup updated',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(SetupOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Not your setup',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Setup not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  zValidator('json', SetupUpdateSchema),
+  async (c) => {
+    const id = c.req.param('id')!;
+    const userId = c.get('userId') as string;
+    const body = c.req.valid('json');
+    try {
+      const s = await service.updateSetup(userId, id, body);
+      return success(c, s);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'SETUP_NOT_FOUND') return error(c, 'NOT_FOUND', 'Setup not found', 404);
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your setup', 403);
+      throw err;
+    }
+  },
+);
 
-setup.delete('/:id', authMiddleware, async (c) => {
-  const id = c.req.param('id')!;
-  const userId = c.get('userId') as string;
-  try {
-    await service.deleteSetup(userId, id);
-    return success(c, { message: 'Setup deleted' });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'SETUP_NOT_FOUND') return error(c, 'NOT_FOUND', 'Setup not found', 404);
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your setup', 403);
-    throw err;
-  }
-});
+setup.delete(
+  '/:id',
+  describeRoute({
+    tags: ['Setups'],
+    summary: 'Delete a setup',
+    description: 'Deletes a brewing-equipment setup owned by the authenticated user.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Setup deleted',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(MessageResponseSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Not your setup',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Setup not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const id = c.req.param('id')!;
+    const userId = c.get('userId') as string;
+    try {
+      await service.deleteSetup(userId, id);
+      return success(c, { message: 'Setup deleted' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'SETUP_NOT_FOUND') return error(c, 'NOT_FOUND', 'Setup not found', 404);
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your setup', 403);
+      throw err;
+    }
+  },
+);
 
-setup.post('/:id/set-default', authMiddleware, async (c) => {
-  const id = c.req.param('id')!;
-  const userId = c.get('userId') as string;
-  try {
-    const s = await service.setDefault(userId, id);
-    return success(c, s);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'SETUP_NOT_FOUND') return error(c, 'NOT_FOUND', 'Setup not found', 404);
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your setup', 403);
-    throw err;
-  }
-});
+setup.post(
+  '/:id/set-default',
+  describeRoute({
+    tags: ['Setups'],
+    summary: 'Set a setup as default',
+    description: 'Marks the given setup as the authenticated user\'s default setup.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Setup marked as default',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(SetupOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Not your setup',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Setup not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const id = c.req.param('id')!;
+    const userId = c.get('userId') as string;
+    try {
+      const s = await service.setDefault(userId, id);
+      return success(c, s);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'SETUP_NOT_FOUND') return error(c, 'NOT_FOUND', 'Setup not found', 404);
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your setup', 403);
+      throw err;
+    }
+  },
+);
 
 export default setup;

--- a/apps/api/src/modules/setup/index.ts
+++ b/apps/api/src/modules/setup/index.ts
@@ -224,7 +224,7 @@ setup.post(
   describeRoute({
     tags: ['Setups'],
     summary: 'Set a setup as default',
-    description: 'Marks the given setup as the authenticated user\'s default setup.',
+    description: "Marks the given setup as the authenticated user's default setup.",
     security: [{ bearerAuth: [] }],
     parameters: [
       { name: 'id', in: 'path', required: true, schema: { type: 'string' } },

--- a/apps/api/src/modules/taste/index.ts
+++ b/apps/api/src/modules/taste/index.ts
@@ -1,48 +1,144 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
+import { z } from 'zod';
 import {
   TasteNoteCreateSchema,
   TasteNoteFilterSchema,
   TasteNoteUpdateSchema,
 } from '@brewform/shared/schemas';
+import {
+  ErrorEnvelopeSchema,
+  MessageResponseSchema,
+  successEnvelope,
+  TasteNoteNodeOutputSchema,
+  TasteNoteOutputSchema,
+} from '@brewform/shared/schemas';
 import { adminMiddleware, authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { error, success, zodValidationHook } from '../../utils/response/index.ts';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import { cacheProvider } from '../../utils/cache/singleton.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
 const taste = new Hono<AppEnv>();
 
-taste.get('/hierarchy', async (c) => {
-  const hierarchy = await service.getHierarchy(cacheProvider!);
-  return success(c, hierarchy);
-});
+taste.get(
+  '/hierarchy',
+  describeRoute({
+    tags: ['Taste Notes'],
+    summary: 'Get the taste-note hierarchy',
+    description: 'Returns the full taste-note tree, each node carrying its nested `children`.',
+    responses: {
+      200: {
+        description: 'Taste-note hierarchy',
+        content: {
+          'application/json': {
+            schema: resolver(successEnvelope(z.array(TasteNoteNodeOutputSchema))),
+          },
+        },
+      },
+    },
+  }),
+  async (c) => {
+    const hierarchy = await service.getHierarchy(cacheProvider!);
+    return success(c, hierarchy);
+  },
+);
 
-taste.get('/search', zValidator('query', TasteNoteFilterSchema), async (c) => {
-  const { search } = c.req.valid('query');
-  if (!search) {
+taste.get(
+  '/search',
+  describeRoute({
+    tags: ['Taste Notes'],
+    summary: 'Search taste notes',
+    description:
+      'Returns a flat list of taste notes matching the search query. With no query, returns the full flat list.',
+    parameters: [
+      { name: 'search', in: 'query', required: false, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'List of matching taste notes',
+        content: {
+          'application/json': {
+            schema: resolver(successEnvelope(z.array(TasteNoteOutputSchema))),
+          },
+        },
+      },
+      400: {
+        description: 'Search query too short',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  zValidator('query', TasteNoteFilterSchema),
+  async (c) => {
+    const { search } = c.req.valid('query');
+    if (!search) {
+      const allNotes = await service.getFlatList(cacheProvider!);
+      return success(c, allNotes);
+    }
+    try {
+      const results = await service.searchTasteNotes(search, cacheProvider!);
+      return success(c, results);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'QUERY_TOO_SHORT') {
+        return error(c, 'QUERY_TOO_SHORT', 'Search query must be at least 3 characters', 400);
+      }
+      throw err;
+    }
+  },
+);
+
+taste.get(
+  '/flat',
+  describeRoute({
+    tags: ['Taste Notes'],
+    summary: 'Get the flat taste-note list',
+    description: 'Returns all taste notes as a flat list, without hierarchy.',
+    responses: {
+      200: {
+        description: 'Flat list of taste notes',
+        content: {
+          'application/json': {
+            schema: resolver(successEnvelope(z.array(TasteNoteOutputSchema))),
+          },
+        },
+      },
+    },
+  }),
+  async (c) => {
     const allNotes = await service.getFlatList(cacheProvider!);
     return success(c, allNotes);
-  }
-  try {
-    const results = await service.searchTasteNotes(search, cacheProvider!);
-    return success(c, results);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'QUERY_TOO_SHORT') {
-      return error(c, 'QUERY_TOO_SHORT', 'Search query must be at least 3 characters', 400);
-    }
-    throw err;
-  }
-});
-
-taste.get('/flat', async (c) => {
-  const allNotes = await service.getFlatList(cacheProvider!);
-  return success(c, allNotes);
-});
+  },
+);
 
 taste.post(
   '/',
+  describeRoute({
+    tags: ['Taste Notes'],
+    summary: 'Create a taste note',
+    description: 'Creates a taste note. Admin only.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(TasteNoteCreateSchema),
+    responses: {
+      201: {
+        description: 'Taste note created',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(TasteNoteOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Forbidden (admin only)',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
   authMiddleware,
   adminMiddleware,
   zValidator('json', TasteNoteCreateSchema, zodValidationHook),
@@ -55,6 +151,32 @@ taste.post(
 
 taste.patch(
   '/:id',
+  describeRoute({
+    tags: ['Taste Notes'],
+    summary: 'Update a taste note',
+    description: 'Updates a taste note. Admin only.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    requestBody: jsonRequestBody(TasteNoteUpdateSchema),
+    responses: {
+      200: {
+        description: 'Taste note updated',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(TasteNoteOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Forbidden (admin only)',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
   authMiddleware,
   adminMiddleware,
   zValidator('json', TasteNoteUpdateSchema, zodValidationHook),
@@ -66,10 +188,40 @@ taste.patch(
   },
 );
 
-taste.delete('/:id', authMiddleware, adminMiddleware, async (c) => {
-  const id = c.req.param('id')!;
-  await service.deleteTasteNote(id, cacheProvider!);
-  return success(c, { message: 'Taste note deleted' });
-});
+taste.delete(
+  '/:id',
+  describeRoute({
+    tags: ['Taste Notes'],
+    summary: 'Delete a taste note',
+    description: 'Deletes a taste note. Admin only.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Taste note deleted',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(MessageResponseSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Forbidden (admin only)',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  adminMiddleware,
+  async (c) => {
+    const id = c.req.param('id')!;
+    await service.deleteTasteNote(id, cacheProvider!);
+    return success(c, { message: 'Taste note deleted' });
+  },
+);
 
 export default taste;

--- a/apps/api/src/modules/user/index.ts
+++ b/apps/api/src/modules/user/index.ts
@@ -1,49 +1,156 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { UserProfileUpdateSchema } from '@brewform/shared/schemas';
+import { describeRoute, resolver } from 'hono-openapi';
+import {
+  ErrorEnvelopeSchema,
+  MessageResponseSchema,
+  PublicUserOutputSchema,
+  SelfUserOutputSchema,
+  successEnvelope,
+  UserRowOutputSchema,
+} from '@brewform/shared/schemas';
 import { authMiddleware, optionalAuthMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { error, success } from '../../utils/response/index.ts';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
 const user = new Hono<AppEnv>();
 
-user.get('/me', authMiddleware, async (c) => {
-  const userId = c.get('userId') as string;
-  try {
-    const profile = await service.getProfile(userId);
-    return success(c, profile);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'USER_NOT_FOUND') return error(c, 'NOT_FOUND', 'User not found', 404);
-    throw err;
-  }
-});
+user.get(
+  '/me',
+  describeRoute({
+    tags: ['Users'],
+    summary: 'Get the authenticated user profile',
+    description: 'Returns the full profile of the authenticated user, including preferences and stats.',
+    security: [{ bearerAuth: [] }],
+    responses: {
+      200: {
+        description: 'Authenticated user profile',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(SelfUserOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'User not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const userId = c.get('userId') as string;
+    try {
+      const profile = await service.getProfile(userId);
+      return success(c, profile);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'USER_NOT_FOUND') return error(c, 'NOT_FOUND', 'User not found', 404);
+      throw err;
+    }
+  },
+);
 
-user.patch('/me', authMiddleware, zValidator('json', UserProfileUpdateSchema), async (c) => {
-  const userId = c.get('userId') as string;
-  const body = c.req.valid('json');
-  const updated = await service.updateProfile(userId, body);
-  return success(c, updated);
-});
+user.patch(
+  '/me',
+  describeRoute({
+    tags: ['Users'],
+    summary: 'Update the authenticated user profile',
+    description: 'Updates the authenticated user\'s profile fields.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(UserProfileUpdateSchema),
+    responses: {
+      200: {
+        description: 'Updated user row',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(UserRowOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  zValidator('json', UserProfileUpdateSchema),
+  async (c) => {
+    const userId = c.get('userId') as string;
+    const body = c.req.valid('json');
+    const updated = await service.updateProfile(userId, body);
+    return success(c, updated);
+  },
+);
 
-user.delete('/me', authMiddleware, async (c) => {
-  const userId = c.get('userId') as string;
-  await service.deleteAccount(userId);
-  return success(c, { message: 'Account deleted' });
-});
+user.delete(
+  '/me',
+  describeRoute({
+    tags: ['Users'],
+    summary: 'Delete the authenticated user account',
+    description: 'Soft-deletes the authenticated user\'s account.',
+    security: [{ bearerAuth: [] }],
+    responses: {
+      200: {
+        description: 'Account deleted',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(MessageResponseSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  async (c) => {
+    const userId = c.get('userId') as string;
+    await service.deleteAccount(userId);
+    return success(c, { message: 'Account deleted' });
+  },
+);
 
-user.get('/:username', optionalAuthMiddleware, async (c) => {
-  const username = c.req.param('username') as string;
-  const requesterId = c.get('userId') as string | undefined;
-  try {
-    const profile = await service.getPublicProfile(username, requesterId);
-    return success(c, profile);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'USER_NOT_FOUND') return error(c, 'NOT_FOUND', 'User not found', 404);
-    throw err;
-  }
-});
+user.get(
+  '/:username',
+  describeRoute({
+    tags: ['Users'],
+    summary: 'Get a public user profile',
+    description:
+      'Returns the public profile for a username, including stats, recipes, badges, and follow status.',
+    parameters: [
+      { name: 'username', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Public user profile',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(PublicUserOutputSchema)) },
+        },
+      },
+      404: {
+        description: 'User not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  optionalAuthMiddleware,
+  async (c) => {
+    const username = c.req.param('username') as string;
+    const requesterId = c.get('userId') as string | undefined;
+    try {
+      const profile = await service.getPublicProfile(username, requesterId);
+      return success(c, profile);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'USER_NOT_FOUND') return error(c, 'NOT_FOUND', 'User not found', 404);
+      throw err;
+    }
+  },
+);
 
 export default user;

--- a/apps/api/src/modules/user/index.ts
+++ b/apps/api/src/modules/user/index.ts
@@ -23,7 +23,8 @@ user.get(
   describeRoute({
     tags: ['Users'],
     summary: 'Get the authenticated user profile',
-    description: 'Returns the full profile of the authenticated user, including preferences and stats.',
+    description:
+      'Returns the full profile of the authenticated user, including preferences and stats.',
     security: [{ bearerAuth: [] }],
     responses: {
       200: {
@@ -61,7 +62,7 @@ user.patch(
   describeRoute({
     tags: ['Users'],
     summary: 'Update the authenticated user profile',
-    description: 'Updates the authenticated user\'s profile fields.',
+    description: "Updates the authenticated user's profile fields.",
     security: [{ bearerAuth: [] }],
     requestBody: jsonRequestBody(UserProfileUpdateSchema),
     responses: {
@@ -92,7 +93,7 @@ user.delete(
   describeRoute({
     tags: ['Users'],
     summary: 'Delete the authenticated user account',
-    description: 'Soft-deletes the authenticated user\'s account.',
+    description: "Soft-deletes the authenticated user's account.",
     security: [{ bearerAuth: [] }],
     responses: {
       200: {

--- a/apps/api/src/modules/vendor/index.ts
+++ b/apps/api/src/modules/vendor/index.ts
@@ -1,81 +1,250 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
+import { describeRoute, resolver } from 'hono-openapi';
+import { z } from 'zod';
 import {
   PaginationSchema,
   SearchQuerySchema,
   VendorCreateSchema,
   VendorUpdateSchema,
 } from '@brewform/shared/schemas';
+import {
+  ErrorEnvelopeSchema,
+  MessageResponseSchema,
+  paginatedEnvelope,
+  successEnvelope,
+  VendorOutputSchema,
+} from '@brewform/shared/schemas';
 import { adminMiddleware, authMiddleware } from '../../middleware/auth.ts';
 import * as service from './service.ts';
 import { error, paginated, success } from '../../utils/response/index.ts';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import type { AppEnv } from '../../types/hono.ts';
 
 const vendor = new Hono<AppEnv>();
 
-vendor.get('/', zValidator('query', PaginationSchema), async (c) => {
-  const { page, perPage } = c.req.valid('query');
-  const result = await service.listVendors(page, perPage);
-  return paginated(c, result.vendors, {
-    page,
-    perPage,
-    total: result.total,
-    totalPages: Math.ceil(result.total / perPage),
-  });
-});
+vendor.get(
+  '/',
+  describeRoute({
+    tags: ['Vendors'],
+    summary: 'List vendors',
+    description: 'Paginated list of coffee vendors/roasters.',
+    parameters: [
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    ],
+    responses: {
+      200: {
+        description: 'Paginated list of vendors',
+        content: {
+          'application/json': { schema: resolver(paginatedEnvelope(VendorOutputSchema)) },
+        },
+      },
+    },
+  }),
+  zValidator('query', PaginationSchema),
+  async (c) => {
+    const { page, perPage } = c.req.valid('query');
+    const result = await service.listVendors(page, perPage);
+    return paginated(c, result.vendors, {
+      page,
+      perPage,
+      total: result.total,
+      totalPages: Math.ceil(result.total / perPage),
+    });
+  },
+);
 
-vendor.get('/search', zValidator('query', SearchQuerySchema), async (c) => {
-  const { q } = c.req.valid('query');
-  const results = await service.searchVendors(q);
-  return success(c, results);
-});
+vendor.get(
+  '/search',
+  describeRoute({
+    tags: ['Vendors'],
+    summary: 'Search vendors',
+    description: 'Returns vendors matching the search query.',
+    parameters: [
+      { name: 'q', in: 'query', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'List of matching vendors',
+        content: {
+          'application/json': {
+            schema: resolver(successEnvelope(z.array(VendorOutputSchema))),
+          },
+        },
+      },
+    },
+  }),
+  zValidator('query', SearchQuerySchema),
+  async (c) => {
+    const { q } = c.req.valid('query');
+    const results = await service.searchVendors(q);
+    return success(c, results);
+  },
+);
 
-vendor.post('/', authMiddleware, zValidator('json', VendorCreateSchema), async (c) => {
-  const userId = c.get('userId') as string;
-  const body = c.req.valid('json');
-  const v = await service.createVendor(userId, body);
-  return success(c, v, 201);
-});
+vendor.post(
+  '/',
+  describeRoute({
+    tags: ['Vendors'],
+    summary: 'Create a vendor',
+    description: 'Creates a coffee vendor/roaster entry.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(VendorCreateSchema),
+    responses: {
+      201: {
+        description: 'Vendor created',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(VendorOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  zValidator('json', VendorCreateSchema),
+  async (c) => {
+    const userId = c.get('userId') as string;
+    const body = c.req.valid('json');
+    const v = await service.createVendor(userId, body);
+    return success(c, v, 201);
+  },
+);
 
-vendor.get('/:id', async (c) => {
-  const id = c.req.param('id')!;
-  try {
-    const v = await service.getVendor(id);
-    return success(c, v);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'VENDOR_NOT_FOUND') return error(c, 'NOT_FOUND', 'Vendor not found', 404);
-    throw err;
-  }
-});
+vendor.get(
+  '/:id',
+  describeRoute({
+    tags: ['Vendors'],
+    summary: 'Get a vendor by id',
+    description: 'Returns a single coffee vendor/roaster by its id.',
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Vendor payload',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(VendorOutputSchema)) },
+        },
+      },
+      404: {
+        description: 'Vendor not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  async (c) => {
+    const id = c.req.param('id')!;
+    try {
+      const v = await service.getVendor(id);
+      return success(c, v);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'VENDOR_NOT_FOUND') return error(c, 'NOT_FOUND', 'Vendor not found', 404);
+      throw err;
+    }
+  },
+);
 
-vendor.patch('/:id', authMiddleware, zValidator('json', VendorUpdateSchema), async (c) => {
-  const id = c.req.param('id')!;
-  const userId = c.get('userId') as string;
-  const user = c.get('user') as { isAdmin: boolean } | null;
-  const isAdmin = user?.isAdmin ?? false;
-  const body = c.req.valid('json');
-  try {
-    const v = await service.updateVendor(userId, id, body, isAdmin);
-    return success(c, v);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'VENDOR_NOT_FOUND') return error(c, 'NOT_FOUND', 'Vendor not found', 404);
-    if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your vendor', 403);
-    throw err;
-  }
-});
+vendor.patch(
+  '/:id',
+  describeRoute({
+    tags: ['Vendors'],
+    summary: 'Update a vendor',
+    description: 'Updates a coffee vendor/roaster. Owner or admin only.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    requestBody: jsonRequestBody(VendorUpdateSchema),
+    responses: {
+      200: {
+        description: 'Vendor updated',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(VendorOutputSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Not your vendor',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Vendor not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  zValidator('json', VendorUpdateSchema),
+  async (c) => {
+    const id = c.req.param('id')!;
+    const userId = c.get('userId') as string;
+    const user = c.get('user') as { isAdmin: boolean } | null;
+    const isAdmin = user?.isAdmin ?? false;
+    const body = c.req.valid('json');
+    try {
+      const v = await service.updateVendor(userId, id, body, isAdmin);
+      return success(c, v);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'VENDOR_NOT_FOUND') return error(c, 'NOT_FOUND', 'Vendor not found', 404);
+      if (message === 'FORBIDDEN') return error(c, 'FORBIDDEN', 'Not your vendor', 403);
+      throw err;
+    }
+  },
+);
 
-vendor.delete('/:id', authMiddleware, adminMiddleware, async (c) => {
-  const id = c.req.param('id')!;
-  try {
-    await service.deleteVendor(id);
-    return success(c, { message: 'Vendor deleted' });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'VENDOR_NOT_FOUND') return error(c, 'NOT_FOUND', 'Vendor not found', 404);
-    throw err;
-  }
-});
+vendor.delete(
+  '/:id',
+  describeRoute({
+    tags: ['Vendors'],
+    summary: 'Delete a vendor',
+    description: 'Deletes a coffee vendor/roaster. Admin only.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Vendor deleted',
+        content: {
+          'application/json': { schema: resolver(successEnvelope(MessageResponseSchema)) },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      403: {
+        description: 'Forbidden (admin only)',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Vendor not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  authMiddleware,
+  adminMiddleware,
+  async (c) => {
+    const id = c.req.param('id')!;
+    try {
+      await service.deleteVendor(id);
+      return success(c, { message: 'Vendor deleted' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'VENDOR_NOT_FOUND') return error(c, 'NOT_FOUND', 'Vendor not found', 404);
+      throw err;
+    }
+  },
+);
 
 export default vendor;

--- a/apps/api/src/routes/openapi.coverage.test.ts
+++ b/apps/api/src/routes/openapi.coverage.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Introspection-based OpenAPI coverage test (Coverage_Test).
+ *
+ * Builds the REAL aggregated router from `routes/index.ts`, requests the
+ * generated `/api/v1/openapi.json` document, and exhaustively asserts the
+ * structural correctness properties of the spec.
+ *
+ * This realizes design Properties 1–7 by iterating the full `paths` map of the
+ * generated spec (exhaustive verification, not sampling) plus the non-JSON
+ * content-type requirements (9.x) and the preserved auth/recipe/admin/health
+ * coverage (Requirement 2).
+ *
+ * Feasibility (Requirement 10.10): `postgres-js` connects lazily and the cache
+ * singleton uses in-memory mode when `CACHE_DRIVER=memory`, so importing the
+ * router and generating the spec performs no DB/KV I/O. Env is set before the
+ * dynamic import so the config singleton loads with the documented test values.
+ *
+ * The pre-existing `routes/openapi.test.ts` smoke test is left unchanged.
+ */
+import { beforeAll, describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+
+// ---------------------------------------------------------------------------
+// Test environment — set BEFORE the dynamic import of the router so the
+// config singleton (loaded at module-eval time) sees these values. No DB/KV
+// connection occurs during spec generation.
+// ---------------------------------------------------------------------------
+Deno.env.set('OPENAPI_ENABLED', 'true');
+Deno.env.set('APP_ENV', 'test');
+Deno.env.set('CACHE_DRIVER', 'memory');
+if (!Deno.env.get('DATABASE_URL')) {
+  Deno.env.set('DATABASE_URL', 'postgresql://test:test@localhost:5432/test');
+}
+if (!Deno.env.get('JWT_SECRET')) {
+  Deno.env.set('JWT_SECRET', 'a-very-long-secret-key-for-testing-12345');
+}
+
+// ---------------------------------------------------------------------------
+// Spec shape (loose typing — we only read the parts we assert against).
+// ---------------------------------------------------------------------------
+type AnyObj = Record<string, unknown>;
+interface Operation {
+  tags?: string[];
+  summary?: string;
+  security?: unknown[];
+  parameters?: AnyObj[];
+  requestBody?: { content?: Record<string, { schema?: unknown }> };
+  responses?: Record<string, { content?: Record<string, { schema?: unknown }> }>;
+}
+interface OpenApiSpec {
+  openapi?: string;
+  paths?: Record<string, Record<string, Operation>>;
+  tags?: Array<{ name: string; description?: string }>;
+}
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'options', 'head', 'trace'];
+
+/** The 17 in-scope base paths (matched by prefix). */
+const IN_SCOPE_BASE_PATHS = [
+  '/api/v1/beans',
+  '/api/v1/badges',
+  '/api/v1/coffee-varieties',
+  '/api/v1/comments',
+  '/api/v1/contact',
+  '/api/v1/equipment',
+  '/api/v1/follow',
+  '/api/v1/photos',
+  '/api/v1/preferences',
+  '/api/v1/qrcode',
+  '/api/v1/reports',
+  '/api/v1/setups',
+  '/api/v1/taste-notes',
+  '/api/v1/users',
+  '/api/v1/vendors',
+  '/share',
+  '/api/v1/sitemap.xml',
+];
+
+interface OpEntry {
+  path: string;
+  method: string;
+  op: Operation;
+}
+
+let spec: OpenApiSpec;
+let allOps: OpEntry[];
+let declaredTags: Set<string>;
+
+function isNonEmptyObject(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) &&
+    Object.keys(value as AnyObj).length > 0;
+}
+
+/** A resolved schema is a non-empty object that is not the unresolved zod stub. */
+function isResolvedSchema(value: unknown): boolean {
+  if (!isNonEmptyObject(value)) return false;
+  const keys = Object.keys(value as AnyObj);
+  if (keys.length === 1 && (value as AnyObj).vendor === 'zod') return false;
+  return true;
+}
+
+/** True when an operation path belongs to one of the 17 in-scope groups. */
+function isInScope(path: string): boolean {
+  return IN_SCOPE_BASE_PATHS.some(
+    (base) => path === base || path.startsWith(base + '/') || path.startsWith(base),
+  );
+}
+
+beforeAll(async () => {
+  // Dynamic import AFTER env is set so the config singleton picks up the values.
+  const { default: routes } = await import('./index.ts');
+  const res = await routes.request('/api/v1/openapi.json');
+  expect(res.status).toBe(200);
+  spec = (await res.json()) as OpenApiSpec;
+
+  const paths = spec.paths ?? {};
+  allOps = [];
+  for (const [path, item] of Object.entries(paths)) {
+    for (const [method, op] of Object.entries(item)) {
+      if (HTTP_METHODS.includes(method.toLowerCase())) {
+        allOps.push({ path, method: method.toLowerCase(), op: op as Operation });
+      }
+    }
+  }
+  declaredTags = new Set((spec.tags ?? []).map((t) => t.name));
+});
+
+describe('OpenAPI coverage — generated spec is well-formed', () => {
+  it('produces a valid OpenAPI document with a non-empty paths map', () => {
+    expect(typeof spec.openapi).toBe('string');
+    expect(Object.keys(spec.paths ?? {}).length).toBeGreaterThan(0);
+    expect(allOps.length).toBeGreaterThan(0);
+  });
+
+  // Property 1 — coverage of all in-scope routes.
+  it('documents all 17 in-scope base paths (P1)', () => {
+    const pathKeys = Object.keys(spec.paths ?? {});
+    const missing = IN_SCOPE_BASE_PATHS.filter(
+      (base) => !pathKeys.some((p) => p === base || p.startsWith(base + '/') || p.startsWith(base)),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  // Property 7 — every operation is tagged.
+  it('every operation declares at least one tag (P7)', () => {
+    const untagged = allOps
+      .filter(({ op }) => !Array.isArray(op.tags) || op.tags.length === 0)
+      .map(({ path, method }) => `${method.toUpperCase()} ${path}`);
+    expect(untagged).toEqual([]);
+  });
+
+  // Property 7 — zero orphan tags (referenced ⊆ declared).
+  it('every referenced tag is declared in the Tag_Registry — zero orphans (P7)', () => {
+    const referenced = new Set<string>();
+    for (const { op } of allOps) {
+      for (const tag of op.tags ?? []) referenced.add(tag);
+    }
+    const orphans = [...referenced].filter((t) => !declaredTags.has(t));
+    expect(orphans).toEqual([]);
+  });
+
+  // Property 5 — every operation declares ≥1 response keyed 100–599.
+  it('every operation declares at least one response keyed 100–599 (P5)', () => {
+    const offenders: string[] = [];
+    for (const { path, method, op } of allOps) {
+      const codes = Object.keys(op.responses ?? {});
+      const hasValid = codes.some((code) => {
+        const n = Number(code);
+        return Number.isInteger(n) && n >= 100 && n <= 599;
+      });
+      if (!hasValid) offenders.push(`${method.toUpperCase()} ${path}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  // Property 4 — every auth-guarded in-scope op documents 401.
+  it('every auth-guarded in-scope operation documents a 401 response (P4)', () => {
+    const missing401: string[] = [];
+    for (const { path, method, op } of allOps) {
+      if (!isInScope(path)) continue;
+      const guarded = Array.isArray(op.security) && op.security.length > 0;
+      if (guarded && !(op.responses && op.responses['401'])) {
+        missing401.push(`${method.toUpperCase()} ${path}`);
+      }
+    }
+    expect(missing401).toEqual([]);
+  });
+
+  // Property 2 — at least one op documents a requestBody JSON schema.
+  it('at least one operation declares a non-empty requestBody JSON schema (P2)', () => {
+    const withRequestBody = allOps.filter(({ op }) => {
+      const schema = op.requestBody?.content?.['application/json']?.schema;
+      return isNonEmptyObject(schema);
+    });
+    expect(withRequestBody.length).toBeGreaterThan(0);
+  });
+
+  // Property 3 — at least one op documents a resolved 2xx response schema.
+  it('at least one operation declares a resolved 2xx response schema (P3)', () => {
+    const withResolved = allOps.filter(({ op }) => {
+      const responses = op.responses ?? {};
+      return Object.entries(responses).some(([code, resp]) => {
+        const n = Number(code);
+        if (!(n >= 200 && n < 300)) return false;
+        const schema = resp.content?.['application/json']?.schema;
+        return isResolvedSchema(schema);
+      });
+    });
+    expect(withResolved.length).toBeGreaterThan(0);
+  });
+
+  // No leftover unresolved resolver stubs anywhere in documented JSON schemas.
+  it('contains no unresolved { vendor: "zod" } resolver stubs in any JSON response schema', () => {
+    const stubs: string[] = [];
+    for (const { path, method, op } of allOps) {
+      for (const [code, resp] of Object.entries(op.responses ?? {})) {
+        const schema = resp.content?.['application/json']?.schema as AnyObj | undefined;
+        if (
+          schema && typeof schema === 'object' &&
+          Object.keys(schema).length === 1 && schema.vendor === 'zod'
+        ) {
+          stubs.push(`${method.toUpperCase()} ${path} [${code}]`);
+        }
+      }
+    }
+    expect(stubs).toEqual([]);
+  });
+});
+
+describe('OpenAPI coverage — preserved tag groups (Requirement 2)', () => {
+  // Preserve Requirement 2 — the previously-documented groups remain present.
+  it('has at least one operation each tagged Auth, Recipes, Admin, and Health', () => {
+    const countByTag = (tag: string) =>
+      allOps.filter(({ op }) => (op.tags ?? []).includes(tag)).length;
+    expect(countByTag('Auth')).toBeGreaterThan(0);
+    expect(countByTag('Recipes')).toBeGreaterThan(0);
+    expect(countByTag('Admin')).toBeGreaterThan(0);
+    expect(countByTag('Health')).toBeGreaterThan(0);
+  });
+});
+
+describe('OpenAPI coverage — Tag_Registry is well-formed (P6)', () => {
+  it('tag names are unique', () => {
+    const names = (spec.tags ?? []).map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('every tag has a description of length 1–200', () => {
+    const offenders = (spec.tags ?? [])
+      .filter((t) => {
+        const len = (t.description ?? '').length;
+        return len < 1 || len > 200;
+      })
+      .map((t) => t.name);
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('OpenAPI coverage — non-JSON routes (Requirements 9.x)', () => {
+  function findOp(predicate: (path: string) => boolean): Operation | undefined {
+    const entry = allOps.find(({ path }) => predicate(path));
+    return entry?.op;
+  }
+
+  it('share operation documents text/html and is not a JSON envelope', () => {
+    const op = findOp((p) => p.includes('/share'));
+    expect(op).toBeDefined();
+    const ok = op!.responses?.['200'];
+    expect(ok).toBeDefined();
+    expect(ok!.content?.['text/html']).toBeDefined();
+    expect(ok!.content?.['application/json']).toBeUndefined();
+  });
+
+  it('sitemap operation documents application/xml and is not a JSON envelope', () => {
+    const op = findOp((p) => p.includes('sitemap'));
+    expect(op).toBeDefined();
+    const ok = op!.responses?.['200'];
+    expect(ok).toBeDefined();
+    expect(ok!.content?.['application/xml']).toBeDefined();
+    expect(ok!.content?.['application/json']).toBeUndefined();
+  });
+
+  it('qrcode 200 documents an image content type and is not a JSON envelope', () => {
+    const op = findOp((p) => p.includes('/qrcode/recipe'));
+    expect(op).toBeDefined();
+    const ok = op!.responses?.['200'];
+    expect(ok).toBeDefined();
+    const ct = ok!.content ?? {};
+    const hasImage = 'image/png' in ct || 'image/svg+xml' in ct;
+    expect(hasImage).toBe(true);
+    expect(ct['application/json']).toBeUndefined();
+  });
+});

--- a/apps/api/src/routes/openapi.coverage.test.ts
+++ b/apps/api/src/routes/openapi.coverage.test.ts
@@ -102,7 +102,7 @@ function isResolvedSchema(value: unknown): boolean {
 /** True when an operation path belongs to one of the 17 in-scope groups. */
 function isInScope(path: string): boolean {
   return IN_SCOPE_BASE_PATHS.some(
-    (base) => path === base || path.startsWith(base + '/') || path.startsWith(base),
+    (base) => path === base || path.startsWith(base + '/'),
   );
 }
 
@@ -136,7 +136,7 @@ describe('OpenAPI coverage — generated spec is well-formed', () => {
   it('documents all 17 in-scope base paths (P1)', () => {
     const pathKeys = Object.keys(spec.paths ?? {});
     const missing = IN_SCOPE_BASE_PATHS.filter(
-      (base) => !pathKeys.some((p) => p === base || p.startsWith(base + '/') || p.startsWith(base)),
+      (base) => !pathKeys.some((p) => p === base || p.startsWith(base + '/')),
     );
     expect(missing).toEqual([]);
   });

--- a/apps/api/src/routes/openapi.ts
+++ b/apps/api/src/routes/openapi.ts
@@ -62,9 +62,33 @@ export function registerOpenApi(app: Hono<AppEnv>): void {
         { name: 'Users', description: 'Public user profiles and the authenticated user' },
         { name: 'Admin', description: 'Privileged admin operations (requires admin role)' },
         { name: 'Health', description: 'Liveness and readiness probes' },
+        { name: 'Beans', description: 'Coffee bean inventory owned by users' },
+        { name: 'Badges', description: 'Achievement badges and per-user awards' },
+        {
+          name: 'Coffee Varieties',
+          description: 'Coffee cultivar reference data and recipes using a variety',
+        },
+        { name: 'Comments', description: 'Recipe comment threads and replies' },
+        { name: 'Contact', description: 'Contact-form message submission' },
+        { name: 'Equipment', description: 'Brewing equipment catalogue and deletion requests' },
+        { name: 'Follow', description: 'Follow/unfollow, follower/following lists, and feed' },
+        { name: 'Photos', description: 'Recipe photo upload and listing' },
+        { name: 'Preferences', description: 'Per-user application and notification preferences' },
+        { name: 'QR Codes', description: 'Recipe QR-code image generation' },
+        { name: 'Reports', description: 'Content moderation reports' },
+        { name: 'Setups', description: 'Saved brewing-equipment setups' },
+        { name: 'Taste Notes', description: 'Taste-note hierarchy, search, and admin management' },
+        { name: 'Vendors', description: 'Coffee vendor/roaster directory' },
+        { name: 'Share', description: 'Server-rendered share/OG preview pages' },
+        { name: 'Sitemap', description: 'XML sitemap for crawlers' },
       ],
     },
-    excludeStaticFile: true,
+    // The sitemap route is mounted at `/api/v1/sitemap.xml`; its path ends in a
+    // file extension, so static-file exclusion would drop it from the spec.
+    // hono-openapi only documents routes carrying `describeRoute()` metadata, so
+    // disabling this does NOT surface the un-annotated `/api/v1/openapi.json` or
+    // `/api/v1/docs` meta endpoints. (Requirement 9.2)
+    excludeStaticFile: false,
     excludeMethods: ['OPTIONS', 'HEAD'],
   });
 

--- a/apps/api/src/routes/share.ts
+++ b/apps/api/src/routes/share.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { describeRoute } from 'hono-openapi';
 import { escapeHtml, escapeHtmlAttr } from '@brewform/shared/utils';
 import { getRecipeMeta } from '../modules/recipe/service.ts';
 import { config } from '../config/index.ts';
@@ -46,38 +47,61 @@ export const OG_TEMPLATE = (meta: {
 </html>`;
 };
 
-share.get('/:slug', async (c) => {
-  const slug = c.req.param('slug')!;
-  try {
-    const meta = await deps.getRecipeMeta(slug);
-    if (meta.visibility !== 'public') {
-      return c.html(RECIPE_NOT_FOUND_HTML, 404);
+share.get(
+  '/:slug',
+  describeRoute({
+    tags: ['Share'],
+    summary: 'Get a recipe share/OG preview page',
+    description:
+      'Returns a server-rendered HTML page with Open Graph/Twitter meta tags for a public recipe, ' +
+      'redirecting browsers to the recipe page. Responds with HTML, not a JSON envelope.',
+    parameters: [
+      { name: 'slug', in: 'path', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      200: {
+        description: 'Share preview HTML page',
+        content: { 'text/html': {} },
+      },
+      404: {
+        description: 'Recipe not found or not public',
+        content: { 'text/html': {} },
+      },
+    },
+  }),
+  async (c) => {
+    const slug = c.req.param('slug')!;
+    try {
+      const meta = await deps.getRecipeMeta(slug);
+      if (meta.visibility !== 'public') {
+        return c.html(RECIPE_NOT_FOUND_HTML, 404);
+      }
+
+      const baseUrl = config.PUBLIC_APP_URL || config.APP_URL;
+      const description = meta.productName
+        ? `${meta.brewMethod || 'Coffee'} recipe using ${meta.productName}`
+        : `${meta.brewMethod || 'Coffee'} recipe by ${
+          meta.author?.displayName || meta.author?.username || 'BrewForm user'
+        }`;
+
+      const html = OG_TEMPLATE({
+        title: meta.title,
+        description,
+        image: meta.photoUrl,
+        url: `${baseUrl}/share/${slug}`,
+        siteName: 'BrewForm',
+        slug,
+      });
+
+      return c.html(html);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'RECIPE_NOT_FOUND') {
+        return c.html(RECIPE_NOT_FOUND_HTML, 404);
+      }
+      throw err;
     }
-
-    const baseUrl = config.PUBLIC_APP_URL || config.APP_URL;
-    const description = meta.productName
-      ? `${meta.brewMethod || 'Coffee'} recipe using ${meta.productName}`
-      : `${meta.brewMethod || 'Coffee'} recipe by ${
-        meta.author?.displayName || meta.author?.username || 'BrewForm user'
-      }`;
-
-    const html = OG_TEMPLATE({
-      title: meta.title,
-      description,
-      image: meta.photoUrl,
-      url: `${baseUrl}/share/${slug}`,
-      siteName: 'BrewForm',
-      slug,
-    });
-
-    return c.html(html);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'RECIPE_NOT_FOUND') {
-      return c.html(RECIPE_NOT_FOUND_HTML, 404);
-    }
-    throw err;
-  }
-});
+  },
+);
 
 export default share;

--- a/apps/api/src/routes/sitemap.ts
+++ b/apps/api/src/routes/sitemap.ts
@@ -145,53 +145,53 @@ sitemap.get(
     },
   }),
   async (_c) => {
-  const baseUrl = (config.PUBLIC_APP_URL || config.APP_URL).replace(/\/+$/, '');
+    const baseUrl = (config.PUBLIC_APP_URL || config.APP_URL).replace(/\/+$/, '');
 
-  const cached = await cacheProvider.get<string>(SITEMAP_CACHE_KEY);
-  if (cached) {
-    return new Response(cached, {
+    const cached = await cacheProvider.get<string>(SITEMAP_CACHE_KEY);
+    if (cached) {
+      return new Response(cached, {
+        headers: {
+          'Content-Type': 'application/xml; charset=utf-8',
+          'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+        },
+      });
+    }
+
+    if (inFlightSitemapBuildPromise) {
+      return inFlightSitemapBuildPromise.then((xml) =>
+        new Response(xml, {
+          headers: {
+            'Content-Type': 'application/xml; charset=utf-8',
+            'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+          },
+        })
+      );
+    }
+
+    inFlightSitemapBuildPromise = (async () => {
+      try {
+        const [publicRecipes, activeUsers] = await Promise.all([
+          deps.getPublicRecipes(),
+          deps.getActiveUsers(),
+        ]);
+
+        const xml = buildXml(baseUrl, publicRecipes, activeUsers);
+
+        await cacheProvider.set(SITEMAP_CACHE_KEY, xml, { ttlMs: SITEMAP_CACHE_TTL });
+
+        return xml;
+      } finally {
+        inFlightSitemapBuildPromise = null;
+      }
+    })();
+
+    const xml = await inFlightSitemapBuildPromise;
+    return new Response(xml, {
       headers: {
         'Content-Type': 'application/xml; charset=utf-8',
         'Cache-Control': 'public, max-age=3600, s-maxage=3600',
       },
     });
-  }
-
-  if (inFlightSitemapBuildPromise) {
-    return inFlightSitemapBuildPromise.then((xml) =>
-      new Response(xml, {
-        headers: {
-          'Content-Type': 'application/xml; charset=utf-8',
-          'Cache-Control': 'public, max-age=3600, s-maxage=3600',
-        },
-      })
-    );
-  }
-
-  inFlightSitemapBuildPromise = (async () => {
-    try {
-      const [publicRecipes, activeUsers] = await Promise.all([
-        deps.getPublicRecipes(),
-        deps.getActiveUsers(),
-      ]);
-
-      const xml = buildXml(baseUrl, publicRecipes, activeUsers);
-
-      await cacheProvider.set(SITEMAP_CACHE_KEY, xml, { ttlMs: SITEMAP_CACHE_TTL });
-
-      return xml;
-    } finally {
-      inFlightSitemapBuildPromise = null;
-    }
-  })();
-
-  const xml = await inFlightSitemapBuildPromise;
-  return new Response(xml, {
-    headers: {
-      'Content-Type': 'application/xml; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
-    },
-  });
   },
 );
 

--- a/apps/api/src/routes/sitemap.ts
+++ b/apps/api/src/routes/sitemap.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { describeRoute } from 'hono-openapi';
 import { recipes, users } from '@brewform/db/schema';
 import { and, desc, eq, isNull } from 'drizzle-orm';
 import { config } from '../config/index.ts';
@@ -128,7 +129,22 @@ export function buildXml(
   return xml;
 }
 
-sitemap.get('/', async (_c) => {
+sitemap.get(
+  '/',
+  describeRoute({
+    tags: ['Sitemap'],
+    summary: 'Get the XML sitemap',
+    description:
+      'Returns the XML sitemap listing static pages, public recipes, and active user profiles for ' +
+      'crawlers. Responds with XML, not a JSON envelope.',
+    responses: {
+      200: {
+        description: 'XML sitemap',
+        content: { 'application/xml': {} },
+      },
+    },
+  }),
+  async (_c) => {
   const baseUrl = (config.PUBLIC_APP_URL || config.APP_URL).replace(/\/+$/, '');
 
   const cached = await cacheProvider.get<string>(SITEMAP_CACHE_KEY);
@@ -176,6 +192,7 @@ sitemap.get('/', async (_c) => {
       'Cache-Control': 'public, max-age=3600, s-maxage=3600',
     },
   });
-});
+  },
+);
 
 export default sitemap;

--- a/apps/api/src/utils/openapi/index.ts
+++ b/apps/api/src/utils/openapi/index.ts
@@ -1,0 +1,32 @@
+// deno-lint-ignore-file no-explicit-any
+import { z } from 'zod';
+
+/**
+ * Builds an inline OpenAPI `requestBody` object from a Zod schema.
+ *
+ * `hono-openapi` v1 only converts `resolver()` schemas that appear under a
+ * route's `responses` (see `resolveResponseSchemas`); resolvers placed under
+ * `requestBody` are neither processed at spec-generation time nor accepted by
+ * the `requestBody` types. To document request bodies without switching the
+ * validation middleware (ADR-012 keeps `@hono/zod-validator`'s `zValidator`),
+ * we synchronously convert the same Zod schema to a JSON Schema object and embed
+ * it directly. This is documentation-only and never affects runtime behavior.
+ *
+ * @param schema The Zod schema validated by `zValidator` for this body.
+ * @param description Optional human-readable request-body description.
+ * @param mediaType Defaults to `application/json`.
+ */
+export function jsonRequestBody(
+  schema: z.ZodType,
+  description?: string,
+  mediaType = 'application/json',
+) {
+  return {
+    ...(description ? { description } : {}),
+    content: {
+      [mediaType]: {
+        schema: z.toJSONSchema(schema, { unrepresentable: 'any' }) as any,
+      },
+    },
+  };
+}

--- a/deno.lock
+++ b/deno.lock
@@ -31,7 +31,7 @@
     "npm:drizzle-orm@0.45": "0.45.2_postgres@3.4.9",
     "npm:fast-check@*": "4.8.0",
     "npm:fast-check@4": "4.8.0",
-    "npm:hono-openapi@1": "1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.19_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-community+standard-openapi@0.2.9__@standard-community+standard-json@0.3.5___@standard-schema+spec@1.1.0___@types+json-schema@7.0.15___quansync@0.2.11___zod@4.4.3__@standard-schema+spec@1.1.0__openapi-types@12.1.3__zod@4.4.3__@types+json-schema@7.0.15__quansync@0.2.11_@types+json-schema@7.0.15_hono@4.12.19_openapi-types@12.1.3_@standard-schema+spec@1.1.0_quansync@0.2.11_zod@4.4.3",
+    "npm:hono-openapi@1": "1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.19_hono@4.12.19_zod-openapi@5.4.6__zod@4.4.3",
     "npm:hono@^4.7.0": "4.12.19",
     "npm:jsdom@29": "29.1.1",
     "npm:mjml@*": "5.2.1_typescript@6.0.3",
@@ -51,6 +51,7 @@
     "npm:vite@8": "8.0.13",
     "npm:vitest@*": "4.1.6_@vitest+coverage-v8@4.1.6_jsdom@29.1.1_vite@8.0.13",
     "npm:vitest@4": "4.1.6_@vitest+coverage-v8@4.1.6_jsdom@29.1.1_vite@8.0.13",
+    "npm:zod-openapi@5": "5.4.6_zod@4.4.3",
     "npm:zod@*": "4.4.3",
     "npm:zod@4": "4.4.3"
   },
@@ -1013,16 +1014,18 @@
         "zod"
       ]
     },
-    "@standard-community/standard-openapi@0.2.9_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-schema+spec@1.1.0_openapi-types@12.1.3_zod@4.4.3_@types+json-schema@7.0.15_quansync@0.2.11": {
+    "@standard-community/standard-openapi@0.2.9_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_openapi-types@12.1.3_zod@4.4.3_zod-openapi@5.4.6__zod@4.4.3": {
       "integrity": "sha512-htj+yldvN1XncyZi4rehbf9kLbu8os2Ke/rfqoZHCMHuw34kiF3LP/yQPdA0tQ940y8nDq3Iou8R3wG+AGGyvg==",
       "dependencies": [
         "@standard-community/standard-json",
         "@standard-schema/spec",
         "openapi-types",
-        "zod"
+        "zod",
+        "zod-openapi"
       ],
       "optionalPeers": [
-        "zod"
+        "zod",
+        "zod-openapi"
       ]
     },
     "@standard-schema/spec@1.1.0": {
@@ -2024,7 +2027,7 @@
     "help-me@5.0.0": {
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="
     },
-    "hono-openapi@1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.19_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-community+standard-openapi@0.2.9__@standard-community+standard-json@0.3.5___@standard-schema+spec@1.1.0___@types+json-schema@7.0.15___quansync@0.2.11___zod@4.4.3__@standard-schema+spec@1.1.0__openapi-types@12.1.3__zod@4.4.3__@types+json-schema@7.0.15__quansync@0.2.11_@types+json-schema@7.0.15_hono@4.12.19_openapi-types@12.1.3_@standard-schema+spec@1.1.0_quansync@0.2.11_zod@4.4.3": {
+    "hono-openapi@1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.19_hono@4.12.19_zod-openapi@5.4.6__zod@4.4.3": {
       "integrity": "sha512-xDvCWpWEIv0weEmnl3EjRQzqbHIO8LnfzMuYOCmbuyE5aes6aXxLg4vM3ybnoZD5TiTUkA6PuRQPJs3R7WRBig==",
       "dependencies": [
         "@hono/standard-validator",
@@ -3657,6 +3660,12 @@
         "yargs-parser@21.1.1"
       ]
     },
+    "zod-openapi@5.4.6_zod@4.4.3": {
+      "integrity": "sha512-P2jsOOBAq/6hCwUsMCjUATZ8szkMsV5VAwZENfyxp2Hc/XPJQpVwAgevWZc65xZauCwWB9LAn7zYeiCJFAEL+A==",
+      "dependencies": [
+        "zod"
+      ]
+    },
     "zod@4.4.3": {
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
     }
@@ -3730,6 +3739,7 @@
       "packages/shared": {
         "packageJson": {
           "dependencies": [
+            "npm:zod-openapi@5",
             "npm:zod@4"
           ]
         }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -179,8 +179,10 @@ Route-level middleware:
 ## OpenAPI
 
 The API exposes an auto-generated OpenAPI 3.x specification derived from `describeRoute(...)`
-decorations on the auth, recipe, admin, and health routes. Two endpoints, both gated by the
-`OPENAPI_ENABLED` env flag:
+metadata that now covers **all mounted route groups** (`auth`, `recipe`, `admin`, `health`, `beans`,
+`badges`, `coffee-varieties`, `comments`, `contact`, `equipment`, `follow`, `photos`, `preferences`,
+`qrcode`, `reports`, `setups`, `taste-notes`, `users`, `vendors`, `share`, `sitemap`). Two endpoints,
+both gated by the `OPENAPI_ENABLED` env flag:
 
 - `GET /api/v1/openapi.json` — machine-readable spec for client generation or Postman import
 - `GET /api/v1/docs` — a Scalar-based HTML viewer (loaded from a CDN)
@@ -188,6 +190,25 @@ decorations on the auth, recipe, admin, and health routes. Two endpoints, both g
 The spec is built at request time via `hono-openapi`'s `openAPIRouteHandler`, so any new route gets
 picked up automatically. See `decisions.md` ADR-012 for why we kept `zValidator` instead of swapping
 to `hono-openapi`'s validator.
+
+### Adding a new route (required)
+
+Every new route — or any change to a route's request/response shape — MUST carry OpenAPI metadata.
+A route without `describeRoute()` is considered incomplete (the coverage test will fail).
+
+1. Prepend `describeRoute({ tags, summary, description, security, parameters, requestBody, responses })`
+   from `hono-openapi`. Keep `zValidator(...)` as the validator (ADR-012); never import
+   `hono-openapi`'s `validator`. Metadata must not change runtime behavior.
+2. Document responses with `resolver(successEnvelope(XOutputSchema))` /
+   `resolver(paginatedEnvelope(XOutputSchema))` and `resolver(ErrorEnvelopeSchema)` for each error
+   (always `401` on auth-guarded routes; `404`/`403`/`400`/`409` where mapped).
+3. Document JSON request bodies with `jsonRequestBody(InputSchema)`
+   (`apps/api/src/utils/openapi/index.ts`) — `resolver()` only converts responses in hono-openapi
+   v1.3.0. Never `import 'zod-openapi/extend'` (removed in `zod-openapi` v5; it breaks the build).
+4. Add the entity Output Schema under `packages/shared/src/schemas/responses/` (derived from the real
+   `service.ts` return shape, additive, with a co-located unit test) and register any new tag in the
+   `tags` array of `routes/openapi.ts`. Non-JSON routes document their true content type, not a JSON envelope.
+5. Run `make test-api` — `routes/openapi.coverage.test.ts` enforces coverage, tagging, and zero orphan tags.
 
 ## Notifications
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -197,19 +197,30 @@ we ever observe meaningful drop rates in production.
 
 ## ADR-012 — `describeRoute` for OpenAPI without replacing `zValidator`
 
-**Decision.** Use `hono-openapi`'s `describeRoute` for tags / summary / responses. Keep the existing
-`@hono/zod-validator`-based `zValidator(...)` for request validation. Spec served at
-`/api/v1/openapi.json`, viewer at `/api/v1/docs`.
+**Decision.** Use `hono-openapi`'s `describeRoute` for tags / summary / request bodies / responses.
+Keep the existing `@hono/zod-validator`-based `zValidator(...)` as the request validation middleware
+on every route — `hono-openapi`'s own `validator` is **not** used anywhere in `apps/api`. Spec
+served at `/api/v1/openapi.json`, viewer at `/api/v1/docs`.
 
-**Why.** `describeRoute` is independent of validator choice — it gives us a non-empty `paths` object
-derived from the routes we care about (auth, recipe, admin, health) without rewriting every
-endpoint's validation. `hono-openapi`'s own `validator` would also work but would change the shape
-of `c.req.valid('json')` and the lint footprint across 17 modules.
+**Why.** `describeRoute` is independent of validator choice — it gives us a populated `paths` object
+without rewriting every endpoint's validation. `describeRoute()` metadata now covers **every mounted
+route group** (`auth`, `recipe`, `admin`, `health`, `beans`, `badges`, `coffee-varieties`,
+`comments`, `contact`, `equipment`, `follow`, `photos`, `preferences`, `qrcode`, `reports`, `setups`,
+`taste-notes`, `users`, `vendors`, `share`, `sitemap`). `hono-openapi`'s own `validator` would also
+work but would change the shape of `c.req.valid('json')` and the lint footprint across every module,
+so we keep `zValidator` as the single request validator.
 
-**Trade-off.** Request bodies and query params are not auto-described in the spec — only responses
-are, plus whatever `zValidator` exposes via Hono's introspection. Acceptable for now: the spec is
-useful for endpoint discovery and client generation; if downstream needs full I/O typing, swap
-`zValidator` for `hono-openapi`'s `validator` module-by-module.
+**Request-body documentation mechanism.** Responses are described with `resolver(zodSchema)`. Request
+bodies cannot use `resolver()` because `hono-openapi` v1.3.0's `resolver()` only processes response
+schemas; instead, request bodies are documented by converting the **same Zod input schema** that
+`zValidator` validates against to JSON Schema using Zod v4's `z.toJSONSchema`, wrapped in a small
+`jsonRequestBody` helper (`apps/api/src/utils/openapi/index.ts`). No schema is duplicated — the
+validator and the documentation share one source.
+
+**Trade-off.** Both request bodies (via `jsonRequestBody`/`z.toJSONSchema`) and responses (via
+`resolver`) are now fully described in the spec, alongside query/path parameters declared in
+`describeRoute().parameters`. The spec is therefore complete enough for client generation and
+full I/O typing while leaving the runtime validation path (`zValidator`) untouched.
 
 ---
 

--- a/docs/requirements-audit-report.md
+++ b/docs/requirements-audit-report.md
@@ -323,7 +323,14 @@ first-brew creation with tooltips. (Minor)
 
 ### §6.9 OpenAPI — ✅ Implemented
 
-- `hono-openapi` with `describeRoute` decorators on all endpoints.
+- `hono-openapi` with `describeRoute()` metadata covering all mounted route groups: `auth`,
+  `recipe`, `admin`, `health`, `beans`, `badges`, `coffee-varieties`, `comments`, `contact`,
+  `equipment`, `follow`, `photos`, `preferences`, `qrcode`, `reports`, `setups`, `taste-notes`,
+  `users`, `vendors`, `share`, and `sitemap`.
+- Typed request/response schemas: responses are described with `resolver()`; request bodies are
+  described by converting the same Zod input schema to JSON Schema (Zod v4 `z.toJSONSchema` via the
+  `jsonRequestBody` helper), since `hono-openapi` v1.3.0's `resolver()` only processes response
+  schemas.
 - Toggleable via `OPENAPI_ENABLED` env var.
 
 ### §6.10 Environment & Configuration — ✅ Implemented

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,7 +9,8 @@
     "./i18n": { "types": "./src/i18n/index.ts", "default": "./src/i18n/index.ts" }
   },
   "dependencies": {
-    "zod": "^4.0.0"
+    "zod": "^4.0.0",
+    "zod-openapi": "^5.0.0"
   },
   "scripts": {}
 }

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -55,3 +55,10 @@ export {
   BrewMethodCompatibilityCreateSchema,
   BrewMethodCompatibilityUpdateSchema,
 } from './compatibility.ts';
+export {
+  ErrorEnvelopeSchema,
+  paginatedEnvelope,
+  PaginationMetaSchema,
+  successEnvelope,
+} from './response.ts';
+export * from './responses/index.ts';

--- a/packages/shared/src/schemas/response.pbt.test.ts
+++ b/packages/shared/src/schemas/response.pbt.test.ts
@@ -11,11 +11,7 @@ import { describe, it } from 'jsr:@std/testing/bdd';
 import { expect } from 'jsr:@std/expect';
 import { z } from 'zod';
 import fc from 'npm:fast-check';
-import {
-  ErrorEnvelopeSchema,
-  paginatedEnvelope,
-  successEnvelope,
-} from './response.ts';
+import { ErrorEnvelopeSchema, paginatedEnvelope, successEnvelope } from './response.ts';
 
 // ---------------------------------------------------------------------------
 // Generators that mirror the runtime helpers in

--- a/packages/shared/src/schemas/response.pbt.test.ts
+++ b/packages/shared/src/schemas/response.pbt.test.ts
@@ -1,0 +1,109 @@
+// Feature: complete-openapi-docs, Property 8: Response-helper output always validates against its envelope schema
+//
+// For any payload, the envelope produced by the error() helper validates against
+// ErrorEnvelopeSchema, the envelope produced by success(data) validates against
+// successEnvelope(dataSchema), and the envelope produced by paginated(items, meta)
+// validates against paginatedEnvelope(itemSchema), each with zero validation
+// errors — including when PaginationMeta carries any valid in-bounds values.
+//
+// Validates: Requirements 6.1, 6.2, 6.3, 6.4, 12.3
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { z } from 'zod';
+import fc from 'npm:fast-check';
+import {
+  ErrorEnvelopeSchema,
+  paginatedEnvelope,
+  successEnvelope,
+} from './response.ts';
+
+// ---------------------------------------------------------------------------
+// Generators that mirror the runtime helpers in
+// `apps/api/src/utils/response/index.ts`.
+// ---------------------------------------------------------------------------
+
+/** Mirrors error(c, code, message, status, details?). */
+function errorEnvelopeArb(): fc.Arbitrary<unknown> {
+  return fc.record({
+    code: fc.string(),
+    message: fc.string(),
+    requestId: fc.string(),
+    details: fc.option(
+      fc.array(fc.record({ field: fc.string(), message: fc.string() })),
+      { nil: undefined },
+    ),
+  }).map((error) => ({ success: false as const, error }));
+}
+
+/** Arbitrary JSON-serializable data payload. */
+function dataArb(): fc.Arbitrary<unknown> {
+  return fc.jsonValue();
+}
+
+/** Mirrors success(c, data) → { success:true, data, meta:{ requestId } }. */
+function successEnvelopeArb(): fc.Arbitrary<unknown> {
+  return fc.record({
+    data: dataArb(),
+    requestId: fc.string(),
+  }).map(({ data, requestId }) => ({
+    success: true as const,
+    data,
+    meta: { requestId },
+  }));
+}
+
+/** Valid in-bounds PaginationMeta (page≥1, perPage≥1, total≥0, totalPages≥0). */
+function paginationMetaArb(): fc.Arbitrary<
+  { page: number; perPage: number; total: number; totalPages: number }
+> {
+  return fc.record({
+    page: fc.integer({ min: 1, max: 1_000_000 }),
+    perPage: fc.integer({ min: 1, max: 1_000_000 }),
+    total: fc.integer({ min: 0, max: 1_000_000 }),
+    totalPages: fc.integer({ min: 0, max: 1_000_000 }),
+  });
+}
+
+/** Mirrors paginated(c, items, pagination). */
+function paginatedEnvelopeArb(): fc.Arbitrary<unknown> {
+  return fc.record({
+    data: fc.array(dataArb()),
+    requestId: fc.string(),
+    pagination: paginationMetaArb(),
+  }).map(({ data, requestId, pagination }) => ({
+    success: true as const,
+    data,
+    meta: { requestId, pagination },
+  }));
+}
+
+describe('Property 8: response-helper output validates against its envelope schema', () => {
+  it('error() output always parses against ErrorEnvelopeSchema', () => {
+    fc.assert(
+      fc.property(errorEnvelopeArb(), (payload) => {
+        expect(ErrorEnvelopeSchema.safeParse(payload).success).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it('success() output always parses against successEnvelope(z.unknown())', () => {
+    const schema = successEnvelope(z.unknown());
+    fc.assert(
+      fc.property(successEnvelopeArb(), (payload) => {
+        expect(schema.safeParse(payload).success).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it('paginated() output always parses against paginatedEnvelope(z.unknown())', () => {
+    const schema = paginatedEnvelope(z.unknown());
+    fc.assert(
+      fc.property(paginatedEnvelopeArb(), (payload) => {
+        expect(schema.safeParse(payload).success).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/packages/shared/src/schemas/response.test.ts
+++ b/packages/shared/src/schemas/response.test.ts
@@ -1,0 +1,203 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { z } from 'zod';
+import {
+  ErrorEnvelopeSchema,
+  paginatedEnvelope,
+  PaginationMetaSchema,
+  successEnvelope,
+} from './response.ts';
+
+describe('ErrorEnvelopeSchema', () => {
+  it('parses a representative error() output (with details)', () => {
+    // Mirrors error(c, 'VALIDATION_ERROR', 'Validation failed', 400, details)
+    const payload = {
+      success: false as const,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Validation failed',
+        details: [{ field: 'name', message: 'Required' }],
+        requestId: 'req-123',
+      },
+    };
+    const result = ErrorEnvelopeSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(payload);
+    }
+  });
+
+  it('parses an error() output without details (optional field omitted)', () => {
+    // Mirrors notFound(c) → error(c, 'NOT_FOUND', '...', 404) with details undefined
+    const payload = {
+      success: false as const,
+      error: {
+        code: 'NOT_FOUND',
+        message: 'Resource not found',
+        requestId: 'req-456',
+      },
+    };
+    const result = ErrorEnvelopeSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects when success is true (wrong discriminant)', () => {
+    const result = ErrorEnvelopeSchema.safeParse({
+      success: true,
+      error: { code: 'X', message: 'Y', requestId: 'z' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when a required field (requestId) is missing', () => {
+    const result = ErrorEnvelopeSchema.safeParse({
+      success: false,
+      error: { code: 'X', message: 'Y' },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('requestId'))).toBe(true);
+    }
+  });
+});
+
+describe('PaginationMetaSchema', () => {
+  it('parses valid pagination metadata', () => {
+    const result = PaginationMetaSchema.safeParse({
+      page: 1,
+      perPage: 20,
+      total: 42,
+      totalPages: 3,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects page < 1', () => {
+    const result = PaginationMetaSchema.safeParse({
+      page: 0,
+      perPage: 20,
+      total: 0,
+      totalPages: 0,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('page'))).toBe(true);
+    }
+  });
+
+  it('rejects total < 0', () => {
+    const result = PaginationMetaSchema.safeParse({
+      page: 1,
+      perPage: 20,
+      total: -1,
+      totalPages: 0,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('total'))).toBe(true);
+    }
+  });
+
+  it('rejects non-integer page', () => {
+    const result = PaginationMetaSchema.safeParse({
+      page: 1.5,
+      perPage: 20,
+      total: 0,
+      totalPages: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('successEnvelope(dataSchema)', () => {
+  const schema = successEnvelope(z.object({ id: z.string(), name: z.string() }));
+
+  it('parses a representative success() output', () => {
+    // Mirrors success(c, data) → { success:true, data, meta:{ requestId } }
+    const payload = {
+      success: true as const,
+      data: { id: 'bean-1', name: 'Ethiopia Yirgacheffe' },
+      meta: { requestId: 'req-789' },
+    };
+    const result = schema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(payload);
+    }
+  });
+
+  it('rejects when the wrapped data fails the supplied schema', () => {
+    const result = schema.safeParse({
+      success: true,
+      data: { id: 'bean-1' },
+      meta: { requestId: 'req-789' },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes('name'))).toBe(true);
+    }
+  });
+
+  it('rejects when meta.requestId is missing', () => {
+    const result = schema.safeParse({
+      success: true,
+      data: { id: 'bean-1', name: 'X' },
+      meta: {},
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('paginatedEnvelope(itemSchema)', () => {
+  const schema = paginatedEnvelope(z.object({ id: z.string() }));
+
+  it('parses a representative paginated() output', () => {
+    // Mirrors paginated(c, items, pagination)
+    const payload = {
+      success: true as const,
+      data: [{ id: 'a' }, { id: 'b' }],
+      meta: {
+        requestId: 'req-abc',
+        pagination: { page: 1, perPage: 20, total: 2, totalPages: 1 },
+      },
+    };
+    const result = schema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(payload);
+    }
+  });
+
+  it('accepts an empty data array', () => {
+    const result = schema.safeParse({
+      success: true,
+      data: [],
+      meta: {
+        requestId: 'req-abc',
+        pagination: { page: 1, perPage: 20, total: 0, totalPages: 0 },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects out-of-bounds pagination meta (page < 1)', () => {
+    const result = schema.safeParse({
+      success: true,
+      data: [],
+      meta: {
+        requestId: 'req-abc',
+        pagination: { page: 0, perPage: 20, total: 0, totalPages: 0 },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when pagination meta is missing', () => {
+    const result = schema.safeParse({
+      success: true,
+      data: [],
+      meta: { requestId: 'req-abc' },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/response.ts
+++ b/packages/shared/src/schemas/response.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+/**
+ * Shared response-envelope schemas mirroring the runtime helpers in
+ * `apps/api/src/utils/response/index.ts`. These are used purely for OpenAPI
+ * documentation via `hono-openapi`'s `resolver()` and never alter runtime
+ * behavior.
+ *
+ * Note: `hono-openapi` v1 + `zod-openapi` v5 read field metadata directly from
+ * the Zod schema structure — no `zod-openapi/extend` side-effect import is
+ * required (and v5 no longer exports that subpath).
+ */
+
+/** Mirrors error() — { success:false, error:{ code, message, details?, requestId } }. */
+export const ErrorEnvelopeSchema = z.object({
+  success: z.literal(false),
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    details: z
+      .array(z.object({ field: z.string(), message: z.string() }))
+      .optional(),
+    requestId: z.string(),
+  }),
+});
+
+/** Mirrors PaginationMeta in `@brewform/shared/types`. */
+export const PaginationMetaSchema = z.object({
+  page: z.number().int().min(1),
+  perPage: z.number().int().min(1),
+  total: z.number().int().min(0),
+  totalPages: z.number().int().min(0),
+});
+
+/** Mirrors success(c, data) — { success:true, data, meta:{ requestId } }. */
+export function successEnvelope<T extends z.ZodTypeAny>(dataSchema: T) {
+  return z.object({
+    success: z.literal(true),
+    data: dataSchema,
+    meta: z.object({ requestId: z.string() }),
+  });
+}
+
+/** Mirrors paginated(c, items, meta) — data is an array + meta.pagination. */
+export function paginatedEnvelope<T extends z.ZodTypeAny>(itemSchema: T) {
+  return z.object({
+    success: z.literal(true),
+    data: z.array(itemSchema),
+    meta: z.object({
+      requestId: z.string(),
+      pagination: PaginationMetaSchema,
+    }),
+  });
+}

--- a/packages/shared/src/schemas/responses/_shared.test.ts
+++ b/packages/shared/src/schemas/responses/_shared.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { AuthorRefSchema, MessageResponseSchema, RecipeAuthorMiniSchema } from './_shared.ts';
+
+/** Normalize a payload to its JSON wire shape (Dates → ISO strings). */
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+describe('MessageResponseSchema', () => {
+  it('parses a message-only payload and round-trips', () => {
+    const payload = { message: 'Bean deleted' };
+    const result = MessageResponseSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(payload);
+  });
+});
+
+describe('AuthorRefSchema', () => {
+  it('parses a populated author projection', () => {
+    const payload = {
+      id: 'u-1',
+      username: 'barista',
+      displayName: 'Barista',
+      avatarUrl: 'https://cdn/x.png',
+    };
+    const result = AuthorRefSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(payload);
+  });
+
+  it('accepts null (leftJoin miss)', () => {
+    expect(AuthorRefSchema.safeParse(null).success).toBe(true);
+  });
+
+  it('accepts null displayName/avatarUrl', () => {
+    const payload = { id: 'u-1', username: 'barista', displayName: null, avatarUrl: null };
+    expect(AuthorRefSchema.safeParse(wire(payload)).success).toBe(true);
+  });
+});
+
+describe('RecipeAuthorMiniSchema', () => {
+  it('parses the mini author projection and round-trips', () => {
+    const payload = { username: 'barista', displayName: null, avatarUrl: null };
+    const result = RecipeAuthorMiniSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(payload);
+  });
+});

--- a/packages/shared/src/schemas/responses/_shared.ts
+++ b/packages/shared/src/schemas/responses/_shared.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+/**
+ * Reusable Output Schema building blocks shared across entity response schemas.
+ *
+ * These mirror the real service return projections (see each module's
+ * `service.ts`/`model.ts`). With `hono-openapi` v1 + `zod-openapi` v5,
+ * `resolver()` reads field metadata natively from the Zod v4 schema structure —
+ * no `zod-openapi/extend` import is needed (that subpath does not exist in v5).
+ *
+ * Timestamp fields use `z.string()` because Hono's `c.json` serializes `Date`
+ * values to ISO strings on the wire.
+ */
+
+/** Message-only payload returned by delete endpoints — `{ message }`. */
+export const MessageResponseSchema = z.object({ message: z.string() });
+
+/**
+ * Nullable author projection used by comment/recipe left-joins.
+ * `leftJoin` means the joined author object can be `null`.
+ */
+export const AuthorRefSchema = z
+  .object({
+    id: z.string(),
+    username: z.string(),
+    displayName: z.string().nullable(),
+    avatarUrl: z.string().nullable(),
+  })
+  .nullable();
+
+/** Minimal recipe-author projection for equipment/coffee-variety recipe lists. */
+export const RecipeAuthorMiniSchema = z.object({
+  username: z.string(),
+  displayName: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+});

--- a/packages/shared/src/schemas/responses/badge.test.ts
+++ b/packages/shared/src/schemas/responses/badge.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { BadgeOutputSchema, UserBadgeOutputSchema } from './badge.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+describe('BadgeOutputSchema', () => {
+  it('parses a representative badge row and round-trips', () => {
+    const payload = {
+      id: 'badge-1',
+      name: 'First Brew',
+      icon: '☕',
+      description: 'Created your first recipe',
+      rule: 'first_brew',
+      threshold: 1,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    };
+    const result = BadgeOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+});
+
+describe('UserBadgeOutputSchema', () => {
+  it('parses a user-badge with joined badge definition and round-trips', () => {
+    const payload = {
+      id: 'ub-1',
+      userId: 'user-1',
+      badgeId: 'badge-1',
+      awardedAt: new Date('2024-02-01T00:00:00.000Z'),
+      badge: {
+        id: 'badge-1',
+        name: 'First Brew',
+        icon: '☕',
+        description: 'Created your first recipe',
+        rule: 'first_brew',
+        threshold: 1,
+      },
+    };
+    const result = UserBadgeOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+
+  it('accepts a null badge (leftJoin miss)', () => {
+    const payload = {
+      id: 'ub-1',
+      userId: 'user-1',
+      badgeId: 'badge-1',
+      awardedAt: '2024-02-01T00:00:00.000Z',
+      badge: null,
+    };
+    expect(UserBadgeOutputSchema.safeParse(payload).success).toBe(true);
+  });
+});

--- a/packages/shared/src/schemas/responses/badge.ts
+++ b/packages/shared/src/schemas/responses/badge.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+/**
+ * Badge Output Schemas.
+ *
+ * `BadgeOutputSchema` mirrors the full `badges` row from `listBadges`
+ * (`db.select().from(badges)`). `UserBadgeOutputSchema` mirrors the
+ * `getUserBadges` projection — a `userBadges` row with the badge definition
+ * left-joined (hence `badge` is nullable).
+ *
+ * Verified against `packages/db/src/schema.ts` (`badges`, `userBadges`) and
+ * `apps/api/src/modules/badge/{service,model}.ts`.
+ */
+export const BadgeOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  icon: z.string(),
+  description: z.string(),
+  rule: z.string(),
+  threshold: z.number().int(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type BadgeOutput = z.infer<typeof BadgeOutputSchema>;
+
+/** Badge definition projection embedded in a user-badge row (leftJoin → nullable). */
+const UserBadgeBadgeSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    icon: z.string(),
+    description: z.string(),
+    rule: z.string(),
+    threshold: z.number().int(),
+  })
+  .nullable();
+
+export const UserBadgeOutputSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  badgeId: z.string(),
+  awardedAt: z.string(),
+  badge: UserBadgeBadgeSchema,
+});
+
+export type UserBadgeOutput = z.infer<typeof UserBadgeOutputSchema>;

--- a/packages/shared/src/schemas/responses/bean.test.ts
+++ b/packages/shared/src/schemas/responses/bean.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { BeanOutputSchema } from './bean.ts';
+
+/** Normalize to JSON wire shape (Dates → ISO strings) before parsing. */
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+describe('BeanOutputSchema', () => {
+  it('parses a representative bean row and round-trips', () => {
+    const payload = {
+      id: 'bean-1',
+      name: 'Ethiopia Yirgacheffe',
+      brand: 'Acme Roasters',
+      vendorId: 'vendor-1',
+      roaster: null,
+      roastLevel: 'light',
+      processing: 'washed',
+      origin: 'Ethiopia',
+      userId: 'user-1',
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+      deletedAt: null,
+    };
+    const result = BeanOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+
+  it('rejects when a required field (name) is missing', () => {
+    const { name: _omit, ...rest } = {
+      id: 'bean-1',
+      name: 'X',
+      brand: null,
+      vendorId: null,
+      roaster: null,
+      roastLevel: null,
+      processing: null,
+      origin: null,
+      userId: 'user-1',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      deletedAt: null,
+    };
+    expect(BeanOutputSchema.safeParse(rest).success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/responses/bean.ts
+++ b/packages/shared/src/schemas/responses/bean.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+/**
+ * Bean Output Schema — mirrors the full `beans` row returned by
+ * `bean/service.ts` (`model.create`/`findById`/`update` use `.returning()` /
+ * `db.select()`), so every column is present. Nullable columns use
+ * `.nullable()`. Timestamps are `z.string()` for the JSON wire shape.
+ *
+ * Verified against `packages/db/src/schema.ts` (`beans`) and
+ * `apps/api/src/modules/bean/{service,model}.ts`.
+ */
+export const BeanOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  brand: z.string().nullable(),
+  vendorId: z.string().nullable(),
+  roaster: z.string().nullable(),
+  roastLevel: z.string().nullable(),
+  processing: z.string().nullable(),
+  origin: z.string().nullable(),
+  userId: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type BeanOutput = z.infer<typeof BeanOutputSchema>;

--- a/packages/shared/src/schemas/responses/coffee-variety.test.ts
+++ b/packages/shared/src/schemas/responses/coffee-variety.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { CoffeeVarietyOutputSchema } from './coffee-variety.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+describe('CoffeeVarietyOutputSchema', () => {
+  it('parses a representative variety row (with array columns) and round-trips', () => {
+    const payload = {
+      id: 'cv-1',
+      name: 'Geisha',
+      category: 'heirloom',
+      species: 'Coffea arabica',
+      origin: 'Ethiopia',
+      spread: null,
+      altitudeRangeM: '1600-2000',
+      cupProfile: 'Floral, jasmine',
+      body: 'light',
+      acidity: 'high',
+      caffeinePct: '1.2',
+      processingCompatibility: ['washed', 'natural'],
+      diseaseResistance: 'low',
+      yield: 'low',
+      plantSize: 'tall',
+      notes: null,
+      subVarieties: ['Panama Geisha'],
+      fermentation: null,
+      dryingTimeDays: '15',
+      dryingMethod: 'raised beds',
+      mucilageRetentionPct: '0',
+      priceRange: 'high',
+      processing: 'washed',
+      typeLabel: 'Heirloom',
+      notableFarms: ['Hacienda La Esmeralda'],
+      notableRegions: ['Boquete'],
+      regionalVariants: [],
+      globalSharePct: '0.5',
+      isSystem: true,
+      createdBy: null,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deletedAt: null,
+    };
+    const result = CoffeeVarietyOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+
+  it('accepts null array columns', () => {
+    const payload = {
+      id: 'cv-2',
+      name: 'Bourbon',
+      category: 'cultivar',
+      species: null,
+      origin: null,
+      spread: null,
+      altitudeRangeM: null,
+      cupProfile: null,
+      body: null,
+      acidity: null,
+      caffeinePct: null,
+      processingCompatibility: null,
+      diseaseResistance: null,
+      yield: null,
+      plantSize: null,
+      notes: null,
+      subVarieties: null,
+      fermentation: null,
+      dryingTimeDays: null,
+      dryingMethod: null,
+      mucilageRetentionPct: null,
+      priceRange: null,
+      processing: null,
+      typeLabel: null,
+      notableFarms: null,
+      notableRegions: null,
+      regionalVariants: null,
+      globalSharePct: null,
+      isSystem: true,
+      createdBy: null,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      deletedAt: null,
+    };
+    expect(CoffeeVarietyOutputSchema.safeParse(payload).success).toBe(true);
+  });
+});

--- a/packages/shared/src/schemas/responses/coffee-variety.ts
+++ b/packages/shared/src/schemas/responses/coffee-variety.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+/**
+ * Coffee variety Output Schema — mirrors the full `coffeeVarieties` row returned
+ * by `coffee-variety/service.ts` (`model.findById`/`findMany`/`create`/`update`).
+ * Several columns are Postgres `text[]` arrays (`string[]`, nullable).
+ *
+ * Verified against `packages/db/src/schema.ts` (`coffeeVarieties`) and
+ * `apps/api/src/modules/coffee-variety/{service,model}.ts`.
+ */
+export const CoffeeVarietyOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  category: z.string(),
+  species: z.string().nullable(),
+  origin: z.string().nullable(),
+  spread: z.string().nullable(),
+  altitudeRangeM: z.string().nullable(),
+  cupProfile: z.string().nullable(),
+  body: z.string().nullable(),
+  acidity: z.string().nullable(),
+  caffeinePct: z.string().nullable(),
+  processingCompatibility: z.array(z.string()).nullable(),
+  diseaseResistance: z.string().nullable(),
+  yield: z.string().nullable(),
+  plantSize: z.string().nullable(),
+  notes: z.string().nullable(),
+  subVarieties: z.array(z.string()).nullable(),
+  fermentation: z.string().nullable(),
+  dryingTimeDays: z.string().nullable(),
+  dryingMethod: z.string().nullable(),
+  mucilageRetentionPct: z.string().nullable(),
+  priceRange: z.string().nullable(),
+  processing: z.string().nullable(),
+  typeLabel: z.string().nullable(),
+  notableFarms: z.array(z.string()).nullable(),
+  notableRegions: z.array(z.string()).nullable(),
+  regionalVariants: z.array(z.string()).nullable(),
+  globalSharePct: z.string().nullable(),
+  isSystem: z.boolean(),
+  createdBy: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type CoffeeVarietyOutput = z.infer<typeof CoffeeVarietyOutputSchema>;

--- a/packages/shared/src/schemas/responses/comment.test.ts
+++ b/packages/shared/src/schemas/responses/comment.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import {
+  CommentOutputSchema,
+  CommentWithAuthorOutputSchema,
+  CommentWithRepliesOutputSchema,
+} from './comment.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+const rawComment = {
+  id: 'c-1',
+  recipeId: 'recipe-1',
+  authorId: 'user-1',
+  content: 'Great recipe!',
+  parentCommentId: null,
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+  deletedAt: null,
+};
+
+const author = { id: 'user-1', username: 'alice', displayName: 'Alice', avatarUrl: null };
+
+describe('CommentOutputSchema', () => {
+  it('parses the raw create row and round-trips', () => {
+    const result = CommentOutputSchema.safeParse(wire(rawComment));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(rawComment));
+  });
+});
+
+describe('CommentWithAuthorOutputSchema', () => {
+  it('parses a row with joined author and round-trips', () => {
+    const payload = { ...rawComment, author };
+    const result = CommentWithAuthorOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+
+  it('accepts a null author (leftJoin miss)', () => {
+    const payload = { ...rawComment, author: null };
+    expect(CommentWithAuthorOutputSchema.safeParse(wire(payload)).success).toBe(true);
+  });
+});
+
+describe('CommentWithRepliesOutputSchema', () => {
+  it('parses a top-level comment with a replies[] thread and round-trips', () => {
+    const reply = {
+      id: 'c-2',
+      recipeId: 'recipe-1',
+      authorId: 'user-2',
+      content: '@alice thanks!',
+      parentCommentId: 'c-1',
+      createdAt: new Date('2024-01-01T01:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T01:00:00.000Z'),
+      deletedAt: null,
+      author: { id: 'user-2', username: 'bob', displayName: null, avatarUrl: null },
+    };
+    const payload = { ...rawComment, author, replies: [reply] };
+    const result = CommentWithRepliesOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+
+  it('accepts an empty replies array', () => {
+    const payload = { ...rawComment, author, replies: [] };
+    expect(CommentWithRepliesOutputSchema.safeParse(wire(payload)).success).toBe(true);
+  });
+});

--- a/packages/shared/src/schemas/responses/comment.ts
+++ b/packages/shared/src/schemas/responses/comment.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { AuthorRefSchema } from './_shared.ts';
+
+/**
+ * Comment Output Schemas.
+ *
+ * `CommentOutputSchema` mirrors the raw `comments` row returned by
+ * `model.create` (POST). `CommentWithAuthorOutputSchema` adds the left-joined
+ * `author` projection (nullable) used in list rows and replies.
+ * `CommentWithRepliesOutputSchema` is a top-level list item with a `replies[]`
+ * array of with-author comments (from `findByRecipe`).
+ *
+ * Verified against `packages/db/src/schema.ts` (`comments`, `users`) and
+ * `apps/api/src/modules/comment/{service,model}.ts`.
+ */
+export const CommentOutputSchema = z.object({
+  id: z.string(),
+  recipeId: z.string(),
+  authorId: z.string(),
+  content: z.string(),
+  parentCommentId: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type CommentOutput = z.infer<typeof CommentOutputSchema>;
+
+export const CommentWithAuthorOutputSchema = CommentOutputSchema.extend({
+  author: AuthorRefSchema,
+});
+
+export type CommentWithAuthorOutput = z.infer<typeof CommentWithAuthorOutputSchema>;
+
+export const CommentWithRepliesOutputSchema = CommentWithAuthorOutputSchema.extend({
+  replies: z.array(CommentWithAuthorOutputSchema),
+});
+
+export type CommentWithRepliesOutput = z.infer<typeof CommentWithRepliesOutputSchema>;

--- a/packages/shared/src/schemas/responses/equipment.test.ts
+++ b/packages/shared/src/schemas/responses/equipment.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import {
+  EquipmentDeleteRequestOutputSchema,
+  EquipmentDeleteRequestResponseSchema,
+  EquipmentOutputSchema,
+  EquipmentRecipesResponseSchema,
+} from './equipment.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+const equipmentRow = {
+  id: 'eq-1',
+  name: 'Hario V60',
+  type: 'dripper',
+  brand: 'Hario',
+  model: 'VDC-02',
+  description: null,
+  createdBy: null,
+  isSystem: true,
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+  deletedAt: null,
+};
+
+const deleteRequestRow = {
+  id: 'edr-1',
+  equipmentId: 'eq-1',
+  requestedById: 'user-1',
+  reason: 'Duplicate entry',
+  status: 'pending',
+  reviewedById: null,
+  reviewedAt: null,
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  deletedAt: null,
+};
+
+const recipeWithAuthor = {
+  id: 'recipe-1',
+  slug: 'my-pour-over',
+  title: 'My Pour Over',
+  authorId: 'user-1',
+  visibility: 'public',
+  currentVersionId: 'rv-1',
+  likeCount: 0,
+  commentCount: 0,
+  forkCount: 0,
+  forkedFromId: null,
+  featured: false,
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+  deletedAt: null,
+  author: { username: 'barista', displayName: null, avatarUrl: null },
+};
+
+describe('EquipmentOutputSchema', () => {
+  it('parses a full equipment row and round-trips', () => {
+    const result = EquipmentOutputSchema.safeParse(wire(equipmentRow));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(equipmentRow));
+  });
+});
+
+describe('EquipmentDeleteRequestOutputSchema', () => {
+  it('parses a delete-request row and round-trips', () => {
+    const result = EquipmentDeleteRequestOutputSchema.safeParse(wire(deleteRequestRow));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(deleteRequestRow));
+  });
+});
+
+describe('EquipmentDeleteRequestResponseSchema (bespoke, no meta)', () => {
+  it('parses { success, data } with no meta wrapper', () => {
+    const payload = { success: true as const, data: deleteRequestRow };
+    const result = EquipmentDeleteRequestResponseSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects when a meta wrapper is present-but-data-missing shape is malformed', () => {
+    const payload = { success: true, data: { id: 'edr-1' } };
+    expect(EquipmentDeleteRequestResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});
+
+describe('EquipmentRecipesResponseSchema (bespoke, total instead of meta)', () => {
+  it('parses { success, data[], total } with no meta wrapper', () => {
+    const payload = { success: true as const, data: [recipeWithAuthor], total: 1 };
+    const result = EquipmentRecipesResponseSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a non-integer total', () => {
+    const payload = { success: true, data: [], total: 1.5 };
+    expect(EquipmentRecipesResponseSchema.safeParse(payload).success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/responses/equipment.ts
+++ b/packages/shared/src/schemas/responses/equipment.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { RecipeWithAuthorOutputSchema } from './recipe.ts';
+
+/**
+ * Equipment Output Schemas.
+ *
+ * `EquipmentOutputSchema` mirrors the full `equipment` row.
+ * `EquipmentDeleteRequestOutputSchema` mirrors the full `equipmentDeleteRequests`
+ * row from `createDeleteRequest`.
+ *
+ * Two routes return **bespoke** envelopes (no `meta` wrapper), matching the real
+ * handler returns in `equipment/index.ts`:
+ *   - `GET /:id/recipes` → `c.json({ success: true, ...{ data, total } })`
+ *   - `POST /:id/delete-request` → `c.json({ success: true, data }, 201)`
+ *
+ * Verified against `packages/db/src/schema.ts` (`equipment`,
+ * `equipmentDeleteRequests`) and `apps/api/src/modules/equipment/*`.
+ */
+export const EquipmentOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.string(),
+  brand: z.string().nullable(),
+  model: z.string().nullable(),
+  description: z.string().nullable(),
+  createdBy: z.string().nullable(),
+  isSystem: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type EquipmentOutput = z.infer<typeof EquipmentOutputSchema>;
+
+export const EquipmentDeleteRequestOutputSchema = z.object({
+  id: z.string(),
+  equipmentId: z.string(),
+  requestedById: z.string(),
+  reason: z.string().nullable(),
+  status: z.string(),
+  reviewedById: z.string().nullable(),
+  reviewedAt: z.string().nullable(),
+  createdAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type EquipmentDeleteRequestOutput = z.infer<typeof EquipmentDeleteRequestOutputSchema>;
+
+/** Bespoke envelope for `POST /:id/delete-request` (201, no `meta`). */
+export const EquipmentDeleteRequestResponseSchema = z.object({
+  success: z.literal(true),
+  data: EquipmentDeleteRequestOutputSchema,
+});
+
+export type EquipmentDeleteRequestResponse = z.infer<typeof EquipmentDeleteRequestResponseSchema>;
+
+/** Bespoke envelope for `GET /:id/recipes` (200, `total` instead of `meta`). */
+export const EquipmentRecipesResponseSchema = z.object({
+  success: z.literal(true),
+  data: z.array(RecipeWithAuthorOutputSchema),
+  total: z.number().int(),
+});
+
+export type EquipmentRecipesResponse = z.infer<typeof EquipmentRecipesResponseSchema>;

--- a/packages/shared/src/schemas/responses/follow.test.ts
+++ b/packages/shared/src/schemas/responses/follow.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import {
+  FollowerListItemOutputSchema,
+  FollowingListItemOutputSchema,
+  FollowOutputSchema,
+} from './follow.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+describe('FollowOutputSchema', () => {
+  it('parses a raw follow row and round-trips', () => {
+    const payload = {
+      id: 'follow-1',
+      followerId: 'user-1',
+      followingId: 'user-2',
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    };
+    const result = FollowOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+});
+
+describe('FollowerListItemOutputSchema', () => {
+  it('parses a follower list item with joined profile and round-trips', () => {
+    const payload = {
+      id: 'follow-1',
+      followerId: 'user-1',
+      followingId: 'user-2',
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      follower: {
+        id: 'user-1',
+        username: 'alice',
+        displayName: 'Alice',
+        avatarUrl: null,
+        bio: 'Coffee lover',
+      },
+    };
+    const result = FollowerListItemOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+});
+
+describe('FollowingListItemOutputSchema', () => {
+  it('parses a following list item with joined profile and round-trips', () => {
+    const payload = {
+      id: 'follow-2',
+      followerId: 'user-1',
+      followingId: 'user-3',
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      following: {
+        id: 'user-3',
+        username: 'bob',
+        displayName: null,
+        avatarUrl: null,
+        bio: null,
+      },
+    };
+    const result = FollowingListItemOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+});

--- a/packages/shared/src/schemas/responses/follow.ts
+++ b/packages/shared/src/schemas/responses/follow.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+/**
+ * Follow Output Schemas.
+ *
+ * `FollowOutputSchema` mirrors the raw `userFollows` row from `createFollow`.
+ * `FollowerListItemOutputSchema` / `FollowingListItemOutputSchema` mirror the
+ * paginated list projections from `getFollowers` / `getFollowing`, which
+ * inner-join the user profile (so the joined object is non-nullable) and expose
+ * `{ id, username, displayName, avatarUrl, bio }`.
+ *
+ * Verified against `packages/db/src/schema.ts` (`userFollows`, `users`) and
+ * `apps/api/src/modules/follow/{service,model}.ts`.
+ */
+export const FollowOutputSchema = z.object({
+  id: z.string(),
+  followerId: z.string(),
+  followingId: z.string(),
+  createdAt: z.string(),
+});
+
+export type FollowOutput = z.infer<typeof FollowOutputSchema>;
+
+/** Joined user profile projection used by follower/following list items. */
+const FollowUserProfileSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  displayName: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+  bio: z.string().nullable(),
+});
+
+export const FollowerListItemOutputSchema = z.object({
+  id: z.string(),
+  followerId: z.string(),
+  followingId: z.string(),
+  createdAt: z.string(),
+  follower: FollowUserProfileSchema,
+});
+
+export type FollowerListItemOutput = z.infer<typeof FollowerListItemOutputSchema>;
+
+export const FollowingListItemOutputSchema = z.object({
+  id: z.string(),
+  followerId: z.string(),
+  followingId: z.string(),
+  createdAt: z.string(),
+  following: FollowUserProfileSchema,
+});
+
+export type FollowingListItemOutput = z.infer<typeof FollowingListItemOutputSchema>;

--- a/packages/shared/src/schemas/responses/index.ts
+++ b/packages/shared/src/schemas/responses/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Barrel for entity Output Schemas (response shapes).
+ *
+ * These document the **actual** service return shapes for OpenAPI via
+ * `hono-openapi`'s `resolver()`. They are additive and never alter runtime
+ * behavior. Re-exported from `packages/shared/src/schemas/index.ts`.
+ */
+export { AuthorRefSchema, MessageResponseSchema, RecipeAuthorMiniSchema } from './_shared.ts';
+export { BeanOutputSchema } from './bean.ts';
+export { BadgeOutputSchema, UserBadgeOutputSchema } from './badge.ts';
+export { VendorOutputSchema } from './vendor.ts';
+export { PhotoOutputSchema } from './photo.ts';
+export { ReportOutputSchema } from './report.ts';
+export { SetupOutputSchema } from './setup.ts';
+export { UserPreferencesOutputSchema } from './preference.ts';
+export {
+  FollowerListItemOutputSchema,
+  FollowingListItemOutputSchema,
+  FollowOutputSchema,
+} from './follow.ts';
+export { CoffeeVarietyOutputSchema } from './coffee-variety.ts';
+export {
+  EquipmentDeleteRequestOutputSchema,
+  EquipmentDeleteRequestResponseSchema,
+  EquipmentOutputSchema,
+  EquipmentRecipesResponseSchema,
+} from './equipment.ts';
+export {
+  FeedRecipeOutputSchema,
+  RecipeRowSchema,
+  RecipeVersionRowSchema,
+  RecipeWithAuthorOutputSchema,
+  RecipeWithVersionsOutputSchema,
+} from './recipe.ts';
+export {
+  CommentOutputSchema,
+  CommentWithAuthorOutputSchema,
+  CommentWithRepliesOutputSchema,
+} from './comment.ts';
+export { TasteNoteNodeOutputSchema, TasteNoteOutputSchema } from './taste.ts';
+export {
+  PublicUserOutputSchema,
+  SelfUserOutputSchema,
+  UserRowOutputSchema,
+} from './user.ts';

--- a/packages/shared/src/schemas/responses/index.ts
+++ b/packages/shared/src/schemas/responses/index.ts
@@ -38,8 +38,4 @@ export {
   CommentWithRepliesOutputSchema,
 } from './comment.ts';
 export { TasteNoteNodeOutputSchema, TasteNoteOutputSchema } from './taste.ts';
-export {
-  PublicUserOutputSchema,
-  SelfUserOutputSchema,
-  UserRowOutputSchema,
-} from './user.ts';
+export { PublicUserOutputSchema, SelfUserOutputSchema, UserRowOutputSchema } from './user.ts';

--- a/packages/shared/src/schemas/responses/malformed-rejection.pbt.test.ts
+++ b/packages/shared/src/schemas/responses/malformed-rejection.pbt.test.ts
@@ -1,0 +1,109 @@
+// Feature: complete-openapi-docs, Property 10: Malformed payloads are rejected
+//
+// For any envelope or Output Schema, a payload that omits a required field,
+// supplies a field of the wrong type, or supplies a PaginationMeta value outside
+// its bounds (e.g. page < 1, total < 0) is reported as invalid.
+//
+// Validates: Requirements 6.6, 8.5, 12.5
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import fc from 'npm:fast-check';
+import { PaginationMetaSchema } from '../response.ts';
+import { BeanOutputSchema } from './bean.ts';
+
+// ---------------------------------------------------------------------------
+// A valid Bean payload generator (wire shape). Used as the base that the
+// property then corrupts in three distinct ways.
+// ---------------------------------------------------------------------------
+const ts = fc.date({ noInvalidDate: true }).map((d) => d.toISOString());
+const nstr = fc.option(fc.string(), { nil: null });
+
+const validBeanArb = fc.record({
+  id: fc.string(),
+  name: fc.string(),
+  brand: nstr,
+  vendorId: nstr,
+  roaster: nstr,
+  roastLevel: nstr,
+  processing: nstr,
+  origin: nstr,
+  userId: fc.string(),
+  createdAt: ts,
+  updatedAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+});
+
+/** Non-string, non-null values that are invalid for a `z.string()` field. */
+const wrongTypeArb = fc.oneof(
+  fc.integer(),
+  fc.boolean(),
+  fc.array(fc.string()),
+  fc.record({ nested: fc.string() }),
+);
+
+describe('Property 10: malformed payloads are rejected', () => {
+  it('rejects a payload with a dropped required field', () => {
+    fc.assert(
+      fc.property(
+        validBeanArb,
+        fc.nat(),
+        (bean, idx) => {
+          const keys = Object.keys(bean);
+          const keyToDrop = keys[idx % keys.length];
+          const corrupted = { ...bean } as Record<string, unknown>;
+          delete corrupted[keyToDrop];
+          expect(BeanOutputSchema.safeParse(corrupted).success).toBe(false);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('rejects a payload with a required string field retyped to a wrong type', () => {
+    // `id` and `userId` are non-nullable strings — a non-string value must fail.
+    fc.assert(
+      fc.property(
+        validBeanArb,
+        fc.constantFrom('id', 'userId', 'name'),
+        wrongTypeArb,
+        (bean, key, wrongValue) => {
+          const corrupted = { ...bean, [key]: wrongValue };
+          expect(BeanOutputSchema.safeParse(corrupted).success).toBe(false);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('rejects PaginationMeta with out-of-bounds values (page < 1 or total < 0)', () => {
+    const invalidMetaArb = fc.oneof(
+      // page < 1
+      fc.record({
+        page: fc.integer({ max: 0 }),
+        perPage: fc.integer({ min: 1, max: 1000 }),
+        total: fc.integer({ min: 0, max: 1000 }),
+        totalPages: fc.integer({ min: 0, max: 1000 }),
+      }),
+      // total < 0
+      fc.record({
+        page: fc.integer({ min: 1, max: 1000 }),
+        perPage: fc.integer({ min: 1, max: 1000 }),
+        total: fc.integer({ max: -1 }),
+        totalPages: fc.integer({ min: 0, max: 1000 }),
+      }),
+      // perPage < 1
+      fc.record({
+        page: fc.integer({ min: 1, max: 1000 }),
+        perPage: fc.integer({ max: 0 }),
+        total: fc.integer({ min: 0, max: 1000 }),
+        totalPages: fc.integer({ min: 0, max: 1000 }),
+      }),
+    );
+    fc.assert(
+      fc.property(invalidMetaArb, (meta) => {
+        expect(PaginationMetaSchema.safeParse(meta).success).toBe(false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/packages/shared/src/schemas/responses/malformed-rejection.pbt.test.ts
+++ b/packages/shared/src/schemas/responses/malformed-rejection.pbt.test.ts
@@ -75,7 +75,7 @@ describe('Property 10: malformed payloads are rejected', () => {
     );
   });
 
-  it('rejects PaginationMeta with out-of-bounds values (page < 1 or total < 0)', () => {
+  it('rejects PaginationMeta with out-of-bounds values (page < 1, total < 0, or perPage < 1)', () => {
     const invalidMetaArb = fc.oneof(
       // page < 1
       fc.record({

--- a/packages/shared/src/schemas/responses/output-schema-acceptance.pbt.test.ts
+++ b/packages/shared/src/schemas/responses/output-schema-acceptance.pbt.test.ts
@@ -1,0 +1,601 @@
+// Feature: complete-openapi-docs, Property 9: Every Output Schema accepts a representative service payload
+//
+// For any entity Output Schema (including every distinct returned variant —
+// taste hierarchy node vs flat note; user self vs row vs public; comment raw vs
+// with-author vs with-replies; recipe with-author vs with-versions vs feed),
+// parsing a representative payload that populates every field the corresponding
+// service returns — scalar columns, joined objects, related-entity arrays,
+// count fields, and boolean flags — succeeds with zero validation errors and
+// yields parsed output equal to the input.
+//
+// Validates: Requirements 7.1, 7.2, 7.3, 12.4
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import type { z } from 'zod';
+import fc from 'npm:fast-check';
+
+import { AuthorRefSchema, MessageResponseSchema, RecipeAuthorMiniSchema } from './_shared.ts';
+import { BeanOutputSchema } from './bean.ts';
+import { BadgeOutputSchema, UserBadgeOutputSchema } from './badge.ts';
+import { VendorOutputSchema } from './vendor.ts';
+import { PhotoOutputSchema } from './photo.ts';
+import { ReportOutputSchema } from './report.ts';
+import { SetupOutputSchema } from './setup.ts';
+import { UserPreferencesOutputSchema } from './preference.ts';
+import {
+  FollowerListItemOutputSchema,
+  FollowingListItemOutputSchema,
+  FollowOutputSchema,
+} from './follow.ts';
+import { CoffeeVarietyOutputSchema } from './coffee-variety.ts';
+import {
+  EquipmentDeleteRequestOutputSchema,
+  EquipmentDeleteRequestResponseSchema,
+  EquipmentOutputSchema,
+  EquipmentRecipesResponseSchema,
+} from './equipment.ts';
+import {
+  FeedRecipeOutputSchema,
+  RecipeRowSchema,
+  RecipeVersionRowSchema,
+  RecipeWithAuthorOutputSchema,
+  RecipeWithVersionsOutputSchema,
+} from './recipe.ts';
+import {
+  CommentOutputSchema,
+  CommentWithAuthorOutputSchema,
+  CommentWithRepliesOutputSchema,
+} from './comment.ts';
+import { TasteNoteNodeOutputSchema, TasteNoteOutputSchema } from './taste.ts';
+import {
+  PublicUserOutputSchema,
+  SelfUserOutputSchema,
+  UserRowOutputSchema,
+} from './user.ts';
+
+// ---------------------------------------------------------------------------
+// Reusable building-block arbitraries — JSON-serializable values matching the
+// wire shape (timestamps are strings, nullable columns may be null).
+// ---------------------------------------------------------------------------
+const str = fc.string();
+const nstr = fc.option(fc.string(), { nil: null });
+const bool = fc.boolean();
+const int = fc.integer();
+const nint = fc.option(fc.integer(), { nil: null });
+const num = fc.double({ noNaN: true, noDefaultInfinity: true });
+const nnum = fc.option(num, { nil: null });
+const ts = fc.date({ noInvalidDate: true }).map((d) => d.toISOString());
+const nStrArr = fc.option(fc.array(fc.string()), { nil: null });
+
+const beanArb = fc.record({
+  id: str,
+  name: str,
+  brand: nstr,
+  vendorId: nstr,
+  roaster: nstr,
+  roastLevel: nstr,
+  processing: nstr,
+  origin: nstr,
+  userId: str,
+  createdAt: ts,
+  updatedAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+});
+
+const badgeArb = fc.record({
+  id: str,
+  name: str,
+  icon: str,
+  description: str,
+  rule: str,
+  threshold: int,
+  createdAt: ts,
+  updatedAt: ts,
+});
+
+const userBadgeArb = fc.record({
+  id: str,
+  userId: str,
+  badgeId: str,
+  awardedAt: ts,
+  badge: fc.option(
+    fc.record({
+      id: str,
+      name: str,
+      icon: str,
+      description: str,
+      rule: str,
+      threshold: int,
+    }),
+    { nil: null },
+  ),
+});
+
+const vendorArb = fc.record({
+  id: str,
+  name: str,
+  website: nstr,
+  description: nstr,
+  createdBy: nstr,
+  createdAt: ts,
+  updatedAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+});
+
+const photoArb = fc.record({
+  id: str,
+  recipeId: str,
+  url: str,
+  thumbnailUrl: nstr,
+  alt: nstr,
+  sortOrder: int,
+  createdAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+});
+
+const reportArb = fc.record({
+  id: str,
+  reporterId: str,
+  entityType: str,
+  entityId: str,
+  reason: str,
+  status: str,
+  resolvedAt: fc.option(ts, { nil: null }),
+  resolvedBy: nstr,
+  createdAt: ts,
+  updatedAt: ts,
+});
+
+const setupArb = fc.record({
+  id: str,
+  name: str,
+  userId: str,
+  brewerDetails: nstr,
+  grinder: nstr,
+  portafilterId: nstr,
+  basketId: nstr,
+  puckScreenId: nstr,
+  paperFilterId: nstr,
+  tamperId: nstr,
+  isDefault: bool,
+  createdAt: ts,
+  updatedAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+});
+
+const preferencesArb = fc.record({
+  id: str,
+  userId: str,
+  unitSystem: str,
+  temperatureUnit: str,
+  theme: str,
+  locale: str,
+  timezone: str,
+  dateFormat: str,
+  newFollower: bool,
+  recipeLiked: bool,
+  recipeCommented: bool,
+  followedUserPosted: bool,
+  createdAt: ts,
+  updatedAt: ts,
+});
+
+const followArb = fc.record({
+  id: str,
+  followerId: str,
+  followingId: str,
+  createdAt: ts,
+});
+
+const followProfileArb = fc.record({
+  id: str,
+  username: str,
+  displayName: nstr,
+  avatarUrl: nstr,
+  bio: nstr,
+});
+
+const followerListItemArb = fc.record({
+  id: str,
+  followerId: str,
+  followingId: str,
+  createdAt: ts,
+  follower: followProfileArb,
+});
+
+const followingListItemArb = fc.record({
+  id: str,
+  followerId: str,
+  followingId: str,
+  createdAt: ts,
+  following: followProfileArb,
+});
+
+const coffeeVarietyArb = fc.record({
+  id: str,
+  name: str,
+  category: str,
+  species: nstr,
+  origin: nstr,
+  spread: nstr,
+  altitudeRangeM: nstr,
+  cupProfile: nstr,
+  body: nstr,
+  acidity: nstr,
+  caffeinePct: nstr,
+  processingCompatibility: nStrArr,
+  diseaseResistance: nstr,
+  yield: nstr,
+  plantSize: nstr,
+  notes: nstr,
+  subVarieties: nStrArr,
+  fermentation: nstr,
+  dryingTimeDays: nstr,
+  dryingMethod: nstr,
+  mucilageRetentionPct: nstr,
+  priceRange: nstr,
+  processing: nstr,
+  typeLabel: nstr,
+  notableFarms: nStrArr,
+  notableRegions: nStrArr,
+  regionalVariants: nStrArr,
+  globalSharePct: nstr,
+  isSystem: bool,
+  createdBy: nstr,
+  createdAt: ts,
+  updatedAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+});
+
+const equipmentArb = fc.record({
+  id: str,
+  name: str,
+  type: str,
+  brand: nstr,
+  model: nstr,
+  description: nstr,
+  createdBy: nstr,
+  isSystem: bool,
+  createdAt: ts,
+  updatedAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+});
+
+const equipmentDeleteRequestArb = fc.record({
+  id: str,
+  equipmentId: str,
+  requestedById: str,
+  reason: nstr,
+  status: str,
+  reviewedById: nstr,
+  reviewedAt: fc.option(ts, { nil: null }),
+  createdAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+});
+
+const equipmentDeleteRequestResponseArb = fc.record({
+  success: fc.constant(true as const),
+  data: equipmentDeleteRequestArb,
+});
+
+const recipeRowArb = fc.record({
+  id: str,
+  slug: str,
+  title: str,
+  authorId: str,
+  visibility: str,
+  currentVersionId: nstr,
+  likeCount: int,
+  commentCount: int,
+  forkCount: int,
+  forkedFromId: nstr,
+  featured: bool,
+  createdAt: ts,
+  updatedAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+});
+
+const miniAuthorArb = fc.record({
+  username: str,
+  displayName: nstr,
+  avatarUrl: nstr,
+});
+
+const recipeWithAuthorArb = fc.record({
+  id: str,
+  slug: str,
+  title: str,
+  authorId: str,
+  visibility: str,
+  currentVersionId: nstr,
+  likeCount: int,
+  commentCount: int,
+  forkCount: int,
+  forkedFromId: nstr,
+  featured: bool,
+  createdAt: ts,
+  updatedAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+  author: miniAuthorArb,
+});
+
+const versionPhotoArb = fc.record({
+  id: str,
+  recipeVersionId: str,
+  photoId: str,
+  sortOrder: int,
+  photo: photoArb,
+});
+
+const recipeVersionArb = fc.record({
+  id: str,
+  recipeId: str,
+  versionNumber: int,
+  productName: nstr,
+  coffeeBrand: nstr,
+  coffeeProcessing: nstr,
+  vendorId: nstr,
+  roastDate: nstr,
+  packageOpenDate: nstr,
+  grindDate: nstr,
+  brewDate: ts,
+  brewMethod: str,
+  drinkType: str,
+  brewerDetails: nstr,
+  grinder: nstr,
+  grindSize: nstr,
+  groundWeightGrams: nnum,
+  extractionTimeSeconds: nint,
+  extractionVolumeMl: nnum,
+  temperatureCelsius: nnum,
+  tds: nstr,
+  brewRatio: nnum,
+  flowRate: nnum,
+  preInfusionTimeSeconds: nint,
+  beanId: nstr,
+  coffeeVarietyId: nstr,
+  coffeeVarietyName: nstr,
+  personalNotes: nstr,
+  preparationNotes: str,
+  isFavourite: bool,
+  rating: nint,
+  emojiTag: nstr,
+  createdAt: ts,
+  versionPhotos: fc.array(versionPhotoArb),
+});
+
+const recipeWithVersionsArb = recipeWithAuthorArb.chain((base) =>
+  fc.array(recipeVersionArb).map((versions) => ({ ...base, versions }))
+);
+
+const feedRecipeArb = recipeRowArb.chain((base) =>
+  fc.record({ id: str, username: str, displayName: nstr }).map((author) => ({ ...base, author }))
+);
+
+const authorRefArb = fc.option(
+  fc.record({ id: str, username: str, displayName: nstr, avatarUrl: nstr }),
+  { nil: null },
+);
+
+const commentArb = fc.record({
+  id: str,
+  recipeId: str,
+  authorId: str,
+  content: str,
+  parentCommentId: nstr,
+  createdAt: ts,
+  updatedAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+});
+
+const commentWithAuthorArb = fc.record({
+  id: str,
+  recipeId: str,
+  authorId: str,
+  content: str,
+  parentCommentId: nstr,
+  createdAt: ts,
+  updatedAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+  author: authorRefArb,
+});
+
+const commentWithRepliesArb = commentWithAuthorArb.chain((base) =>
+  fc.array(commentWithAuthorArb).map((replies) => ({ ...base, replies }))
+);
+
+const tasteNoteArb = fc.record({
+  id: str,
+  name: str,
+  parentId: nstr,
+  color: nstr,
+  definition: nstr,
+  depth: int,
+  createdAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+});
+
+// Recursive taste-note node (bounded depth via fc.letrec).
+const { tasteNoteNode } = fc.letrec<{ tasteNoteNode: unknown }>((tie) => ({
+  tasteNoteNode: fc.record({
+    id: str,
+    name: str,
+    parentId: nstr,
+    color: nstr,
+    definition: nstr,
+    depth: int,
+    createdAt: ts,
+    deletedAt: fc.option(ts, { nil: null }),
+    children: fc.oneof(
+      { depthSize: 'small' },
+      fc.constant([]),
+      fc.array(tie('tasteNoteNode'), { maxLength: 3 }),
+    ),
+  }),
+}));
+
+const userBaseArb = {
+  id: str,
+  email: str,
+  emailVerifiedAt: fc.option(ts, { nil: null }),
+  username: str,
+  displayName: nstr,
+  avatarUrl: nstr,
+  bio: nstr,
+  onboardingCompleted: bool,
+  isAdmin: bool,
+  isBanned: bool,
+  createdAt: ts,
+  updatedAt: ts,
+  deletedAt: fc.option(ts, { nil: null }),
+};
+
+const userRowArb = fc.record({ ...userBaseArb });
+
+const selfPreferencesArb = fc.option(
+  fc.record({
+    unitSystem: str,
+    temperatureUnit: str,
+    theme: str,
+    locale: str,
+    timezone: str,
+    dateFormat: str,
+    emailNotifications: fc.record({
+      newFollower: bool,
+      recipeLiked: bool,
+      recipeCommented: bool,
+      followedUserPosted: bool,
+    }),
+  }),
+  { nil: null },
+);
+
+const selfUserArb = fc.record({
+  ...userBaseArb,
+  preferences: selfPreferencesArb,
+  recipeCount: int,
+  followerCount: int,
+  followingCount: int,
+});
+
+const { email: _omitEmail, ...userBaseNoEmail } = userBaseArb;
+const publicUserArb = fc.record({
+  ...userBaseNoEmail,
+  recipeCount: int,
+  followerCount: int,
+  followingCount: int,
+  recipes: fc.array(fc.record({
+    id: str,
+    slug: str,
+    title: str,
+    likeCount: int,
+    commentCount: int,
+    createdAt: ts,
+    currentVersion: fc.option(
+      fc.record({ brewMethod: str, drinkType: str }),
+      { nil: null },
+    ),
+  })),
+  badges: fc.constant([]),
+  isFollowing: bool,
+});
+
+const messageArb = fc.record({ message: str });
+const authorRefCaseArb = authorRefArb;
+const recipeAuthorMiniArb = miniAuthorArb;
+
+// ---------------------------------------------------------------------------
+// Cases — one per Output Schema / distinct variant.
+// ---------------------------------------------------------------------------
+// deno-lint-ignore no-explicit-any
+const cases: Array<{ name: string; schema: z.ZodType<any>; arb: fc.Arbitrary<unknown> }> = [
+  { name: 'MessageResponseSchema', schema: MessageResponseSchema, arb: messageArb },
+  { name: 'AuthorRefSchema', schema: AuthorRefSchema, arb: authorRefCaseArb },
+  { name: 'RecipeAuthorMiniSchema', schema: RecipeAuthorMiniSchema, arb: recipeAuthorMiniArb },
+  { name: 'BeanOutputSchema', schema: BeanOutputSchema, arb: beanArb },
+  { name: 'BadgeOutputSchema', schema: BadgeOutputSchema, arb: badgeArb },
+  { name: 'UserBadgeOutputSchema', schema: UserBadgeOutputSchema, arb: userBadgeArb },
+  { name: 'VendorOutputSchema', schema: VendorOutputSchema, arb: vendorArb },
+  { name: 'PhotoOutputSchema', schema: PhotoOutputSchema, arb: photoArb },
+  { name: 'ReportOutputSchema', schema: ReportOutputSchema, arb: reportArb },
+  { name: 'SetupOutputSchema', schema: SetupOutputSchema, arb: setupArb },
+  { name: 'UserPreferencesOutputSchema', schema: UserPreferencesOutputSchema, arb: preferencesArb },
+  { name: 'FollowOutputSchema', schema: FollowOutputSchema, arb: followArb },
+  {
+    name: 'FollowerListItemOutputSchema',
+    schema: FollowerListItemOutputSchema,
+    arb: followerListItemArb,
+  },
+  {
+    name: 'FollowingListItemOutputSchema',
+    schema: FollowingListItemOutputSchema,
+    arb: followingListItemArb,
+  },
+  { name: 'CoffeeVarietyOutputSchema', schema: CoffeeVarietyOutputSchema, arb: coffeeVarietyArb },
+  { name: 'EquipmentOutputSchema', schema: EquipmentOutputSchema, arb: equipmentArb },
+  {
+    name: 'EquipmentDeleteRequestOutputSchema',
+    schema: EquipmentDeleteRequestOutputSchema,
+    arb: equipmentDeleteRequestArb,
+  },
+  {
+    name: 'EquipmentDeleteRequestResponseSchema',
+    schema: EquipmentDeleteRequestResponseSchema,
+    arb: equipmentDeleteRequestResponseArb,
+  },
+  { name: 'RecipeRowSchema', schema: RecipeRowSchema, arb: recipeRowArb },
+  {
+    name: 'RecipeWithAuthorOutputSchema',
+    schema: RecipeWithAuthorOutputSchema,
+    arb: recipeWithAuthorArb,
+  },
+  { name: 'RecipeVersionRowSchema', schema: RecipeVersionRowSchema, arb: recipeVersionArb },
+  {
+    name: 'RecipeWithVersionsOutputSchema',
+    schema: RecipeWithVersionsOutputSchema,
+    arb: recipeWithVersionsArb,
+  },
+  { name: 'FeedRecipeOutputSchema', schema: FeedRecipeOutputSchema, arb: feedRecipeArb },
+  {
+    name: 'EquipmentRecipesResponseSchema',
+    schema: EquipmentRecipesResponseSchema,
+    arb: fc.record({
+      success: fc.constant(true as const),
+      data: fc.array(recipeWithAuthorArb),
+      total: int,
+    }),
+  },
+  { name: 'CommentOutputSchema', schema: CommentOutputSchema, arb: commentArb },
+  {
+    name: 'CommentWithAuthorOutputSchema',
+    schema: CommentWithAuthorOutputSchema,
+    arb: commentWithAuthorArb,
+  },
+  {
+    name: 'CommentWithRepliesOutputSchema',
+    schema: CommentWithRepliesOutputSchema,
+    arb: commentWithRepliesArb,
+  },
+  { name: 'TasteNoteOutputSchema', schema: TasteNoteOutputSchema, arb: tasteNoteArb },
+  { name: 'TasteNoteNodeOutputSchema', schema: TasteNoteNodeOutputSchema, arb: tasteNoteNode },
+  { name: 'UserRowOutputSchema', schema: UserRowOutputSchema, arb: userRowArb },
+  { name: 'SelfUserOutputSchema', schema: SelfUserOutputSchema, arb: selfUserArb },
+  { name: 'PublicUserOutputSchema', schema: PublicUserOutputSchema, arb: publicUserArb },
+];
+
+describe('Property 9: every Output Schema accepts a representative generated payload', () => {
+  for (const { name, schema, arb } of cases) {
+    it(`${name} parses and round-trips representative payloads`, () => {
+      fc.assert(
+        fc.property(arb, (payload) => {
+          const result = schema.safeParse(payload);
+          expect(result.success).toBe(true);
+          if (result.success) {
+            expect(result.data).toEqual(payload);
+          }
+        }),
+        { numRuns: 100 },
+      );
+    });
+  }
+});

--- a/packages/shared/src/schemas/responses/output-schema-acceptance.pbt.test.ts
+++ b/packages/shared/src/schemas/responses/output-schema-acceptance.pbt.test.ts
@@ -47,11 +47,7 @@ import {
   CommentWithRepliesOutputSchema,
 } from './comment.ts';
 import { TasteNoteNodeOutputSchema, TasteNoteOutputSchema } from './taste.ts';
-import {
-  PublicUserOutputSchema,
-  SelfUserOutputSchema,
-  UserRowOutputSchema,
-} from './user.ts';
+import { PublicUserOutputSchema, SelfUserOutputSchema, UserRowOutputSchema } from './user.ts';
 
 // ---------------------------------------------------------------------------
 // Reusable building-block arbitraries — JSON-serializable values matching the

--- a/packages/shared/src/schemas/responses/photo.test.ts
+++ b/packages/shared/src/schemas/responses/photo.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { PhotoOutputSchema } from './photo.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+describe('PhotoOutputSchema', () => {
+  it('parses a representative photo row and round-trips', () => {
+    const payload = {
+      id: 'photo-1',
+      recipeId: 'recipe-1',
+      url: 'https://cdn/p.jpg',
+      thumbnailUrl: 'https://cdn/p-thumb.jpg',
+      alt: 'A pour over',
+      sortOrder: 0,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      deletedAt: null,
+    };
+    const result = PhotoOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+
+  it('rejects a non-integer sortOrder', () => {
+    const payload = {
+      id: 'photo-1',
+      recipeId: 'recipe-1',
+      url: 'https://cdn/p.jpg',
+      thumbnailUrl: null,
+      alt: null,
+      sortOrder: 1.5,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      deletedAt: null,
+    };
+    expect(PhotoOutputSchema.safeParse(payload).success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/responses/photo.ts
+++ b/packages/shared/src/schemas/responses/photo.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/**
+ * Photo Output Schema — mirrors the full `photos` row returned by
+ * `photo/service.ts` (`model.create`/`findByRecipe`). Reused by recipe version
+ * photos.
+ *
+ * Verified against `packages/db/src/schema.ts` (`photos`) and
+ * `apps/api/src/modules/photo/{service,model}.ts`.
+ */
+export const PhotoOutputSchema = z.object({
+  id: z.string(),
+  recipeId: z.string(),
+  url: z.string(),
+  thumbnailUrl: z.string().nullable(),
+  alt: z.string().nullable(),
+  sortOrder: z.number().int(),
+  createdAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type PhotoOutput = z.infer<typeof PhotoOutputSchema>;

--- a/packages/shared/src/schemas/responses/preference.test.ts
+++ b/packages/shared/src/schemas/responses/preference.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { UserPreferencesOutputSchema } from './preference.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+describe('UserPreferencesOutputSchema', () => {
+  it('parses the flat preferences row and round-trips', () => {
+    const payload = {
+      id: 'pref-1',
+      userId: 'user-1',
+      unitSystem: 'metric',
+      temperatureUnit: 'celsius',
+      theme: 'light',
+      locale: 'en',
+      timezone: 'UTC',
+      dateFormat: 'YYYY_MM_DD',
+      newFollower: true,
+      recipeLiked: true,
+      recipeCommented: false,
+      followedUserPosted: true,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    };
+    const result = UserPreferencesOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+
+  it('rejects a nested emailNotifications object (request-body shape, not the flat row)', () => {
+    const payload = {
+      id: 'pref-1',
+      userId: 'user-1',
+      unitSystem: 'metric',
+      temperatureUnit: 'celsius',
+      theme: 'light',
+      locale: 'en',
+      timezone: 'UTC',
+      dateFormat: 'YYYY_MM_DD',
+      emailNotifications: { newFollower: true },
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    expect(UserPreferencesOutputSchema.safeParse(payload).success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/responses/preference.ts
+++ b/packages/shared/src/schemas/responses/preference.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+/**
+ * User preferences Output Schema — the **flat** `user_preferences` row returned
+ * by `preference/service.ts` (`model.findByUserId`/`upsert` via `.returning()`).
+ *
+ * Note: the request body (`UserPreferencesSchema`) nests notification flags
+ * under `emailNotifications`, but the persisted/returned row is flat
+ * (`newFollower`, `recipeLiked`, …). This schema reflects the flat row.
+ *
+ * Verified against `packages/db/src/schema.ts` (`userPreferences`) and
+ * `apps/api/src/modules/preference/{service,model}.ts`.
+ */
+export const UserPreferencesOutputSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  unitSystem: z.string(),
+  temperatureUnit: z.string(),
+  theme: z.string(),
+  locale: z.string(),
+  timezone: z.string(),
+  dateFormat: z.string(),
+  newFollower: z.boolean(),
+  recipeLiked: z.boolean(),
+  recipeCommented: z.boolean(),
+  followedUserPosted: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type UserPreferencesOutput = z.infer<typeof UserPreferencesOutputSchema>;

--- a/packages/shared/src/schemas/responses/recipe.test.ts
+++ b/packages/shared/src/schemas/responses/recipe.test.ts
@@ -1,0 +1,132 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import {
+  FeedRecipeOutputSchema,
+  RecipeRowSchema,
+  RecipeVersionRowSchema,
+  RecipeWithAuthorOutputSchema,
+  RecipeWithVersionsOutputSchema,
+} from './recipe.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+const recipeRow = {
+  id: 'recipe-1',
+  slug: 'my-pour-over',
+  title: 'My Pour Over',
+  authorId: 'user-1',
+  visibility: 'public',
+  currentVersionId: 'rv-1',
+  likeCount: 12,
+  commentCount: 3,
+  forkCount: 1,
+  forkedFromId: null,
+  featured: false,
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+  deletedAt: null,
+};
+
+const versionRow = {
+  id: 'rv-1',
+  recipeId: 'recipe-1',
+  versionNumber: 1,
+  productName: 'Yirgacheffe',
+  coffeeBrand: 'Acme',
+  coffeeProcessing: 'washed',
+  vendorId: null,
+  roastDate: null,
+  packageOpenDate: null,
+  grindDate: null,
+  brewDate: new Date('2024-01-01T08:00:00.000Z'),
+  brewMethod: 'v60',
+  drinkType: 'filter',
+  brewerDetails: 'Hario V60-02',
+  grinder: 'Comandante',
+  grindSize: '24 clicks',
+  groundWeightGrams: 15.5,
+  extractionTimeSeconds: 150,
+  extractionVolumeMl: 250,
+  temperatureCelsius: 93.5,
+  tds: '1.38',
+  brewRatio: 16.6,
+  flowRate: 1.7,
+  preInfusionTimeSeconds: 30,
+  beanId: null,
+  coffeeVarietyId: null,
+  coffeeVarietyName: null,
+  personalNotes: null,
+  preparationNotes: 'Bloom 45s',
+  isFavourite: false,
+  rating: 8,
+  emojiTag: null,
+  createdAt: new Date('2024-01-01T08:05:00.000Z'),
+  versionPhotos: [
+    {
+      id: 'rvp-1',
+      recipeVersionId: 'rv-1',
+      photoId: 'photo-1',
+      sortOrder: 0,
+      photo: {
+        id: 'photo-1',
+        recipeId: 'recipe-1',
+        url: 'https://cdn/p.jpg',
+        thumbnailUrl: null,
+        alt: null,
+        sortOrder: 0,
+        createdAt: new Date('2024-01-01T08:06:00.000Z'),
+        deletedAt: null,
+      },
+    },
+  ],
+};
+
+const miniAuthor = { username: 'barista', displayName: 'Barista', avatarUrl: null };
+
+describe('RecipeRowSchema', () => {
+  it('parses a full recipe row with count fields and round-trips', () => {
+    const result = RecipeRowSchema.safeParse(wire(recipeRow));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(recipeRow));
+  });
+});
+
+describe('RecipeVersionRowSchema', () => {
+  it('parses a version row with versionPhotos[] and round-trips', () => {
+    const result = RecipeVersionRowSchema.safeParse(wire(versionRow));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(versionRow));
+  });
+});
+
+describe('RecipeWithAuthorOutputSchema', () => {
+  it('parses a recipe + mini author (equipment recipes) and round-trips', () => {
+    const payload = { ...recipeRow, author: miniAuthor };
+    const result = RecipeWithAuthorOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+});
+
+describe('RecipeWithVersionsOutputSchema', () => {
+  it('parses a recipe + author + versions[] (coffee-variety recipes) and round-trips', () => {
+    const payload = { ...recipeRow, author: miniAuthor, versions: [versionRow] };
+    const result = RecipeWithVersionsOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+});
+
+describe('FeedRecipeOutputSchema', () => {
+  it('parses a feed recipe with the id/username/displayName author projection', () => {
+    const payload = {
+      ...recipeRow,
+      author: { id: 'user-1', username: 'barista', displayName: null },
+    };
+    const result = FeedRecipeOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+});

--- a/packages/shared/src/schemas/responses/recipe.ts
+++ b/packages/shared/src/schemas/responses/recipe.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+import { PhotoOutputSchema } from './photo.ts';
+import { RecipeAuthorMiniSchema } from './_shared.ts';
+
+/**
+ * Shared recipe Output Schemas returned by equipment, coffee-variety, and feed
+ * routes. Authored from the real `db.query.recipes.findMany(...)` projections in
+ * `recipe/model.ts`, `coffee-variety/model.ts`, and `equipment/model.ts`.
+ *
+ * Verified against `packages/db/src/schema.ts` (`recipes`, `recipeVersions`,
+ * `recipeVersionPhotos`, `photos`).
+ */
+
+/** Full `recipes` row. */
+export const RecipeRowSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  title: z.string(),
+  authorId: z.string(),
+  visibility: z.string(),
+  currentVersionId: z.string().nullable(),
+  likeCount: z.number().int(),
+  commentCount: z.number().int(),
+  forkCount: z.number().int(),
+  forkedFromId: z.string().nullable(),
+  featured: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type RecipeRow = z.infer<typeof RecipeRowSchema>;
+
+/**
+ * Recipe enriched with the mini author projection
+ * (`{ username, displayName, avatarUrl }`), as returned by
+ * `equipment/model.ts getRecipesUsingEquipment`.
+ */
+export const RecipeWithAuthorOutputSchema = RecipeRowSchema.extend({
+  author: RecipeAuthorMiniSchema,
+});
+
+export type RecipeWithAuthorOutput = z.infer<typeof RecipeWithAuthorOutputSchema>;
+
+/** A `recipeVersionPhotos` join row carrying the full joined `photo`. */
+const RecipeVersionPhotoSchema = z.object({
+  id: z.string(),
+  recipeVersionId: z.string(),
+  photoId: z.string(),
+  sortOrder: z.number().int(),
+  photo: PhotoOutputSchema,
+});
+
+/**
+ * Full `recipeVersions` row plus its `versionPhotos[]`. Nullable columns use
+ * `.nullable()`; `tds` is `numeric` → serialized as a string by postgres-js,
+ * while `real`/`integer` columns deserialize to numbers.
+ */
+export const RecipeVersionRowSchema = z.object({
+  id: z.string(),
+  recipeId: z.string(),
+  versionNumber: z.number().int(),
+  productName: z.string().nullable(),
+  coffeeBrand: z.string().nullable(),
+  coffeeProcessing: z.string().nullable(),
+  vendorId: z.string().nullable(),
+  roastDate: z.string().nullable(),
+  packageOpenDate: z.string().nullable(),
+  grindDate: z.string().nullable(),
+  brewDate: z.string(),
+  brewMethod: z.string(),
+  drinkType: z.string(),
+  brewerDetails: z.string().nullable(),
+  grinder: z.string().nullable(),
+  grindSize: z.string().nullable(),
+  groundWeightGrams: z.number().nullable(),
+  extractionTimeSeconds: z.number().int().nullable(),
+  extractionVolumeMl: z.number().nullable(),
+  temperatureCelsius: z.number().nullable(),
+  tds: z.string().nullable(),
+  brewRatio: z.number().nullable(),
+  flowRate: z.number().nullable(),
+  preInfusionTimeSeconds: z.number().int().nullable(),
+  beanId: z.string().nullable(),
+  coffeeVarietyId: z.string().nullable(),
+  coffeeVarietyName: z.string().nullable(),
+  personalNotes: z.string().nullable(),
+  preparationNotes: z.string(),
+  isFavourite: z.boolean(),
+  rating: z.number().int().nullable(),
+  emojiTag: z.string().nullable(),
+  createdAt: z.string(),
+  versionPhotos: z.array(RecipeVersionPhotoSchema),
+});
+
+export type RecipeVersionRow = z.infer<typeof RecipeVersionRowSchema>;
+
+/**
+ * Recipe with author + full `versions[]` (each with `versionPhotos[]`), as
+ * returned by `coffee-variety/model.ts getRecipesUsingVariety`.
+ */
+export const RecipeWithVersionsOutputSchema = RecipeRowSchema.extend({
+  author: RecipeAuthorMiniSchema,
+  versions: z.array(RecipeVersionRowSchema),
+});
+
+export type RecipeWithVersionsOutput = z.infer<typeof RecipeWithVersionsOutputSchema>;
+
+/**
+ * Feed recipe (follow `/feed` → `recipe/model.ts getFeed → findMany`). The feed
+ * author projection is `{ id, username, displayName }` only (no `avatarUrl`),
+ * and no `versions` are loaded.
+ */
+export const FeedRecipeOutputSchema = RecipeRowSchema.extend({
+  author: z.object({
+    id: z.string(),
+    username: z.string(),
+    displayName: z.string().nullable(),
+  }),
+});
+
+export type FeedRecipeOutput = z.infer<typeof FeedRecipeOutputSchema>;

--- a/packages/shared/src/schemas/responses/report.test.ts
+++ b/packages/shared/src/schemas/responses/report.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { ReportOutputSchema } from './report.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+describe('ReportOutputSchema', () => {
+  it('parses a representative report row and round-trips', () => {
+    const payload = {
+      id: 'report-1',
+      reporterId: 'user-1',
+      entityType: 'recipe',
+      entityId: 'recipe-1',
+      reason: 'Spam',
+      status: 'pending',
+      resolvedAt: null,
+      resolvedBy: null,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    };
+    const result = ReportOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+
+  it('parses a resolved report (populated optional fields)', () => {
+    const payload = {
+      id: 'report-2',
+      reporterId: 'user-1',
+      entityType: 'comment',
+      entityId: 'comment-1',
+      reason: 'Abuse',
+      status: 'resolved',
+      resolvedAt: '2024-01-02T00:00:00.000Z',
+      resolvedBy: 'admin-1',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    };
+    expect(ReportOutputSchema.safeParse(payload).success).toBe(true);
+  });
+});

--- a/packages/shared/src/schemas/responses/report.ts
+++ b/packages/shared/src/schemas/responses/report.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+/**
+ * Report Output Schema — mirrors the full `reports` row returned by
+ * `report/service.ts` (`model.create`/`findMany`/`resolve`).
+ *
+ * Verified against `packages/db/src/schema.ts` (`reports`) and
+ * `apps/api/src/modules/report/{service,model}.ts`.
+ */
+export const ReportOutputSchema = z.object({
+  id: z.string(),
+  reporterId: z.string(),
+  entityType: z.string(),
+  entityId: z.string(),
+  reason: z.string(),
+  status: z.string(),
+  resolvedAt: z.string().nullable(),
+  resolvedBy: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type ReportOutput = z.infer<typeof ReportOutputSchema>;

--- a/packages/shared/src/schemas/responses/setup.test.ts
+++ b/packages/shared/src/schemas/responses/setup.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { SetupOutputSchema } from './setup.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+describe('SetupOutputSchema', () => {
+  it('parses a representative setup row and round-trips', () => {
+    const payload = {
+      id: 'setup-1',
+      name: 'Espresso bench',
+      userId: 'user-1',
+      brewerDetails: 'Lever machine',
+      grinder: 'EK43',
+      portafilterId: 'eq-1',
+      basketId: null,
+      puckScreenId: null,
+      paperFilterId: null,
+      tamperId: null,
+      isDefault: true,
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deletedAt: null,
+    };
+    const result = SetupOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+});

--- a/packages/shared/src/schemas/responses/setup.ts
+++ b/packages/shared/src/schemas/responses/setup.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+/**
+ * Setup Output Schema — mirrors the full `setups` row returned by
+ * `setup/service.ts` (`model.findById`/`create`/`update`/`setDefault`).
+ *
+ * Verified against `packages/db/src/schema.ts` (`setups`) and
+ * `apps/api/src/modules/setup/{service,model}.ts`.
+ */
+export const SetupOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  userId: z.string(),
+  brewerDetails: z.string().nullable(),
+  grinder: z.string().nullable(),
+  portafilterId: z.string().nullable(),
+  basketId: z.string().nullable(),
+  puckScreenId: z.string().nullable(),
+  paperFilterId: z.string().nullable(),
+  tamperId: z.string().nullable(),
+  isDefault: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type SetupOutput = z.infer<typeof SetupOutputSchema>;

--- a/packages/shared/src/schemas/responses/taste.test.ts
+++ b/packages/shared/src/schemas/responses/taste.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { TasteNoteNodeOutputSchema, TasteNoteOutputSchema } from './taste.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+const flatNote = {
+  id: 'tn-1',
+  name: 'Fruity',
+  parentId: null,
+  color: '#ff0000',
+  definition: 'Fruit-forward notes',
+  depth: 0,
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  deletedAt: null,
+};
+
+describe('TasteNoteOutputSchema', () => {
+  it('parses a flat taste-note row and round-trips', () => {
+    const result = TasteNoteOutputSchema.safeParse(wire(flatNote));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(flatNote));
+  });
+});
+
+describe('TasteNoteNodeOutputSchema (recursive hierarchy)', () => {
+  it('parses a nested hierarchy node with children[] and round-trips', () => {
+    const node = {
+      ...flatNote,
+      children: [
+        {
+          id: 'tn-2',
+          name: 'Berry',
+          parentId: 'tn-1',
+          color: null,
+          definition: null,
+          depth: 1,
+          createdAt: new Date('2024-01-01T00:00:00.000Z'),
+          deletedAt: null,
+          children: [
+            {
+              id: 'tn-3',
+              name: 'Blueberry',
+              parentId: 'tn-2',
+              color: null,
+              definition: null,
+              depth: 2,
+              createdAt: new Date('2024-01-01T00:00:00.000Z'),
+              deletedAt: null,
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+    const result = TasteNoteNodeOutputSchema.safeParse(wire(node));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(node));
+  });
+
+  it('rejects a node missing the children array', () => {
+    expect(TasteNoteNodeOutputSchema.safeParse(wire(flatNote)).success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/responses/taste.ts
+++ b/packages/shared/src/schemas/responses/taste.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+/**
+ * Taste note Output Schemas.
+ *
+ * `TasteNoteOutputSchema` is the flat `tasteNotes` row returned by `/flat` and
+ * `/search` (`model.findAll`/`searchByName`). `TasteNoteNodeOutputSchema` is the
+ * recursive hierarchy node returned by `/hierarchy` (`model.getHierarchy`),
+ * where each node carries a `children[]` array of the same shape — modeled with
+ * `z.lazy` for the self-reference.
+ *
+ * Verified against `packages/db/src/schema.ts` (`tasteNotes`) and
+ * `apps/api/src/modules/taste/{service,model}.ts`.
+ */
+export const TasteNoteOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  parentId: z.string().nullable(),
+  color: z.string().nullable(),
+  definition: z.string().nullable(),
+  depth: z.number().int(),
+  createdAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type TasteNoteOutput = z.infer<typeof TasteNoteOutputSchema>;
+
+/** Recursive hierarchy node: a flat taste note plus its `children[]`. */
+export type TasteNoteNodeOutput = TasteNoteOutput & {
+  children: TasteNoteNodeOutput[];
+};
+
+export const TasteNoteNodeOutputSchema: z.ZodType<TasteNoteNodeOutput> = TasteNoteOutputSchema
+  .extend({
+    children: z.lazy(() => z.array(TasteNoteNodeOutputSchema)),
+  });

--- a/packages/shared/src/schemas/responses/user.test.ts
+++ b/packages/shared/src/schemas/responses/user.test.ts
@@ -1,10 +1,6 @@
 import { describe, it } from 'jsr:@std/testing/bdd';
 import { expect } from 'jsr:@std/expect';
-import {
-  PublicUserOutputSchema,
-  SelfUserOutputSchema,
-  UserRowOutputSchema,
-} from './user.ts';
+import { PublicUserOutputSchema, SelfUserOutputSchema, UserRowOutputSchema } from './user.ts';
 
 function wire<T>(payload: T): unknown {
   return JSON.parse(JSON.stringify(payload));

--- a/packages/shared/src/schemas/responses/user.test.ts
+++ b/packages/shared/src/schemas/responses/user.test.ts
@@ -1,0 +1,129 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import {
+  PublicUserOutputSchema,
+  SelfUserOutputSchema,
+  UserRowOutputSchema,
+} from './user.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+const baseUser = {
+  id: 'user-1',
+  email: 'alice@example.com',
+  emailVerifiedAt: null,
+  username: 'alice',
+  displayName: 'Alice',
+  avatarUrl: null,
+  bio: 'Coffee lover',
+  onboardingCompleted: true,
+  isAdmin: false,
+  isBanned: false,
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+  deletedAt: null,
+};
+
+describe('UserRowOutputSchema (PATCH /me)', () => {
+  it('parses the bare row (no preferences/stats) and round-trips', () => {
+    const result = UserRowOutputSchema.safeParse(wire(baseUser));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(baseUser));
+  });
+});
+
+describe('SelfUserOutputSchema (GET /me)', () => {
+  it('parses row + nested preferences + stats and round-trips', () => {
+    const payload = {
+      ...baseUser,
+      preferences: {
+        unitSystem: 'metric',
+        temperatureUnit: 'celsius',
+        theme: 'light',
+        locale: 'en',
+        timezone: 'UTC',
+        dateFormat: 'YYYY_MM_DD',
+        emailNotifications: {
+          newFollower: true,
+          recipeLiked: true,
+          recipeCommented: false,
+          followedUserPosted: true,
+        },
+      },
+      recipeCount: 5,
+      followerCount: 10,
+      followingCount: 3,
+    };
+    const result = SelfUserOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+
+  it('accepts null preferences (no preferences row)', () => {
+    const payload = {
+      ...baseUser,
+      preferences: null,
+      recipeCount: 0,
+      followerCount: 0,
+      followingCount: 0,
+    };
+    expect(SelfUserOutputSchema.safeParse(wire(payload)).success).toBe(true);
+  });
+});
+
+describe('PublicUserOutputSchema (GET /:username)', () => {
+  it('parses row minus email + stats + recipes[] + badges + isFollowing', () => {
+    const { email: _email, ...publicBase } = baseUser;
+    const payload = {
+      ...publicBase,
+      recipeCount: 2,
+      followerCount: 1,
+      followingCount: 0,
+      recipes: [
+        {
+          id: 'recipe-1',
+          slug: 'my-pour-over',
+          title: 'My Pour Over',
+          likeCount: 4,
+          commentCount: 1,
+          createdAt: new Date('2024-01-01T00:00:00.000Z'),
+          currentVersion: { brewMethod: 'v60', drinkType: 'filter' },
+        },
+        {
+          id: 'recipe-2',
+          slug: 'no-version',
+          title: 'Draft',
+          likeCount: 0,
+          commentCount: 0,
+          createdAt: new Date('2024-01-02T00:00:00.000Z'),
+          currentVersion: null,
+        },
+      ],
+      badges: [],
+      isFollowing: true,
+    };
+    const result = PublicUserOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+
+  it('does not include email in the public profile output (email omitted)', () => {
+    const { email: _email, ...publicBase } = baseUser;
+    const payload = {
+      ...publicBase,
+      recipeCount: 0,
+      followerCount: 0,
+      followingCount: 0,
+      recipes: [],
+      badges: [],
+      isFollowing: false,
+    };
+    const result = PublicUserOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).email).toBeUndefined();
+    }
+  });
+});

--- a/packages/shared/src/schemas/responses/user.ts
+++ b/packages/shared/src/schemas/responses/user.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod';
+
+/**
+ * User Output Schemas — three distinct returned shapes.
+ *
+ *  - `SelfUserOutputSchema` (`GET /me`, `getProfile`): the `users` row minus
+ *    `passwordHash`, plus the nested `preferences` object (nullable, from the
+ *    `user_preferences` leftJoin in `model.findById`) and the `recipeCount` /
+ *    `followerCount` / `followingCount` stats.
+ *  - `UserRowOutputSchema` (`PATCH /me`, `updateProfile`): the bare `users` row
+ *    minus `passwordHash` (no preferences, no stats).
+ *  - `PublicUserOutputSchema` (`GET /:username`, `getPublicProfile`): the row
+ *    minus `passwordHash` and `email`, plus stats, `recipes[]`, `badges` (always
+ *    `[]`), and `isFollowing`.
+ *
+ * Verified against `packages/db/src/schema.ts` (`users`, `userPreferences`) and
+ * `apps/api/src/modules/user/{service,model}.ts`.
+ */
+
+/** Base `users` row with `passwordHash` stripped. */
+const UserBaseSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  emailVerifiedAt: z.string().nullable(),
+  username: z.string(),
+  displayName: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+  bio: z.string().nullable(),
+  onboardingCompleted: z.boolean(),
+  isAdmin: z.boolean(),
+  isBanned: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+/** Aggregated profile stats. */
+const UserStatsSchema = {
+  recipeCount: z.number().int(),
+  followerCount: z.number().int(),
+  followingCount: z.number().int(),
+};
+
+/** Nested preferences projection on the self profile (nullable when absent). */
+const SelfPreferencesSchema = z
+  .object({
+    unitSystem: z.string(),
+    temperatureUnit: z.string(),
+    theme: z.string(),
+    locale: z.string(),
+    timezone: z.string(),
+    dateFormat: z.string(),
+    emailNotifications: z.object({
+      newFollower: z.boolean(),
+      recipeLiked: z.boolean(),
+      recipeCommented: z.boolean(),
+      followedUserPosted: z.boolean(),
+    }),
+  })
+  .nullable();
+
+export const UserRowOutputSchema = UserBaseSchema;
+
+export type UserRowOutput = z.infer<typeof UserRowOutputSchema>;
+
+export const SelfUserOutputSchema = UserBaseSchema.extend({
+  preferences: SelfPreferencesSchema,
+  ...UserStatsSchema,
+});
+
+export type SelfUserOutput = z.infer<typeof SelfUserOutputSchema>;
+
+/** Public-profile recipe summary item with the latest version's brew metadata. */
+const PublicUserRecipeSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  title: z.string(),
+  likeCount: z.number().int(),
+  commentCount: z.number().int(),
+  createdAt: z.string(),
+  currentVersion: z
+    .object({
+      brewMethod: z.string(),
+      drinkType: z.string(),
+    })
+    .nullable(),
+});
+
+export const PublicUserOutputSchema = UserBaseSchema.omit({ email: true }).extend({
+  ...UserStatsSchema,
+  recipes: z.array(PublicUserRecipeSchema),
+  badges: z.array(z.unknown()),
+  isFollowing: z.boolean(),
+});
+
+export type PublicUserOutput = z.infer<typeof PublicUserOutputSchema>;

--- a/packages/shared/src/schemas/responses/vendor.test.ts
+++ b/packages/shared/src/schemas/responses/vendor.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { VendorOutputSchema } from './vendor.ts';
+
+function wire<T>(payload: T): unknown {
+  return JSON.parse(JSON.stringify(payload));
+}
+
+describe('VendorOutputSchema', () => {
+  it('parses a representative vendor row and round-trips', () => {
+    const payload = {
+      id: 'vendor-1',
+      name: 'Acme Roasters',
+      website: 'https://acme.example',
+      description: null,
+      createdBy: 'user-1',
+      createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      deletedAt: null,
+    };
+    const result = VendorOutputSchema.safeParse(wire(payload));
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(wire(payload));
+  });
+});

--- a/packages/shared/src/schemas/responses/vendor.ts
+++ b/packages/shared/src/schemas/responses/vendor.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+/**
+ * Vendor Output Schema — mirrors the full `vendors` row returned by
+ * `vendor/service.ts` (`model.findById`/`create`/`update`/`search`).
+ *
+ * Verified against `packages/db/src/schema.ts` (`vendors`) and
+ * `apps/api/src/modules/vendor/{service,model}.ts`.
+ */
+export const VendorOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  website: z.string().nullable(),
+  description: z.string().nullable(),
+  createdBy: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  deletedAt: z.string().nullable(),
+});
+
+export type VendorOutput = z.infer<typeof VendorOutputSchema>;

--- a/plans/D25-complete-openapi-docs.md
+++ b/plans/D25-complete-openapi-docs.md
@@ -1,163 +1,268 @@
 # D25 — Complete OpenAPI Documentation for All Route Modules
 
-**Severity:** Low  
-**Status:** Open  
-**Files:** `apps/api/src/modules/*/index.ts` (15 modules)
+**Severity:** Low
+**Status:** Open (validated & expanded 2026-06-13)
+**Files:** `apps/api/src/modules/*/index.ts` (15 undocumented modules), `apps/api/src/routes/{share,sitemap,openapi}.ts`, `packages/shared/src/schemas/*` (new output schemas), docs.
 
 ---
 
 ## Issue Description
 
-Only 3 of 18 route modules have `describeRoute()` decorators from `hono-openapi`:
+Only 4 of 20 mounted route groups carry `describeRoute()` metadata from `hono-openapi`.
+Verified against the codebase on 2026-06-13.
 
-| Module | Has `describeRoute` | Routes |
-|--------|---------------------|--------|
-| recipe | Yes | 14 routes |
-| admin | Yes | 5 routes |
-| auth | Yes | 9 routes |
-| bean | No | — |
-| badge | No | — |
-| coffee-variety | No | — |
-| comment | No | — |
-| contact | No | — |
-| equipment | No | — |
-| follow | No | — |
-| photo | No | — |
-| preference | No | — |
-| qrcode | No | — |
-| report | No | — |
-| setup | No | — |
-| taste | No | — |
-| user | No | — |
-| vendor | No | — |
+### Documented today
 
-This means 15 modules are missing from the OpenAPI spec at `/api/v1/openapi.json`.
+| Route group | File | `describeRoute` | Notes |
+|-------------|------|-----------------|-------|
+| auth | `modules/auth/index.ts` | Yes | 9 routes |
+| recipe | `modules/recipe/index.ts` | Yes | 14 routes |
+| admin | `modules/admin/index.ts` | Yes | ~50 routes |
+| health | `routes/health.ts` | Yes | liveness/readiness |
+
+### Undocumented (this work)
+
+| Module | File | Base path | Actual route count |
+|--------|------|-----------|--------------------|
+| bean | `modules/bean/index.ts` | `/api/v1/beans` | 5 |
+| badge | `modules/badge/index.ts` | `/api/v1/badges` | 3 |
+| coffee-variety | `modules/coffee-variety/index.ts` | `/api/v1/coffee-varieties` | 7 |
+| comment | `modules/comment/index.ts` | `/api/v1/comments` | 3 |
+| contact | `modules/contact/index.ts` | `/api/v1/contact` | 1 |
+| equipment | `modules/equipment/index.ts` | `/api/v1/equipment` | 8 |
+| follow | `modules/follow/index.ts` | `/api/v1/follow` | 5 |
+| photo | `modules/photo/index.ts` | `/api/v1/photos` | 3 |
+| preference | `modules/preference/index.ts` | `/api/v1/preferences` | 2 |
+| qrcode | `modules/qrcode/index.ts` | `/api/v1/qrcode` | 1 |
+| report | `modules/report/index.ts` | `/api/v1/reports` | 3 |
+| setup | `modules/setup/index.ts` | `/api/v1/setups` | 6 |
+| taste | `modules/taste/index.ts` | `/api/v1/taste-notes` | 6 |
+| user | `modules/user/index.ts` | `/api/v1/users` | 4 |
+| vendor | `modules/vendor/index.ts` | `/api/v1/vendors` | 6 |
+| share | `routes/share.ts` | `/share` | 1 (HTML) |
+| sitemap | `routes/sitemap.ts` | `/api/v1/sitemap.xml` | 1 (XML) |
+
+**~63 JSON routes across the 15 modules + 2 non-JSON routes (share, sitemap).**
+
+> The original plan listed approximate counts that did not match the code
+> (e.g. taste 3→6, vendor 4→6, setup 5→6, coffee-variety 6→7, comment 5→3,
+> contact 2→1, qrcode 2→1, follow 4→5, user 5→4) and omitted `share`/`sitemap`.
 
 ---
 
 ## Impact
 
-- **Incomplete API docs:** 83% of endpoints are undocumented in the OpenAPI spec.
-- **Developer experience:** Consumers cannot discover or test these endpoints via the Scalar UI.
-- **Client generation:** Auto-generated API clients miss most endpoints.
+- **Incomplete API docs:** the majority of endpoints are missing from `/api/v1/openapi.json`.
+- **Developer experience:** consumers cannot discover or test these endpoints in the Scalar UI at `/api/v1/docs`.
+- **Client generation:** auto-generated clients miss most endpoints and have no typed request/response bodies.
+- **Stale documentation:** `docs/requirements-audit-report.md` §6.9 incorrectly claims `describeRoute` is on "all endpoints"; `docs/decisions.md` ADR-012 and `docs/architecture.md` reference only auth/recipe/admin/health.
 
 ---
 
 ## Root Cause
 
-OpenAPI annotations were added to recipe, admin, and auth modules during initial development. The remaining modules were added without `describeRoute()` decorators.
+OpenAPI annotations were added to auth, recipe, admin, and health during initial
+development (ADR-012). Remaining modules were added later without `describeRoute()`.
 
 ---
 
-## Affected Files
+## Architectural Constraints (must hold)
 
-| Module | File | Route Count (approx) |
-|--------|------|---------------------|
-| bean | `apps/api/src/modules/bean/index.ts` | ~5 |
-| badge | `apps/api/src/modules/badge/index.ts` | ~3 |
-| coffee-variety | `apps/api/src/modules/coffee-variety/index.ts` | ~6 |
-| comment | `apps/api/src/modules/comment/index.ts` | ~5 |
-| contact | `apps/api/src/modules/contact/index.ts` | ~2 |
-| equipment | `apps/api/src/modules/equipment/index.ts` | ~8 |
-| follow | `apps/api/src/modules/follow/index.ts` | ~4 |
-| photo | `apps/api/src/modules/photo/index.ts` | ~3 |
-| preference | `apps/api/src/modules/preference/index.ts` | ~3 |
-| qrcode | `apps/api/src/modules/qrcode/index.ts` | ~2 |
-| report | `apps/api/src/modules/report/index.ts` | ~4 |
-| setup | `apps/api/src/modules/setup/index.ts` | ~5 |
-| taste | `apps/api/src/modules/taste/index.ts` | ~3 |
-| user | `apps/api/src/modules/user/index.ts` | ~5 |
-| vendor | `apps/api/src/modules/vendor/index.ts` | ~4 |
+1. **ADR-012 — keep `@hono/zod-validator`.** Do **not** replace `zValidator(...)`
+   with `hono-openapi`'s `validator`. Request validation stays exactly as-is;
+   OpenAPI metadata is added purely through `describeRoute()` + `resolver()`.
+   This preserves the shape of `c.req.valid(...)` and the lint footprint.
+2. **`hono-openapi` v1.3.0, Zod v4.** `resolver(zodSchema)` converts a Zod schema
+   to an OpenAPI schema object. Confirmed API (Context7 `/rhinobase/hono-openapi`):
+   ```ts
+   import { describeRoute, resolver } from 'hono-openapi';
+   route.post(
+     '/',
+     describeRoute({
+       tags: ['Beans'],
+       summary: '...',
+       security: [{ bearerAuth: [] }],
+       requestBody: {
+         content: { 'application/json': { schema: resolver(BeanCreateSchema) } },
+       },
+       responses: {
+         201: {
+           description: 'Bean created',
+           content: { 'application/json': { schema: resolver(BeanResponseSchema) } },
+         },
+         401: { description: 'Unauthorized',
+           content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } } },
+       },
+     }),
+     authMiddleware,
+     zValidator('json', BeanCreateSchema), // unchanged
+     handler,
+   );
+   ```
+3. **Tags must be registered.** `routes/openapi.ts` declares only 5 tags today
+   (Auth, Recipes, Users, Admin, Health). Every new tag must be added to that
+   `tags` array with a description, or modules render ungrouped/undescribed.
+4. **Schema-from-request is preferred over duplication.** Reuse the existing
+   shared input schemas (`*CreateSchema`, `*UpdateSchema`, `*FilterSchema`,
+   `PaginationSchema`) for request bodies / query params via `resolver()`.
 
 ---
 
-## Existing Pattern (Reference)
+## Scope (confirmed with stakeholder)
 
-From `apps/api/src/modules/recipe/index.ts`:
+- **A) Coverage:** ALL mounted routes — the 15 modules **plus** `share` and
+  `sitemap`. Re-verify the mounted list in `routes/index.ts` so nothing new is
+  missed.
+- **B) Depth: full ("go deeper").** Document request bodies, query params, path
+  params, **and** response bodies with concrete schemas via `resolver()`.
+- **C) Response payloads: full entity output schemas (Option 2).** Author output
+  schemas for every entity returned by the API and embed them in typed response
+  envelopes. No generic `data` placeholders.
+- **D) Testing:** add an automated spec-coverage test that introspects the real
+  app (no manual `curl`).
 
-```typescript
-import { describeRoute } from 'hono-openapi';
+---
 
-recipe.get(
-  '/',
-  describeRoute({
-    tags: ['Recipes'],
-    summary: 'List recipes',
-    description: 'Paginated, filterable list of recipes.',
-    responses: { 200: { description: 'Paginated list of recipes' } },
-  }),
-  optionalAuthMiddleware,
-  zValidator('query', RecipeFilterSchema),
-  async (c) => { ... },
-);
+## Response Envelope Schemas (new, shared)
+
+The API uses two envelopes (`apps/api/src/utils/response/index.ts`):
+
+```jsonc
+// success
+{ "success": true, "data": <T | T[]>, "meta": { "requestId": "..", "pagination?": {..} } }
+// error
+{ "success": false, "error": { "code": "..", "message": "..", "details?": [..], "requestId": ".." } }
 ```
 
+Create reusable Zod schemas (location: `packages/shared/src/schemas/response.ts`)
+that mirror these exactly:
+
+- `ErrorEnvelopeSchema` — `{ success: false, error: { code, message, details?, requestId } }`
+- `PaginationMetaSchema` — `{ page, perPage, total, totalPages }` (match `@brewform/shared/types`).
+- `successEnvelope(dataSchema)` — helper returning `{ success: true, data: dataSchema, meta: { requestId } }`.
+- `paginatedEnvelope(itemSchema)` — `{ success: true, data: itemSchema[], meta: { requestId, pagination } }`.
+
+These must stay consistent with the runtime `success`/`paginated`/`error` helpers;
+add a unit test that asserts a sample runtime response validates against the schema.
+
 ---
 
-## Fix Approach
+## Entity Output Schemas (new, shared)
 
-Add `describeRoute()` to every route in every module, following the existing pattern. Group by module tags:
+> **Critical:** API responses are **not** raw Drizzle rows. Services return joined
+> and computed fields (author objects, equipment lists, taste notes, like/favourite
+> counts, `isLiked`/`isFavourited` flags, version data, etc.). Output schemas MUST
+> match the **actual service return shape**, derived by reading each `service.ts`
+> return type — not by copying table columns.
 
-| Module | Tag |
-|--------|-----|
-| bean | `Beans` |
-| badge | `Badges` |
-| coffee-variety | `Coffee Varieties` |
-| comment | `Comments` |
-| contact | `Contact` |
-| equipment | `Equipment` |
-| follow | `Follow` |
-| photo | `Photos` |
-| preference | `Preferences` |
-| qrcode | `QR Codes` |
-| report | `Reports` |
-| setup | `Setups` |
-| taste | `Taste Notes` |
-| user | `Users` |
-| vendor | `Vendors` |
+`drizzle-zod` is **not** currently a dependency. Two acceptable approaches
+(implementer to pick, document choice in the spec/ADR):
+- Hand-author output schemas in `packages/shared/src/schemas/responses/` (no new dep), OR
+- Add `drizzle-zod` to derive base select schemas, then `.extend()` with computed
+  fields (reduces drift, adds a dependency — requires sign-off).
+
+Entities needing output schemas (from `packages/db/src/schema.ts`, main entities):
+`user` (public + self variants), `recipe` (+ list/detail/meta/version variants),
+`bean`, `equipment`, `vendor`, `coffeeVariety`, `tasteNote` (+ hierarchy node),
+`comment`, `photo`, `setup`, `badge` (+ userBadge), `report`, `userPreferences`,
+`follow` (follower/following list item), `equipmentDeleteRequest`, admin
+aggregate/leaderboard/time-series payloads (reuse where recipe/admin already
+return shapes), `qrcode` (binary/data-URL response).
+
+Every output schema gets a co-located unit test asserting a representative
+service payload parses successfully.
+
+---
+
+## Non-JSON Routes
+
+- **`share` (`GET /share/:slug`)** returns `text/html` (OG redirect page) or a 404
+  HTML page. Document with `responses: { 200: { content: { 'text/html': {} } }, 404: { content: { 'text/html': {} } } }` and a `slug` path param. Tag: `Share`.
+- **`sitemap` (`GET /api/v1/sitemap.xml`)** returns `application/xml`. Document with
+  `responses: { 200: { content: { 'application/xml': {} } } }`. Tag: `Sitemap`.
+- `qrcode` returns an image/data-URL — document its actual content type, not a JSON envelope.
+
+---
+
+## Tag Registry (to add in `routes/openapi.ts`)
+
+Existing: Auth, Recipes, Users, Admin, Health.
+Add: Beans, Badges, Coffee Varieties, Comments, Contact, Equipment, Follow,
+Photos, Preferences, QR Codes, Reports, Setups, Taste Notes, Vendors, Share, Sitemap.
+(`Users` already exists — reuse it for the `user` module.)
 
 ---
 
 ## Implementation Steps
 
-1. **List** all route files missing `describeRoute()` — confirm the 15 modules above.
-2. **For each module:**
-   a. Read the `index.ts` file.
-   b. Import `describeRoute` from `'hono-openapi'`.
-   c. Add `describeRoute({ tags: [...], summary: '...', description: '...', responses: { ... } })` to each route.
-   d. Use consistent tag naming per module.
-3. **Verify** OpenAPI spec:
-   ```bash
-   curl http://localhost:8000/api/v1/openapi.json | jq '.paths | keys | length'
-   ```
-   Should return the total number of endpoints (~70+).
-4. **Run** `make check-api` — type-check passes.
-5. **Run** `make test` — all tests pass.
+1. **Re-verify inventory** from `routes/index.ts`; confirm no module is missed.
+2. **Add response envelope + entity output schemas** in `@brewform/shared/schemas`,
+   each derived from the real service return shape, each with a unit test.
+3. **Register new tags** in `routes/openapi.ts`.
+4. **Per module:** import `describeRoute`/`resolver`, add metadata to every route —
+   `tags`, `summary`, `description`, `security` (where auth-guarded), `requestBody`
+   (reuse input schema), parameters (path/query), and typed `responses` (success +
+   error envelopes). Leave all `zValidator(...)` calls untouched.
+5. **Annotate `share` and `sitemap`** with correct non-JSON content types.
+6. **Update stale docs:** `docs/requirements-audit-report.md` §6.9,
+   `docs/decisions.md` ADR-012, `docs/architecture.md`.
+7. **Add automated coverage test** (see below).
+8. `make check-api` (type-check), `make lint`, `make test` — all pass.
 
 ---
 
 ## Testing Strategy
 
+### Automated spec-coverage test (new) — replaces manual `curl`
+
+Build the **real** router and introspect the generated spec. Feasibility verified:
+`postgres-js` connects lazily and the cache singleton defaults to in-memory, so
+importing `routes/index.ts` does not require a live DB/KV (tests already set
+`DATABASE_URL`, `JWT_SECRET`, `CACHE_DRIVER=memory`, `APP_ENV=test`).
+
+File: `apps/api/src/routes/openapi.coverage.test.ts` (extends existing
+`openapi.test.ts` smoke test, which stays as-is).
+
+Assertions:
+| Check | Expected |
+|-------|----------|
+| Spec `paths` includes every base path | all 17 new groups present |
+| Each documented operation has ≥1 `tags` entry | no untagged operations |
+| Every tag used by an operation is declared in the top-level `tags` array | no orphan tags |
+| Representative routes expose `requestBody`/`responses` content schemas | `resolver` output present |
+| Existing auth/recipe/admin/health operations | unchanged |
+
+### Schema unit tests (new)
+
 | Test | Expected |
 |------|----------|
-| `GET /api/v1/openapi.json` | Contains all 18 module tags |
-| `GET /api/v1/docs` (Scalar UI) | Shows all endpoints grouped by tag |
-| Endpoint count in spec | Matches actual route count |
-| Existing annotated routes | Unchanged |
+| Each entity output schema parses a representative service payload | passes |
+| `ErrorEnvelopeSchema` parses a real `error()` response | passes |
+| `paginatedEnvelope(...)` parses a real `paginated()` response | passes |
+
+### Manual smoke (optional, dev only)
+
+`curl http://localhost:8000/api/v1/openapi.json | jq '.paths | keys | length'`
+should reflect the full endpoint count; `/api/v1/docs` shows all tags.
 
 ---
 
 ## Risk Assessment
 
-**Risk: Low**
+**Risk: Low–Medium** (raised from original "Low" due to Option 2 scope).
 
-- Documentation-only change.
-- `describeRoute` is a decorator that adds metadata — no runtime behavior change.
-- Can be done incrementally per module.
-- Hono-OpenAPI is already a dependency.
+- `describeRoute`/`resolver` add metadata only — no runtime behaviour change to handlers.
+- `zValidator` is untouched, so request validation behaviour is unchanged (ADR-012 preserved).
+- **Main risk: output-schema drift.** Output schemas are hand-derived from service
+  return shapes and can diverge from reality. Mitigated by per-schema unit tests
+  against representative payloads and the coverage test.
+- New shared schemas are additive; no existing schema is modified.
+- Can be delivered incrementally per module after the shared schemas land.
 
 ---
 
 ## Dependencies
 
-- None. Can be parallelized across modules.
+- Shared output/envelope schemas must land **before** module annotation (step 2 → step 4).
+- Tag registration (step 3) is independent.
+- Optional: `drizzle-zod` (only if the derive-from-table approach is chosen — needs sign-off).

--- a/plans/D25-complete-openapi-docs.md
+++ b/plans/D25-complete-openapi-docs.md
@@ -73,25 +73,29 @@ development (ADR-012). Remaining modules were added later without `describeRoute
    OpenAPI metadata is added purely through `describeRoute()` + `resolver()`.
    This preserves the shape of `c.req.valid(...)` and the lint footprint.
 2. **`hono-openapi` v1.3.0, Zod v4.** `resolver(zodSchema)` converts a Zod schema
-   to an OpenAPI schema object. Confirmed API (Context7 `/rhinobase/hono-openapi`):
+   to an OpenAPI schema object for **responses**. `jsonRequestBody(zodSchema)` (from
+   `apps/api/src/utils/openapi/index.ts`) converts a Zod schema to a JSON Schema object
+   for **request bodies** via `z.toJSONSchema` — because `hono-openapi` v1.3.0's `resolver()`
+   only processes response schemas. Confirmed pattern:
    ```ts
    import { describeRoute, resolver } from 'hono-openapi';
+   import { jsonRequestBody } from '../../utils/openapi/index.ts';
    route.post(
      '/',
      describeRoute({
        tags: ['Beans'],
        summary: '...',
        security: [{ bearerAuth: [] }],
-       requestBody: {
-         content: { 'application/json': { schema: resolver(BeanCreateSchema) } },
-       },
+       requestBody: jsonRequestBody(BeanCreateSchema),
        responses: {
          201: {
            description: 'Bean created',
-           content: { 'application/json': { schema: resolver(BeanResponseSchema) } },
+           content: { 'application/json': { schema: resolver(successEnvelope(BeanOutputSchema)) } },
          },
-         401: { description: 'Unauthorized',
-           content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } } },
+         401: {
+           description: 'Unauthorized',
+           content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+         },
        },
      }),
      authMiddleware,
@@ -180,7 +184,8 @@ service payload parses successfully.
   HTML page. Document with `responses: { 200: { content: { 'text/html': {} } }, 404: { content: { 'text/html': {} } } }` and a `slug` path param. Tag: `Share`.
 - **`sitemap` (`GET /api/v1/sitemap.xml`)** returns `application/xml`. Document with
   `responses: { 200: { content: { 'application/xml': {} } } }`. Tag: `Sitemap`.
-- `qrcode` returns an image/data-URL — document its actual content type, not a JSON envelope.
+- **`qrcode` (`GET /api/v1/qrcode/recipe/:filename`)** returns a binary image. Document with
+  `responses: { 200: { content: { 'image/png': { schema: { type: 'string', format: 'binary' } }, 'image/svg+xml': { schema: { type: 'string', format: 'binary' } } } } }` and a `filename` path param. The 403/404 error responses remain JSON envelopes (returned by the `error()` helper). Do not wrap the 200 success response in a JSON envelope. Tag: `QR Codes`.
 
 ---
 


### PR DESCRIPTION
# D25 — Complete OpenAPI Documentation for All Route Modules

## Summary

Completes OpenAPI coverage for the API. Previously only 4 of 21 mounted route groups
(`auth`, `recipe`, `admin`, `health`) carried `describeRoute()` metadata, so the spec at
`/api/v1/openapi.json` and the Scalar UI at `/api/v1/docs` were missing the majority of
endpoints and had no typed request/response bodies.

This PR adds `describeRoute()` metadata to **every** remaining in-scope route (15 domain
modules + `share` + `sitemap`), authors reusable response-envelope schemas and full entity
**output schemas** in `@brewform/shared`, registers the missing OpenAPI tags, adds an
introspection-based coverage test plus property-based tests, and corrects stale docs.

It is a **documentation-only** change: no handler, status code, or response body changes.

## Why

- 83% of endpoints were undocumented — consumers couldn't discover or test them, and
  generated clients missed most of the API.
- Docs (`requirements-audit-report.md` §6.9, ADR-012, `architecture.md`) incorrectly
  described coverage.

## What Changed

### Shared schemas (`packages/shared`) — additive only
- **`schemas/response.ts`** — `ErrorEnvelopeSchema`, `PaginationMetaSchema`, and the generic
  `successEnvelope(dataSchema)` / `paginatedEnvelope(itemSchema)` helpers mirroring the runtime
  `success`/`paginated`/`error` helpers.
- **`schemas/responses/*.ts`** — entity output schemas for every in-scope entity
  (bean, badge, vendor, photo, report, setup, preference, follow, coffee-variety, equipment,
  recipe, comment, taste, user), including distinct variants (e.g. user self/row/public; taste
  hierarchy node vs flat; comment raw/with-author/with-replies; recipe with-author/with-versions/feed)
  and the two bespoke equipment envelopes. Each is derived from the **actual `service.ts` return
  shape** (joined objects, computed/count fields, flags) — not raw table columns — and has a
  co-located unit test.
- Wired additively through `schemas/responses/index.ts` and the top-level `schemas/index.ts`;
  no existing schema modified. `zod-openapi@^5` added to `packages/shared/package.json`.

### API annotations (`apps/api`)
- Annotated all 17 in-scope route groups with `describeRoute()` + typed responses. Added the
  16 new tags to the `tags` registry in `routes/openapi.ts`.
- **`utils/openapi/index.ts`** — new `jsonRequestBody(schema)` helper that documents request
  bodies via Zod v4 `z.toJSONSchema` (see Notes).
- Non-JSON routes documented with their true content type: `share` → `text/html`,
  `sitemap` → `application/xml`, `qrcode` → `image/png` / `image/svg+xml` (with JSON error envelopes).
- Fixed `excludeStaticFile: true` → `false` in `routes/openapi.ts` so `/api/v1/sitemap.xml`
  (a file-extension path) appears in the spec.

### Tests
- **`routes/openapi.coverage.test.ts`** — builds the real router, fetches the generated spec, and
  exhaustively asserts coverage of all 17 base paths, every operation tagged, zero orphan tags,
  resolved request/response schemas, `401` on auth-guarded routes, preserved auth/recipe/admin/health,
  and correct non-JSON content types. No DB/KV connection required.
- **Property-based tests (`fast-check`, ≥100 runs each):** envelope acceptance (P8), output-schema
  acceptance/round-trip (P9), malformed-payload rejection (P10).
- Existing `routes/openapi.test.ts` smoke test left unchanged.

### Docs & conventions
- Corrected `docs/requirements-audit-report.md` §6.9, `docs/decisions.md` ADR-012, and
  `docs/architecture.md` to reflect coverage across all mounted route groups.
- Added a mandatory "every new route must include OpenAPI metadata" convention to `AGENTS.md`,
  `.serena/memories/conventions.md`, and the `architecture.md` OpenAPI section.
- Added `.vscode/settings.json` + `.vscode/extensions.json` to enable the Deno language server
  (fixes false "cannot find module / .ts extension" errors from VSCode's built-in TS server).

## Constraints honored
- **ADR-012 preserved:** `@hono/zod-validator`'s `zValidator(...)` remains the request validator on
  every route; `hono-openapi`'s `validator` is never imported. Metadata is additive only.
- **No runtime behavior change** — handlers, status codes, and response bodies are unchanged.
- **Additive schemas only** — no existing schema modified; `drizzle-zod` not added.

## Testing
- `make check` — passed (0 type errors)
- `make lint` — passed (0 errors)
- `make test` — passed: API + shared **172 files / 1155 steps / 0 failed** (incl. coverage test +
  3 property tests + all schema unit tests); web **806 passed**. No regressions.
- Static checks: `hono-openapi`'s `validator` never imported; `drizzle-zod` absent from all manifests.

## Notes / decisions
- **`resolver()` is responses-only in `hono-openapi` v1.3.0.** Request bodies use the same Zod input
  schema (the one `zValidator` validates) converted via Zod v4 `z.toJSONSchema`, wrapped in the
  `jsonRequestBody` helper — no schema duplication. Recorded in ADR-012.
- **No `zod-openapi/extend` import.** That subpath was removed in `zod-openapi` v5 and breaks the
  Deno build; `resolver()` reads metadata natively from Zod v4 schemas.
- Output schemas are hand-authored (not `drizzle-zod`) to keep `@brewform/shared` browser-safe;
  drift is guarded by the per-schema unit tests and Property 9. See design ADR-OAPI-1.
- No new runtime dependencies beyond `zod-openapi` (already transitive via `hono-openapi`).
- No database or schema changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comprehensive OpenAPI documentation is now generated for all API routes, providing complete specification of endpoints, parameters, request bodies, and response formats.
  * Standardized response envelopes across all API responses for improved consistency and predictability.

* **Tests**
  * Added automated validation tests for API response schemas and OpenAPI documentation coverage to ensure compliance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->