### PR TITLE
D28: Deprecation Signal for `tasteNoteId` (Phase 1)

### DIFF
--- a/apps/api/src/modules/recipe/index.ts
+++ b/apps/api/src/modules/recipe/index.ts
@@ -46,11 +46,33 @@ recipe.get(
       { name: 'sortOrder', in: 'query', required: false, schema: { type: 'string' } },
       { name: 'cursor', in: 'query', required: false, schema: { type: 'string' } },
       { name: 'includeTotal', in: 'query', required: false, schema: { type: 'boolean' } },
+      {
+        name: 'tasteNoteId',
+        in: 'query',
+        required: false,
+        deprecated: true,
+        description: 'Deprecated. Use tasteNoteIds instead. See D28.',
+        schema: { type: 'string', format: 'uuid' },
+      },
+      {
+        name: 'tasteNoteIds',
+        in: 'query',
+        required: false,
+        description: 'Comma-separated taste note UUIDs (AND logic, max 10)',
+        schema: { type: 'string' },
+      },
     ],
     responses: {
       200: {
         description:
           'Paginated list of recipes. Returns `meta.cursor` when cursor pagination is active, or `meta.pagination` when offset pagination is active.',
+        headers: {
+          Deprecation: {
+            schema: { type: 'string' },
+            description:
+              'Present (value "true") when the deprecated tasteNoteId parameter is used. See RFC 8594.',
+          },
+        },
         content: {
           'application/json': {
             schema: resolver(
@@ -74,6 +96,7 @@ recipe.get(
     const filters = c.req.valid('query');
     const userId = c.get('userId') ?? null;
     const isAdmin = c.get('user')?.isAdmin ?? false;
+    const requestId = c.get('requestId');
     try {
       const result = await service.listRecipes(
         filters,
@@ -81,22 +104,37 @@ recipe.get(
         filters.perPage,
         userId,
         isAdmin,
+        requestId,
       );
 
+      const depHeaders = result.deprecations?.tasteNoteId === true
+        ? { headers: { Deprecation: 'true' } }
+        : undefined;
+
       if ('hasMore' in result) {
-        return cursorPaginated(c, result.recipes, {
-          nextCursor: result.nextCursor,
-          hasMore: result.hasMore,
-          total: result.total,
-        });
+        return cursorPaginated(
+          c,
+          result.recipes,
+          {
+            nextCursor: result.nextCursor,
+            hasMore: result.hasMore,
+            total: result.total,
+          },
+          depHeaders,
+        );
       }
 
-      return paginated(c, result.recipes, {
-        page: filters.page,
-        perPage: filters.perPage,
-        total: result.total,
-        totalPages: Math.ceil(result.total / filters.perPage),
-      });
+      return paginated(
+        c,
+        result.recipes,
+        {
+          page: filters.page,
+          perPage: filters.perPage,
+          total: result.total,
+          totalPages: Math.ceil(result.total / filters.perPage),
+        },
+        depHeaders,
+      );
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (message === 'VALIDATION_ERROR: INVALID_CURSOR') {
@@ -114,9 +152,47 @@ recipe.get(
     summary: 'List starred (favourited) recipes',
     description: 'Paginated, filterable list of recipes the current user has starred.',
     security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'sortBy', in: 'query', required: false, schema: { type: 'string' } },
+      { name: 'sortOrder', in: 'query', required: false, schema: { type: 'string' } },
+      {
+        name: 'tasteNoteId',
+        in: 'query',
+        required: false,
+        deprecated: true,
+        description: 'Deprecated. Use tasteNoteIds instead. See D28.',
+        schema: { type: 'string', format: 'uuid' },
+      },
+      {
+        name: 'tasteNoteIds',
+        in: 'query',
+        required: false,
+        description: 'Comma-separated taste note UUIDs (AND logic, max 10)',
+        schema: { type: 'string' },
+      },
+    ],
     responses: {
-      200: { description: 'Paginated list of starred recipes' },
-      401: { description: 'Unauthorized' },
+      200: {
+        description: 'Paginated list of starred recipes',
+        headers: {
+          Deprecation: {
+            schema: { type: 'string' },
+            description:
+              'Present (value "true") when the deprecated tasteNoteId parameter is used. See RFC 8594.',
+          },
+        },
+        content: {
+          'application/json': {
+            schema: resolver(paginatedEnvelope(FeedRecipeOutputSchema)),
+          },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
     },
   }),
   authMiddleware,
@@ -124,13 +200,25 @@ recipe.get(
   async (c) => {
     const userId = c.get('userId') as string;
     const filters = c.req.valid('query');
-    const result = await service.listStarredRecipes(filters, filters.page, filters.perPage, userId);
-    return paginated(c, result.recipes, {
-      page: filters.page,
-      perPage: filters.perPage,
-      total: result.total,
-      totalPages: Math.ceil(result.total / filters.perPage),
-    });
+    const requestId = c.get('requestId');
+    const result = await service.listStarredRecipes(
+      filters,
+      filters.page,
+      filters.perPage,
+      userId,
+      requestId,
+    );
+    return paginated(
+      c,
+      result.recipes,
+      {
+        page: filters.page,
+        perPage: filters.perPage,
+        total: result.total,
+        totalPages: Math.ceil(result.total / filters.perPage),
+      },
+      result.deprecations?.tasteNoteId === true ? { headers: { Deprecation: 'true' } } : undefined,
+    );
   },
 );
 

--- a/apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts
+++ b/apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts
@@ -1,0 +1,386 @@
+// deno-lint-ignore-file no-explicit-any require-await
+
+/**
+ * Tests for the D28 deprecation signal on the recipe filter.
+ *
+ * Asserts that:
+ *  - `tasteNoteId` (singular) only -> `deprecations.tasteNoteId === true`
+ *  - `tasteNoteIds` (plural) only -> no flag
+ *  - Both set (plural wins per the existing `else if`) -> no flag
+ *  - Neither set -> no flag
+ *
+ * Also exercises the controller boundary via Hono's `app.request(...)` to
+ * assert the `Deprecation: true` header is present on the response (both
+ * offset and cursor modes).
+ */
+
+import '../../test-setup.ts';
+import { afterEach, beforeAll, describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { Hono } from 'hono';
+import type { AppEnv } from '../../types/hono.ts';
+import recipeRouter from './index.ts';
+import * as service from './service.ts';
+import { db } from '@brewform/db';
+import { recipes, recipeTasteNotes, recipeVersions, tasteNotes, users } from '@brewform/db/schema';
+import { eq } from 'drizzle-orm';
+import { signAccessToken } from '../auth/jwt.ts';
+import { encodeCursor } from '@brewform/shared/utils';
+
+/** Valid v4 UUID used as a placeholder taste-note ID in filter tests. */
+const TEST_TASTE_NOTE_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+const TEST_TASTE_NOTE_ID_2 = 'b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a22';
+
+let testUserId: string;
+let testUserRecord: { id: string; email: string; username: string; isAdmin: boolean };
+let testRecipeVersionId: string;
+let testTasteNoteId: string;
+let testRecipe: { id: string; createdAt: Date };
+
+async function createTestUser(): Promise<string> {
+  const [user] = await db.insert(users).values({
+    email: `d28-test-${Date.now()}@test.brewform.dev`,
+    username: `d28test${Date.now() % 100000}`,
+    passwordHash: 'test-hash',
+  }).returning({ id: users.id });
+  return user.id;
+}
+
+async function createTestRecipe(
+  authorId: string,
+): Promise<{ recipeId: string; versionId: string; createdAt: Date }> {
+  const [recipe] = await db.insert(recipes).values({
+    slug: `d28-test-recipe-${Date.now() % 100000}`,
+    title: 'D28 Test Recipe',
+    authorId,
+    visibility: 'public',
+  }).returning({ id: recipes.id, createdAt: recipes.createdAt });
+
+  const [version] = await db.insert(recipeVersions).values({
+    recipeId: recipe.id,
+    versionNumber: 1,
+    brewMethod: 'v60',
+    drinkType: 'pour_over',
+    preparationNotes: 'Test preparation notes',
+  }).returning({ id: recipeVersions.id });
+
+  await db.update(recipes).set({ currentVersionId: version.id }).where(eq(recipes.id, recipe.id));
+
+  return { recipeId: recipe.id, versionId: version.id, createdAt: recipe.createdAt };
+}
+
+async function linkTasteNoteToRecipe(recipeVersionId: string): Promise<string> {
+  const [tasteNote] = await db.insert(tasteNotes).values({
+    name: 'D28 Test Taste Note',
+  }).returning({ id: tasteNotes.id });
+
+  await db.insert(recipeTasteNotes).values({
+    recipeVersionId,
+    tasteNoteId: tasteNote.id,
+  });
+  return tasteNote.id;
+}
+
+/**
+ * Build a minimal Hono app mounting the recipe router with context vars
+ * preset for the /recipes (optionalAuth) endpoint — anonymous access.
+ */
+function createTestApp() {
+  const app = new Hono<AppEnv>();
+  app.use('*', async (c, next) => {
+    c.set('requestId', crypto.randomUUID());
+    c.set('userId', null);
+    c.set('user', null);
+    await next();
+  });
+  app.route('/api/v1/recipes', recipeRouter);
+  return app;
+}
+
+/**
+ * Build a Hono app with a real JWT access token for the /starred endpoint,
+ * which is guarded by `authMiddleware`.
+ */
+function createAuthedTestApp(
+  user: { id: string; email: string; username: string; isAdmin: boolean },
+) {
+  const app = new Hono<AppEnv>();
+  app.use('*', async (c, next) => {
+    c.set('requestId', crypto.randomUUID());
+    await next();
+  });
+  app.route('/api/v1/recipes', recipeRouter);
+  return { app, token: signAccessToken(user) };
+}
+
+const opts = { sanitizeResources: false, sanitizeOps: false };
+
+describe(
+  'listRecipes deprecation flag (D28)',
+  opts,
+  () => {
+    beforeAll(async () => {
+      testUserId = await createTestUser();
+      const { recipeId, versionId, createdAt } = await createTestRecipe(testUserId);
+      testRecipe = { id: recipeId, createdAt };
+      testRecipeVersionId = versionId;
+      testTasteNoteId = await linkTasteNoteToRecipe(testRecipeVersionId);
+    });
+
+    afterEach(async () => {
+      await db.delete(recipeTasteNotes).where(
+        eq(recipeTasteNotes.recipeVersionId, testRecipeVersionId),
+      );
+      await db.delete(tasteNotes).where(eq(tasteNotes.id, testTasteNoteId));
+    });
+
+    it('sets deprecations.tasteNoteId when only the singular form is used', async () => {
+      const result = await service.listRecipes(
+        {
+          tasteNoteId: TEST_TASTE_NOTE_ID,
+          page: 1,
+          perPage: 20,
+          sortBy: 'createdAt' as any,
+          sortOrder: 'desc' as any,
+        } as any,
+        1,
+        20,
+        null,
+        false,
+        'test-request-id',
+      );
+      expect(result.deprecations?.tasteNoteId).toBe(true);
+    });
+
+    it('does not set deprecations when only the plural form is used', async () => {
+      const result = await service.listRecipes(
+        {
+          tasteNoteIds: TEST_TASTE_NOTE_ID,
+          page: 1,
+          perPage: 20,
+          sortBy: 'createdAt' as any,
+          sortOrder: 'desc' as any,
+        } as any,
+        1,
+        20,
+        null,
+        false,
+        'test-request-id',
+      );
+      expect(result.deprecations?.tasteNoteId).toBeFalsy();
+    });
+
+    it('does not set deprecations when both forms are provided (plural wins)', async () => {
+      const result = await service.listRecipes(
+        {
+          tasteNoteIds: TEST_TASTE_NOTE_ID,
+          tasteNoteId: TEST_TASTE_NOTE_ID_2,
+          page: 1,
+          perPage: 20,
+          sortBy: 'createdAt' as any,
+          sortOrder: 'desc' as any,
+        } as any,
+        1,
+        20,
+        null,
+        false,
+        'test-request-id',
+      );
+      expect(result.deprecations?.tasteNoteId).toBeFalsy();
+    });
+
+    it('does not set deprecations when neither form is provided', async () => {
+      const result = await service.listRecipes(
+        {
+          page: 1,
+          perPage: 20,
+          sortBy: 'createdAt' as any,
+          sortOrder: 'desc' as any,
+        } as any,
+        1,
+        20,
+        null,
+        false,
+        'test-request-id',
+      );
+      expect(result.deprecations?.tasteNoteId).toBeFalsy();
+    });
+  },
+);
+
+describe(
+  'listStarredRecipes deprecation flag (D28)',
+  opts,
+  () => {
+    beforeAll(async () => {
+      if (!testUserId) {
+        testUserId = await createTestUser();
+        const { recipeId, versionId, createdAt } = await createTestRecipe(testUserId);
+        testRecipe = { id: recipeId, createdAt };
+        testRecipeVersionId = versionId;
+        testTasteNoteId = await linkTasteNoteToRecipe(testRecipeVersionId);
+      }
+    });
+
+    it('sets deprecations.tasteNoteId when only the singular form is used', async () => {
+      const result = await service.listStarredRecipes(
+        {
+          tasteNoteId: TEST_TASTE_NOTE_ID,
+          page: 1,
+          perPage: 20,
+          sortBy: 'createdAt' as any,
+          sortOrder: 'desc' as any,
+        } as any,
+        1,
+        20,
+        testUserId,
+        'test-request-id',
+      );
+      expect(result.deprecations?.tasteNoteId).toBe(true);
+    });
+
+    it('does not set deprecations when only the plural form is used', async () => {
+      const result = await service.listStarredRecipes(
+        {
+          tasteNoteIds: TEST_TASTE_NOTE_ID,
+          page: 1,
+          perPage: 20,
+          sortBy: 'createdAt' as any,
+          sortOrder: 'desc' as any,
+        } as any,
+        1,
+        20,
+        testUserId,
+        'test-request-id',
+      );
+      expect(result.deprecations?.tasteNoteId).toBeFalsy();
+    });
+
+    it('does not set deprecations when both forms are provided (plural wins)', async () => {
+      const result = await service.listStarredRecipes(
+        {
+          tasteNoteIds: TEST_TASTE_NOTE_ID,
+          tasteNoteId: TEST_TASTE_NOTE_ID_2,
+          page: 1,
+          perPage: 20,
+          sortBy: 'createdAt' as any,
+          sortOrder: 'desc' as any,
+        } as any,
+        1,
+        20,
+        testUserId,
+        'test-request-id',
+      );
+      expect(result.deprecations?.tasteNoteId).toBeFalsy();
+    });
+
+    it('does not set deprecations when neither form is provided', async () => {
+      const result = await service.listStarredRecipes(
+        {
+          page: 1,
+          perPage: 20,
+          sortBy: 'createdAt' as any,
+          sortOrder: 'desc' as any,
+        } as any,
+        1,
+        20,
+        testUserId,
+        'test-request-id',
+      );
+      expect(result.deprecations?.tasteNoteId).toBeFalsy();
+    });
+  },
+);
+
+describe(
+  'Deprecation response header (D28)',
+  opts,
+  () => {
+    it('sets Deprecation: true on /api/v1/recipes when tasteNoteId is used (offset mode)', async () => {
+      const app = createTestApp();
+      const res = await app.request(
+        `/api/v1/recipes?tasteNoteId=${TEST_TASTE_NOTE_ID}`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Deprecation')).toBe('true');
+    });
+
+    it('does not set Deprecation header when tasteNoteIds is used', async () => {
+      const app = createTestApp();
+      const res = await app.request(
+        `/api/v1/recipes?tasteNoteIds=${TEST_TASTE_NOTE_ID}`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Deprecation')).toBeNull();
+    });
+
+    it('does not set Deprecation header when no taste note filter is used', async () => {
+      const app = createTestApp();
+      const res = await app.request('/api/v1/recipes');
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Deprecation')).toBeNull();
+    });
+
+    it('does not set Deprecation header on the invalid-cursor error path', async () => {
+      const app = createTestApp();
+      const res = await app.request(
+        `/api/v1/recipes?tasteNoteId=${TEST_TASTE_NOTE_ID}&cursor=invalid&sortBy=createdAt`,
+      );
+      expect(res.status).toBe(400);
+      expect(res.headers.get('Deprecation')).toBeNull();
+    });
+
+    it('sets Deprecation: true in cursor mode when tasteNoteId is used (success path)', async () => {
+      // Build a valid cursor from the test recipe's createdAt + id.
+      // This exercises the cursorPaginated branch (not the paginated branch).
+      const cursor = encodeCursor({
+        createdAt: testRecipe.createdAt.toISOString(),
+        id: testRecipe.id,
+      });
+      const app = createTestApp();
+      const res = await app.request(
+        `/api/v1/recipes?tasteNoteId=${TEST_TASTE_NOTE_ID}&cursor=${cursor}&sortBy=createdAt`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Deprecation')).toBe('true');
+    });
+
+    it('sets Deprecation: true on /api/v1/recipes/starred when tasteNoteId is used (with auth)', async () => {
+      if (!testUserRecord) {
+        const [user] = await db.select().from(users).where(eq(users.id, testUserId)).limit(1);
+        testUserRecord = {
+          id: user.id,
+          email: user.email,
+          username: user.username,
+          isAdmin: user.isAdmin,
+        };
+      }
+      const { app, token } = createAuthedTestApp(testUserRecord);
+      const res = await app.request(
+        `/api/v1/recipes/starred?tasteNoteId=${TEST_TASTE_NOTE_ID}`,
+        { headers: { Authorization: `Bearer ${await token}` } },
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Deprecation')).toBe('true');
+    });
+
+    it('does not set Deprecation header on /api/v1/recipes/starred when tasteNoteIds is used', async () => {
+      if (!testUserRecord) {
+        const [user] = await db.select().from(users).where(eq(users.id, testUserId)).limit(1);
+        testUserRecord = {
+          id: user.id,
+          email: user.email,
+          username: user.username,
+          isAdmin: user.isAdmin,
+        };
+      }
+      const { app, token } = createAuthedTestApp(testUserRecord);
+      const res = await app.request(
+        `/api/v1/recipes/starred?tasteNoteIds=${TEST_TASTE_NOTE_ID}`,
+        { headers: { Authorization: `Bearer ${await token}` } },
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Deprecation')).toBeNull();
+    });
+  },
+);

--- a/apps/api/src/modules/recipe/service.ts
+++ b/apps/api/src/modules/recipe/service.ts
@@ -495,6 +495,7 @@ export async function listRecipes(
   perPage: number,
   _requestingUserId: string | null = null,
   isAdmin: boolean = false,
+  requestId?: string,
 ) {
   logger.debug(
     { userId: _requestingUserId, page, perPage, filters: JSON.stringify(filters) },
@@ -504,6 +505,20 @@ export async function listRecipes(
   const where = model.buildListRecipesWhere(filters, isAdmin);
   const sortBy = filters.sortBy || 'createdAt';
   const sortOrder = filters.sortOrder || 'desc';
+
+  const deprecations: { tasteNoteId?: boolean } = {};
+  if (!filters.tasteNoteIds && filters.tasteNoteId) {
+    deprecations.tasteNoteId = true;
+    logger.warn(
+      { filter: 'tasteNoteId', userId: _requestingUserId, requestId },
+      'Deprecated query parameter used',
+    );
+  }
+
+  const withDeprecations = <T>(result: T): T & { deprecations?: { tasteNoteId?: boolean } } =>
+    deprecations.tasteNoteId
+      ? { ...result, deprecations }
+      : (result as T & { deprecations?: { tasteNoteId?: boolean } });
 
   if (filters.cursor) {
     if (page > 1) {
@@ -525,7 +540,7 @@ export async function listRecipes(
         { userId: _requestingUserId, page, perPage, resultCount: result.total },
         'listRecipes completed',
       );
-      return result;
+      return withDeprecations(result);
     }
 
     let cursor: { createdAt: string; id: string };
@@ -556,7 +571,7 @@ export async function listRecipes(
       { userId: _requestingUserId, perPage, hasMore: result.hasMore },
       'listRecipes completed',
     );
-    return result;
+    return withDeprecations(result);
   }
 
   const result = await model.findMany(where, page, perPage, sortBy, sortOrder);
@@ -564,7 +579,7 @@ export async function listRecipes(
     { userId: _requestingUserId, page, perPage, resultCount: result.total },
     'listRecipes completed',
   );
-  return result;
+  return withDeprecations(result);
 }
 
 /**
@@ -585,14 +600,28 @@ export async function listStarredRecipes(
   page: number,
   perPage: number,
   userId: string,
+  requestId?: string,
 ) {
   logger.debug({ userId }, 'listStarredRecipes started');
   if (filters.cursor) {
     logger.debug('Cursor provided but starred recipes use offset pagination, using offset');
   }
+
+  const deprecations: { tasteNoteId?: boolean } = {};
+  if (!filters.tasteNoteIds && filters.tasteNoteId) {
+    deprecations.tasteNoteId = true;
+    logger.warn(
+      { filter: 'tasteNoteId', userId, requestId },
+      'Deprecated query parameter used',
+    );
+  }
+
   const result = await model.findStarred(userId, filters, page, perPage);
   logger.debug({ userId }, 'listStarredRecipes completed');
-  return result;
+  return {
+    ...result,
+    ...(deprecations.tasteNoteId ? { deprecations } : {}),
+  };
 }
 
 /**

--- a/apps/api/src/utils/response/index.ts
+++ b/apps/api/src/utils/response/index.ts
@@ -28,7 +28,26 @@ export function success<T>(
 }
 
 /** Return a success envelope with pagination metadata. Shorthand for success() with pagination. */
-export function paginated<T>(c: Context, data: T[], pagination: PaginationMeta) {
+/**
+ * Return a success envelope with pagination metadata and optional response
+ * headers. Shorthand for success() with pagination.
+ *
+ * @param c - Hono request context.
+ * @param data - Items on the current page.
+ * @param pagination - Offset pagination metadata.
+ * @param options - Optional response headers (e.g., `Deprecation`).
+ */
+export function paginated<T>(
+  c: Context,
+  data: T[],
+  pagination: PaginationMeta,
+  options?: { headers?: Record<string, string> },
+) {
+  if (options?.headers) {
+    for (const [name, value] of Object.entries(options.headers)) {
+      c.header(name, value);
+    }
+  }
   return c.json({
     success: true as const,
     data,
@@ -49,7 +68,29 @@ export function paginated<T>(c: Context, data: T[], pagination: PaginationMeta) 
  * @param data - Items on the current page.
  * @param cursorMeta - Cursor pagination metadata.
  */
-export function cursorPaginated<T>(c: Context, data: T[], cursorMeta: CursorPaginationMeta) {
+/**
+ * Return a success envelope with cursor-pagination metadata and optional
+ * response headers.
+ *
+ * Use this for cursor-based list endpoints. The response shape is
+ * `{ success: true, data, meta: { requestId, cursor: { nextCursor, hasMore, total? } } }`.
+ *
+ * @param c - Hono request context.
+ * @param data - Items on the current page.
+ * @param cursorMeta - Cursor pagination metadata.
+ * @param options - Optional response headers (e.g., `Deprecation`).
+ */
+export function cursorPaginated<T>(
+  c: Context,
+  data: T[],
+  cursorMeta: CursorPaginationMeta,
+  options?: { headers?: Record<string, string> },
+) {
+  if (options?.headers) {
+    for (const [name, value] of Object.entries(options.headers)) {
+      c.header(name, value);
+    }
+  }
   return c.json({
     success: true as const,
     data,

--- a/apps/api/src/utils/response/response.test.ts
+++ b/apps/api/src/utils/response/response.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from 'jsr:@std/testing/bdd';
 import { expect } from 'jsr:@std/expect';
+import { Hono } from 'hono';
 import {
+  cursorPaginated,
   error,
   forbidden,
   notFound,
@@ -129,5 +131,51 @@ describe('Response Helpers', () => {
       expect((result as any).body.error.code).toBe('VALIDATION_ERROR');
       expect((result as any).body.error.details).toEqual(details);
     });
+  });
+});
+
+describe('paginated with headers option (D28)', () => {
+  it('sets response headers when options.headers is provided', async () => {
+    const app = new Hono();
+    app.get('/test', (c) =>
+      paginated(c, [], { page: 1, perPage: 20, total: 0, totalPages: 0 }, {
+        headers: { Deprecation: 'true' },
+      }));
+    const res = await app.request('/test');
+    expect(res.headers.get('Deprecation')).toBe('true');
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual([]);
+    expect(body.meta.pagination).toEqual({ page: 1, perPage: 20, total: 0, totalPages: 0 });
+  });
+
+  it('does not set headers when options is not provided', async () => {
+    const app = new Hono();
+    app.get('/test', (c) => paginated(c, [], { page: 1, perPage: 20, total: 0, totalPages: 0 }));
+    const res = await app.request('/test');
+    expect(res.headers.get('Deprecation')).toBeNull();
+  });
+});
+
+describe('cursorPaginated with headers option (D28)', () => {
+  it('sets response headers when options.headers is provided', async () => {
+    const app = new Hono();
+    app.get('/test', (c) =>
+      cursorPaginated(c, [], { nextCursor: null, hasMore: false }, {
+        headers: { Deprecation: 'true' },
+      }));
+    const res = await app.request('/test');
+    expect(res.headers.get('Deprecation')).toBe('true');
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual([]);
+    expect(body.meta.cursor).toEqual({ nextCursor: null, hasMore: false });
+  });
+
+  it('does not set headers when options is not provided', async () => {
+    const app = new Hono();
+    app.get('/test', (c) => cursorPaginated(c, [], { nextCursor: null, hasMore: false }));
+    const res = await app.request('/test');
+    expect(res.headers.get('Deprecation')).toBeNull();
   });
 });

--- a/deno.lock
+++ b/deno.lock
@@ -36,6 +36,7 @@
     "npm:jsdom@29": "29.1.1",
     "npm:mjml@*": "5.2.1_typescript@6.0.3",
     "npm:mjml@5": "5.2.1_typescript@6.0.3",
+    "npm:nodemailer@*": "9.0.1",
     "npm:nodemailer@9": "9.0.1",
     "npm:pino-pretty@13": "13.1.3",
     "npm:pino@10": "10.3.1",

--- a/docs/api.md
+++ b/docs/api.md
@@ -231,7 +231,7 @@ Response `401` (invalid or expired refresh token):
 | `search`       | —             | Search by title                                        |
 | `equipmentId`  | —             | Filter by linked equipment UUID                        |
 | `tasteNoteIds` | —             | Comma-separated taste note UUIDs (AND logic, max 10)   |
-| `tasteNoteId`  | —             | Single taste note UUID (deprecated, use tasteNoteIds)  |
+| `tasteNoteId`  | —             | Single taste note UUID (**deprecated**, use `tasteNoteIds`). Responses include a `Deprecation: true` header (RFC 8594). Will be removed in a future release — see [`openspec/changes/d28-remove-deprecated-taste-note-id/`](../openspec/changes/d28-remove-deprecated-taste-note-id/proposal.md). |
 | `grinder`      | —             | Filter by grinder name                                 |
 | `mainBrewer`   | —             | Filter by main brewer name (partial, case-insensitive) |
 | `sortBy`       | `createdAt`   | Sort field: `createdAt`, `likeCount`, `rating`         |

--- a/openspec/changes/d28-remove-deprecated-taste-note-id/design.md
+++ b/openspec/changes/d28-remove-deprecated-taste-note-id/design.md
@@ -5,47 +5,99 @@ standard 3-layer pattern: `model.ts` (data access) → `service.ts` (business
 logic) → `index.ts` (HTTP controller). The deprecated singular `tasteNoteId`
 parameter is declared on the public `RecipeFilterSchema` at
 `packages/shared/src/schemas/recipe.ts:134-135` and is honoured inside the
-service / model filter blocks via an `else if (filters.tasteNoteId)` branch
-that takes effect only when the plural `tasteNoteIds` is absent.
+`buildRecipeFilters` helper in `apps/api/src/modules/recipe/model.ts:167-176`
+via an `else if (filters.tasteNoteId)` branch that takes effect only when the
+plural `tasteNoteIds` is absent.
 
-D12 (separate change, in progress) extracts the shared filter-building logic
-into `buildRecipeFilters` and brings the missing `else if` branch over to
-`findStarred`, closing the parity gap. D12 explicitly defers the deprecation
-cycle itself (see `openspec/changes/d12-recipe-filter-logic/design.md:90`).
-D28 is that deprecation cycle, **Phase 1 only** — emit the signal, do not
-remove the field. Phase 2 (field removal) becomes a separate plan once
-production telemetry from D28 confirms no significant callers remain.
+D12 (recipe-filter-logic, merged and archived at
+`openspec/changes/archive/2026-06-06-d12-recipe-filter-logic/`) extracted
+`buildRecipeFilters` into `model.ts:83-179` and brought the `else if` branch
+to `findStarred` (via the shared helper), closing the parity gap. D12
+explicitly deferred the deprecation cycle itself. D28 is that deprecation
+cycle, **Phase 1 only** — emit the signal, do not remove the field. Phase 2
+(field removal) becomes a separate plan once production telemetry from D28
+confirms no significant callers remain.
 
 The frontend never sends the singular form. Audit of
 `apps/web/src/components/recipe-list/useRecipeFilters.ts`,
 `RecipeListView.tsx`, `RecipeCreatePage.tsx`, `RecipeEditPage.tsx`,
 `TasteNotesPage.tsx`, and `TastingNotesSection.tsx` confirms that only
-`tasteNoteIds` is generated. Any usage of `tasteNoteId` in production
-therefore comes from third-party API consumers — and there is currently no
-mechanism to count or attribute them.
+`tasteNoteIds` is generated as a filter parameter. (The singular
+`tasteNoteId` that appears in `TastingNotesSection.tsx` and
+`radar-chart-data.ts` is a property on the `TasteNote` domain object, not a
+filter query parameter.) Any usage of `tasteNoteId` as a filter parameter in
+production therefore comes from third-party API consumers — and there is
+currently no mechanism to count or attribute them.
 
-### Codebase facts (verified)
+### Codebase facts (verified against `main` on 2026-06-22)
 
 - `packages/shared/src/schemas/recipe.ts:134-135` declares
-  `tasteNoteId: z.uuid().optional()` with a one-line comment marking it
-  deprecated; there is no `@deprecated` JSDoc tag.
-- `apps/api/src/modules/recipe/service.ts:544-551` contains the existing
-  `else if (filters.tasteNoteId)` branch in `listRecipes` that applies the
-  legacy single-id filter.
-- `apps/api/src/modules/recipe/index.ts:42-55` is the `/recipes` controller;
-  `index.ts:72-82` is the `/recipes/starred` controller. Both currently call
-  `paginated(c, result.recipes, { page, perPage, total, totalPages })`.
-- `apps/api/src/utils/response/index.ts:30-40` defines `paginated<T>()`. It
-  accepts no options object today; all responses are 200 with a
-  `{ success, data, meta }` envelope.
+  `tasteNoteId: z.uuid().optional()` with a one-line inline comment marking
+  it deprecated; there is no `@deprecated` JSDoc tag and no `.meta()` call.
+  The codebase uses **Zod v4.4.3** (per `deno.lock` and `package.json`),
+  whose `.meta()` method stores metadata in the `globalRegistry` that
+  `zod-openapi` v5.4.6 (pulled in by `hono-openapi@1.3.0`) reads during
+  OpenAPI generation.
+- `apps/api/src/modules/recipe/model.ts:67-77` defines the
+  `RecipeFilterCriteria` interface. Line 73 already carries a JSDoc
+  `@deprecated` tag on `tasteNoteId`. This is the data-access-layer type;
+  the public Zod schema (`RecipeFilterSchema` in `packages/shared`) is the
+  one D28 annotates.
+- `apps/api/src/modules/recipe/model.ts:83-179` defines
+  `buildRecipeFilters(filters: RecipeFilterCriteria): SQL[]`. The `else if
+  (filters.tasteNoteId)` branch is at lines 167-176. This helper is called
+  by `buildListRecipesWhere` (model.ts:206-217, called by
+  `service.listRecipes` at service.ts:504) and by `findStarred`
+  (model.ts:870). Both listing endpoints honour the singular parameter
+  identically.
+- `apps/api/src/modules/recipe/service.ts:492-568` is `listRecipes`. It
+  has **no explicit return type annotation** and returns a **union** of two
+  shapes: `{ recipes, total }` (offset mode, from `model.findMany`) and
+  `{ recipes, hasMore, nextCursor, total? }` (cursor mode, from
+  `model.findCursor`). The function receives `_requestingUserId` (passed
+  through from the controller) but **no `requestId`** — the service has no
+  access to the Hono context.
+- `apps/api/src/modules/recipe/service.ts:583-596` is
+  `listStarredRecipes`, a thin wrapper around `model.findStarred` that
+  returns `{ recipes, total }` verbatim. No `deprecations` field is
+  propagated today.
+- `apps/api/src/modules/recipe/index.ts:73-107` is the `/recipes`
+  controller handler. It has a **two-branch return**: `cursorPaginated(...)`
+  for cursor mode (line 87) and `paginated(...)` for offset mode (line 94).
+  The `describeRoute` metadata is at lines 37-70; its `parameters` array
+  (lines 42-49) lists only `page`, `perPage`, `sortBy`, `sortOrder`,
+  `cursor`, `includeTotal` — it does **not** document `tasteNoteId` or
+  `tasteNoteIds` as query parameters.
+- `apps/api/src/modules/recipe/index.ts:124-134` is the `/starred`
+  controller handler. Its `describeRoute` (lines 112-121) is thinner — it
+  has `security` and `401` but no `parameters` array and no typed `200`
+  response schema.
+- `apps/api/src/utils/response/index.ts:31-40` defines `paginated<T>()`.
+  `cursorPaginated<T>()` is at lines 52-61. Neither accepts a `headers`
+  argument today; both hardcode status 200 and emit
+  `{ success, data, meta }`.
 - `docs/api.md:234` lists the row
   `| tasteNoteId | — | Single taste note UUID (deprecated, use tasteNoteIds) |`.
+- `requestId` is set on the Hono context by `requestIdMiddleware`
+  (`hono/request-id`, registered in `main.ts:24,42`) and is available as
+  `c.get('requestId')` in controllers. It is declared in `AppVariables`
+  (`types/hono.ts:13-18`).
+- The controller file `index.ts` does **not** import `createLogger` and has
+  no logger setup. The service layer (`service.ts:63`) has
+  `createLogger('recipe-service')`; the model layer (`model.ts:46`) has
+  `createLogger('recipe-model')`.
+- The OpenAPI coverage test (`openapi.coverage.test.ts`) is purely
+  spec-driven (it introspects `/api/v1/openapi.json`) and does not inspect
+  response headers. `/api/v1/recipes` is NOT in its `IN_SCOPE_BASE_PATHS`
+  list, so the P1 coverage check does not apply to the recipes router.
+  Adding a `Deprecation` header to recipe responses will not affect this
+  test.
 
 ### Stakeholders
 
 - **API (`apps/api/`)** — primary, all code changes live here.
-- **Shared package (`packages/shared/`)** — one JSDoc tag added to the
-  schema; no shape change.
+- **Shared package (`packages/shared/`)** — JSDoc tag + `.meta()` added to
+  the schema; no shape change.
 - **Docs (`docs/api.md`)** — one row updated.
 - **Web app, DB package** — unaffected.
 - **Product / Ops** — gains the telemetry needed to plan Phase 2.
@@ -55,55 +107,73 @@ mechanism to count or attribute them.
 **Goals:**
 
 - Emit an RFC 8594 `Deprecation: true` response header on every response
-  whose request used the singular `tasteNoteId` without the plural form.
+  whose request used the singular `tasteNoteId` without the plural form —
+  on **both** offset-paginated and cursor-paginated responses.
 - Emit a structured `warn` log line in the same conditions, with traceable
   IDs only (no payload, no PII).
 - Surface the deprecation in generated types / OpenAPI via a JSDoc
-  `@deprecated` tag on the schema field.
+  `@deprecated` tag and Zod `.meta({ deprecated: true })` on the schema field.
 - Document the deprecation status (and link to the OpenSpec change folder)
   in `docs/api.md`.
-- Cover the four deprecation cases with focused unit tests; optionally add a
-  controller-level header assertion.
+- Update `describeRoute` metadata on both routes to declare the
+  `tasteNoteId` parameter (with `deprecated: true`) and the `Deprecation`
+  response header — per AGENTS.md's mandatory OpenAPI rule.
+- Cover the four deprecation cases with focused unit tests for both
+  endpoints; add a controller-level test asserting the `Deprecation: true`
+  HTTP header (both offset and cursor modes).
 - Pass `make check-api`, `make lint`, and `make test-api` with zero
   regressions.
 
 **Non-Goals:**
 
 - **Field removal.** Phase 2 / D29+ removes `tasteNoteId` from the schema,
-  the service / model branches, the docs, and any remaining consumers. D28
-  does not touch any of that.
+  the `buildRecipeFilters` branch, the docs, and any remaining consumers.
+  D28 does not touch any of that.
 - **`Sunset` header.** Phase 1 emits `Deprecation: true` only. Setting a
   `Sunset` date implies a removal commitment that belongs to Phase 2.
-- **Other deprecations.** D28 only addresses `tasteNoteId`. Future deprecated
-  fields get their own plans, even if they reuse the helper extension.
+- **Other deprecations.** D28 only addresses `tasteNoteId`. Future
+  deprecated fields get their own plans, even if they reuse the helper
+  extension.
 - **Filter semantics.** No SQL changes. The existing `else if` precedence
-  (plural wins) is preserved exactly.
-- **Third-party client outreach.** Notifying API consumers is an operations
-  concern downstream of the telemetry D28 produces.
+  (plural wins) in `buildRecipeFilters` is preserved exactly.
+- **`findStarred` filter type cleanup.** The inline anonymous filter type
+  at `model.ts:855-866` is a pre-existing drift from `RecipeFilterCriteria`.
+  D28 may optionally replace it but this is not required for the
+  deprecation signal.
+- **Explicit `ListRecipesResult` interface.** The current `listRecipes`
+  has no explicit return type annotation (it returns a union). D28 adds
+  the `deprecations` field via spread; introducing a formal interface is
+  out of scope.
+- **Third-party client outreach.** Notifying API consumers is an
+  operations concern downstream of the telemetry D28 produces.
 
 ## Decisions
 
-### Decision 1: Detect the deprecated parameter in the service / model, not the controller
+### Decision 1: Detect the deprecated parameter in the service layer, not in `buildRecipeFilters` and not in the controller
 
-**Rationale.** The decision _"this request used a deprecated input"_ is the
-same logical decision the filter branch already makes (`else if
-(filters.tasteNoteId)`). Surfacing it from the service / model means there is
-a single source of truth: if the filter applies, the flag is set. Detecting
-in the controller would require duplicating the precedence check (plural
-wins) in a second place, which is exactly the kind of drift D12 was created
-to eliminate.
+**Rationale.** D12 moved the `else if (filters.tasteNoteId)` branch into
+`buildRecipeFilters` (`model.ts:167-176`). That function is a pure
+data-access helper that returns `SQL[]` — `model.ts:2-4` explicitly
+documents it as _"Pure Drizzle ORM operations — no business logic, no side
+effects."_ Adding a `warn` log there would violate the layering.
 
-The carrier is an optional `deprecations?: { tasteNoteId?: boolean }` field
-on the return shape:
+The controller is the other candidate, but D28's original Decision 1
+rejected controller-side detection because it duplicates the precedence
+check. With D12's extraction, the precedence check is now trivially
+expressible as a single boolean (`!filters.tasteNoteIds &&
+filters.tasteNoteId`) at the service call site — the `else if` SQL logic is
+fully encapsulated in `buildRecipeFilters`, so the service is not
+duplicating filter logic, only checking which input shape was provided.
+
+The service layer is the right home: it has the `logger` already
+instantiated (`createLogger('recipe-service')` at `service.ts:63`), it is
+the layer the controller calls, and it returns the result the controller
+consumes. The carrier is an optional `deprecations?: { tasteNoteId?:
+boolean }` field on the return shape:
 
 ```ts
-export interface ListRecipesResult {
-  recipes: Recipe[];
-  total: number;
-  deprecations?: {
-    tasteNoteId?: boolean;
-  };
-}
+// Spread into both cursor and offset return paths:
+return { ...result, ...(deprecations.tasteNoteId ? { deprecations } : {}) };
 ```
 
 This is forward-compatible: future deprecation flags add new keys without
@@ -111,9 +181,11 @@ breaking existing readers (`result.deprecations?.someFutureFlag`).
 
 **Alternatives considered.**
 
+- Detect in `buildRecipeFilters` — rejected; it's a pure `SQL[]` helper
+  with no logger and no side effects (by declaration at `model.ts:2-4`).
 - Detect in the controller by inspecting `c.req.valid('query')` directly —
-  rejected; duplicates the `if (filters.tasteNoteIds) … else if (filters.tasteNoteId)`
-  precedence in a second location.
+  rejected; would duplicate the precedence check in a second location and
+  couples HTTP-layer input inspection to the deprecation decision.
 - Throw a typed warning object from the service — rejected; mixes control
   flow with the success path.
 
@@ -122,13 +194,12 @@ breaking existing readers (`result.deprecations?.someFutureFlag`).
 **Rationale.** The service layer is HTTP-agnostic by convention (it returns
 domain data and is reused by background jobs that have no `Context`). Setting
 a response header from inside `listRecipes` would couple the service to Hono
-and break the layering rule documented in AGENTS.md (_"Services import from
-model files, never from `drizzle-orm` directly"_ — the spirit being that each
-layer touches only its own neighbours).
+and break the layering rule documented in AGENTS.md.
 
-The controllers at `apps/api/src/modules/recipe/index.ts:42-55` and
-`index.ts:72-82` already own the HTTP envelope (`paginated(c, …)`). Adding
-one conditional argument there keeps HTTP concerns where they belong.
+The controllers at `index.ts:73-107` ( `/recipes`) and `index.ts:124-134`
+(`/starred`) already own the HTTP envelope (`paginated(c, …)` /
+`cursorPaginated(c, …)`). Adding one conditional argument there keeps HTTP
+concerns where they belong.
 
 **Alternatives considered.**
 
@@ -138,7 +209,41 @@ one conditional argument there keeps HTTP concerns where they belong.
 - Set the header via `c.header()` in the service by injecting the context —
   rejected; same coupling problem.
 
-### Decision 3: Header name is `Deprecation: true` (RFC 8594, no `Sunset`)
+### Decision 3: Both `paginated()` AND `cursorPaginated()` get the `{ headers }` argument
+
+**Rationale.** The `/recipes` controller has a two-branch return
+(`index.ts:86-99`): `cursorPaginated(...)` for cursor mode (line 87) and
+`paginated(...)` for offset mode (line 94). If a client sends
+`?tasteNoteId=<uuid>&cursor=<...>&sortBy=createdAt`, the response goes
+through `cursorPaginated`. Extending only `paginated` would silently drop
+the `Deprecation` header in cursor mode — violating the spec's unqualified
+claim that the header is emitted. Both helpers must accept the optional
+`{ headers }` argument.
+
+The extension is purely additive — every existing
+`paginated(c, data, pagination)` and `cursorPaginated(c, data, cursorMeta)`
+call site works unchanged because the new fourth argument is optional.
+
+### Decision 4: `requestId` is plumbed through as a new optional service parameter
+
+**Rationale.** The service layer has no access to the Hono context. The
+module-scoped `logger` (`createLogger('recipe-service')` at `service.ts:63`)
+carries no per-request context. D28's log shape `{ filter, userId, requestId }`
+requires `requestId`, which is available as `c.get('requestId')` in the
+controller. The cleanest approach is to add an optional `requestId?: string`
+parameter to both `listRecipes` and `listStarredRecipes`, passed from the
+controller. The parameter is optional so existing callers (tests, etc.)
+work unchanged.
+
+**Alternatives considered.**
+
+- Move detection + log to the controller — rejected (Decision 1).
+- Use a child-logger pattern with per-request context — rejected; would
+  require a larger refactor of the logger setup and is out of scope for D28.
+- Omit `requestId` from the log — rejected; traceability is a core
+  requirement per AGENTS.md.
+
+### Decision 5: Header name is `Deprecation: true` (RFC 8594, no `Sunset`)
 
 **Rationale.** [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594) defines the
 `Deprecation` response header for exactly this purpose. The value can be
@@ -152,7 +257,7 @@ when the deprecated input will stop working. D28 explicitly does **not** set
 `Sunset` because Phase 1 makes no commitment about the removal date — that
 commitment belongs to Phase 2 / D29+ once telemetry exists to inform it.
 
-### Decision 4: Log level is `warn`, not `error`
+### Decision 6: Log level is `warn`, not `error`
 
 **Rationale.** The request still succeeds end-to-end; the deprecated input
 produces a correct response (the singular filter is applied). An `error`
@@ -160,9 +265,10 @@ level would mis-signal to alerting systems that something is broken. `warn`
 is the level used elsewhere in the codebase for "recoverable, but worth
 noticing" events (per AGENTS.md log-level guidance) and matches the semantics
 of RFC 8594 §6.1 ("Deprecation does not by itself signal a problem with the
-request or response").
+request or response"). The existing `logger.warn` in `service.ts:522` for
+cursor/sort incompatibility is the precedent.
 
-### Decision 5: Log shape is `{ filter, userId, requestId }` — IDs only, no payload
+### Decision 7: Log shape is `{ filter, userId, requestId }` — IDs only, no payload
 
 **Rationale.** AGENTS.md is explicit:
 _"Never log passwords, tokens, secrets, API keys, or PII (emails, IPs)"_ and
@@ -170,8 +276,8 @@ _"Use `log.debug({ relevantIds }, 'message')` — include traceable IDs,
 exclude payloads."_ The same rule applies at `warn` level. The chosen shape:
 
 ```ts
-log.warn(
-  { filter: 'tasteNoteId', userId, requestId },
+logger.warn(
+  { filter: 'tasteNoteId', userId: _requestingUserId, requestId },
   'Deprecated query parameter used',
 );
 ```
@@ -182,7 +288,7 @@ callers when present (`userId`, which is `null` for anonymous requests on
 UUID value of the taste note is omitted because it is not needed to act on
 the telemetry and could leak data about the caller's taste-note inventory.
 
-### Decision 6: Controller checks `result.deprecations?.tasteNoteId === true`
+### Decision 8: Controller checks `result.deprecations?.tasteNoteId === true`
 
 **Rationale.** Strict-equality check against `true` keeps the controller
 forward-compatible: a future flag with a non-boolean value (e.g., a Date or
@@ -192,67 +298,70 @@ without the flag (e.g., during a test that stubs the service) see
 `undefined`, not a thrown reference error.
 
 ```ts
-return paginated(
-  c,
-  result.recipes,
-  { page: filters.page, perPage: filters.perPage, total: result.total, totalPages: ... },
-  result.deprecations?.tasteNoteId === true
-    ? { headers: { Deprecation: 'true' } }
-    : undefined,
-);
-```
+const depHeaders = result.deprecations?.tasteNoteId === true
+  ? { headers: { Deprecation: 'true' } }
+  : undefined;
 
-### Decision 7: `paginated()` gains an optional `{ headers }` argument
-
-**Rationale.** Two implementation options were considered for the controller
-plumbing:
-
-1. Call `c.header('Deprecation', 'true')` directly in the controller before
-   `paginated(...)`. Hono accumulates `c.header()` calls and applies them
-   to the next response, so this works.
-2. Extend `paginated()` to accept `options?: { headers?: Record<string, string> }`
-   and apply them internally.
-
-Option 2 was chosen because it keeps the controller's contract _declarative_:
-the controller passes everything that should affect the response (envelope,
-pagination, headers) as arguments to one function. Option 1 would leave a
-"set this header magically before the next response" sequencing requirement
-that future readers might overlook when reordering code. The extension is
-purely additive — every existing `paginated(c, data, pagination)` call site
-works unchanged.
-
-The implementation is one short loop:
-
-```ts
-if (options?.headers) {
-  for (const [name, value] of Object.entries(options.headers)) {
-    c.header(name, value);
-  }
+// Both branches use the same depHeaders:
+if ('hasMore' in result) {
+  return cursorPaginated(c, result.recipes, { ... }, depHeaders);
 }
+return paginated(c, result.recipes, { ... }, depHeaders);
 ```
 
-### Decision 8: Backward compatibility is unconditional
+### Decision 9: Schema annotation uses both JSDoc `@deprecated` AND Zod `.meta({ deprecated: true })`
 
-**Rationale.** The new header is additive at the wire level. Clients that do
-not inspect response headers see no behavioural change. Clients that inspect
-all response headers may begin to see `Deprecation: true` on responses they
-were already getting; the field still filters correctly so no observable
-behaviour changes. The `paginated()` extension is additive at the API level —
-no existing call site needs to pass the new options object.
+**Rationale.** The codebase uses **Zod v4.4.3**, whose `.meta()` method stores
+metadata in the `globalRegistry`. `zod-openapi` v5.4.6 (pulled in transitively
+by `hono-openapi@1.3.0`) reads from this same `globalRegistry` during OpenAPI
+generation. Adding `.meta({ deprecated: true })` makes the deprecation visible
+in the generated OpenAPI spec's parameter/schema objects. The JSDoc
+`@deprecated` tag provides TypeScript editor strikethrough for developers
+consuming the schema directly. Both are needed because they serve different
+toolchains:
 
-There is no migration step, no feature flag, and no rollout sequencing
-beyond "land D12 first" (a hard dependency documented in the proposal).
+| Mechanism | Visible to |
+| --- | --- |
+| JSDoc `@deprecated` | TypeScript language server (editor strikethrough) |
+| `.meta({ deprecated: true })` | `zod-openapi` → `hono-openapi` → OpenAPI spec |
 
-### Decision 9: Test strategy — focused service tests + optional controller test
+The `RecipeFilterCriteria` interface in `model.ts:73` already has a JSDoc
+`@deprecated` tag — D28 brings the public Zod schema to the same level and
+adds the `.meta()` for OpenAPI visibility.
+
+Note: because the `/recipes` route's `describeRoute` `parameters` array is
+the sole source of documented query parameters ( `zValidator` does not
+auto-generate OpenAPI parameters — see Codebase facts), the `deprecated:
+true` flag on the OpenAPI `ParameterObject` in the `parameters` array is
+also needed for full OpenAPI visibility. The `.meta()` on the Zod schema is
+belt-and-suspenders for any consumer that introspects the schema directly.
+
+### Decision 10: OpenAPI `describeRoute` is updated (mandatory per AGENTS.md)
+
+**Rationale.** AGENTS.md mandates: _"Every new route (or change to a route's
+request/response shape) MUST include OpenAPI metadata."_ Adding a
+`Deprecation` response header changes the response shape. Both routes'
+`describeRoute` blocks must:
+
+1. Add `tasteNoteId` (with `deprecated: true`) and `tasteNoteIds` to the
+   `parameters` array — currently neither filter parameter is documented.
+2. Declare the `Deprecation` response header on the `200` response via
+   `headers: { Deprecation: { schema: { type: 'string' } } }`.
+
+The OpenAPI coverage test (`openapi.coverage.test.ts`) is purely spec-driven
+and does not inspect response headers, so this addition will not affect the
+test. But the AGENTS.md convention requires it regardless.
+
+### Decision 11: Test strategy — focused service tests + controller-level header test
 
 **Rationale.** Four deprecation cases need coverage:
 
-| Case                                                  | Expected behaviour                                        |
-| ----------------------------------------------------- | --------------------------------------------------------- |
-| `tasteNoteId` set, `tasteNoteIds` not set             | `deprecations.tasteNoteId === true`; header on response   |
-| `tasteNoteIds` set, `tasteNoteId` not set             | `deprecations.tasteNoteId` is `undefined` or `false`      |
-| Both set (plural wins per existing `else if`)         | `deprecations.tasteNoteId` is `undefined` or `false`      |
-| Neither set                                           | `deprecations.tasteNoteId` is `undefined` or `false`      |
+| Case | Expected behaviour |
+| --- | --- |
+| `tasteNoteId` set, `tasteNoteIds` not set | `deprecations.tasteNoteId === true`; header on response |
+| `tasteNoteIds` set, `tasteNoteId` not set | `deprecations.tasteNoteId` is `undefined` or absent |
+| Both set (plural wins per existing `else if`) | `deprecations.tasteNoteId` is `undefined` or absent |
+| Neither set | `deprecations.tasteNoteId` is `undefined` or absent |
 
 These are added to a new file
 `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts`. Putting
@@ -260,49 +369,77 @@ them in a dedicated file (rather than extending `model.test.ts` from D12)
 keeps the deprecation concern grouped for easy removal when Phase 2 lands —
 deleting one file is cleaner than picking scenarios out of a shared file.
 
-An optional Hono-test-client integration test asserts the
-`Deprecation: true` header is present on
-`GET /api/v1/recipes?tasteNoteId=<uuid>` and absent on
-`GET /api/v1/recipes?tasteNoteIds=<uuid>`. This crosses the
-service → controller boundary that the unit tests cover separately, but is
-optional because the boundary is exercised manually via the controller diff
-review.
+The service-level tests follow the existing mock pattern from
+`service.preservation.test.ts` (hand-rolled Drizzle-like stubs, mock
+`model.findMany` / `model.findStarred`). The controller-level test uses
+Hono's `app.request(...)` pattern (no `hono/testing` import — the codebase
+uses the built-in instance method) to assert the `Deprecation: true` header
+is present on `GET /api/v1/recipes?tasteNoteId=<uuid>` and absent on
+`GET /api/v1/recipes?tasteNoteIds=<uuid>`. A cursor-mode test asserts the
+header is also present when `cursor` is used with the singular parameter.
 
-### Decision 10: Data-flow diagram
+The response-helper test (`response.test.ts`) is extended to assert that
+`paginated(c, data, meta, { headers: { Deprecation: 'true' } })` and
+`cursorPaginated(c, data, meta, { headers: { Deprecation: 'true' } })`
+correctly set the header via `c.header()`.
+
+### Decision 12: Data-flow diagram
 
 ```text
 +---------------------------+
 | GET /api/v1/recipes       |
 | ?tasteNoteId=<uuid>       |
+| [&cursor=...&sortBy=      |
+|  createdAt]              |
 +-------------+-------------+
               |
               v
 +---------------------------+        +---------------------------+
-| index.ts:42-55            |        | index.ts:72-82            |
-| (recipes controller)      |        | (starred controller)      |
+| index.ts:73-107           |        | index.ts:124-134          |
+| (/recipes controller)    |        | (/starred controller)     |
+|                           |        |                           |
+| requestId = c.get(        |        | requestId = c.get(        |
+|   'requestId')            |        |   'requestId')            |
 +-------------+-------------+        +-------------+-------------+
               |                                    |
               v                                    v
 +---------------------------+        +---------------------------+
-| service.ts:listRecipes    |        | model.ts:findStarred      |
-|                           |        |  (after D12)              |
-|   if (!tasteNoteIds       |        |   if (!tasteNoteIds       |
-|        && tasteNoteId) {  |        |        && tasteNoteId) {  |
-|     deprecations          |        |     deprecations          |
-|       .tasteNoteId = true |        |       .tasteNoteId = true |
-|     log.warn(...)         |        |     log.warn(...)         |
-|   }                       |        |   }                       |
+| service.ts:listRecipes    |        | service.ts:               |
+| (lines 492-568)           |        |  listStarredRecipes       |
+|                           |        |  (lines 583-596)          |
+| if (!tasteNoteIds &&      |        |                           |
+|     tasteNoteId) {        |        | if (!tasteNoteIds &&      |
+|   deprecations            |        |     tasteNoteId) {        |
+|     .tasteNoteId = true  |        |   deprecations            |
+|   logger.warn(            |        |     .tasteNoteId = true  |
+|     {filter,userId,       |        |   logger.warn(            |
+|      requestId},          |        |     {filter,userId,       |
+|     'Deprecated...')      |        |      requestId},          |
+| }                         |        |     'Deprecated...')      |
+|                           |        | }                         |
+| returns { ...result,      |        | returns { ...result,      |
+|   ...(dep.tasteNoteId ?   |        |   ...(dep.tasteNoteId ?   |
+|     {deprecations}:{}) }  |        |     {deprecations}:{}) }  |
 +-------------+-------------+        +-------------+-------------+
               |                                    |
-              | { recipes, total,                  | { recipes, total,
-              |   deprecations? }                  |   deprecations? }
+              | { recipes, total,                   | { recipes, total,
+              |   deprecations? }                   |   deprecations? }
+              |   OR                                |
+              | { recipes, hasMore,                 |
+              |   nextCursor, total?,                |
+              |   deprecations? }                   |
               v                                    v
 +----------------------------------------------------+
 | controller checks                                  |
 |   result.deprecations?.tasteNoteId === true        |
-| -> calls paginated(c, data, meta, {                |
-|      headers: { Deprecation: 'true' }              |
-|    })                                              |
+| -> depHeaders = { headers: { Deprecation: 'true' } |
+|                                                    |
+| /recipes: passes depHeaders to BOTH                |
+|   cursorPaginated(c, ..., depHeaders)              |
+|   paginated(c, ..., depHeaders)                    |
+|                                                    |
+| /starred: passes depHeaders to                    |
+|   paginated(c, ..., depHeaders)                   |
 +-------------+--------------------------------------+
               |
               v
@@ -314,9 +451,10 @@ review.
 +---------------------------+
 ```
 
-The service / model layer never touches HTTP plumbing; the controller never
-re-derives the precedence check. The `deprecations` discriminator is the only
-contract between them.
+The service layer never touches HTTP plumbing; the controller never
+re-derives the precedence check. The `deprecations` discriminator is the
+only contract between them. The `buildRecipeFilters` helper in `model.ts`
+is untouched — it remains a pure `SQL[]`-returning function.
 
 ## Risks / Trade-offs
 
@@ -336,37 +474,46 @@ contract between them.
   know), but it means the deprecation could remain in Phase 1 indefinitely
   if telemetry shows no callers — which is fine, the header is a no-op for
   conforming clients.
+- **Two response helpers extended.** Extending both `paginated` and
+  `cursorPaginated` doubles the surface area of the response-helper change.
+  Mitigation: the extension is identical for both (a 3-line loop) and is
+  purely additive.
 
 ## Migration Plan
 
 This is a pure backend additive change — no data migration, no feature flag,
-no deploy sequencing beyond the D12 dependency.
+no deploy sequencing.
 
-1. **Rebase on D12** so that `findStarred` already honours the singular
-   `tasteNoteId`. If D12 has not merged yet, sequence D28 to merge after.
-2. **Extend `paginated()`** in `apps/api/src/utils/response/index.ts` with
-   the optional `{ headers }` argument. `make check-api` must pass.
-3. **Add the `deprecations` field** to the service / model return shapes,
-   detect the deprecated parameter, emit the `warn` log. `make check-api`
-   and `make test-api` must pass.
-4. **Update both controllers** in `apps/api/src/modules/recipe/index.ts` to
-   pass the optional `{ headers }` argument when the flag is set.
-   `make check-api` must pass.
-5. **Annotate the schema** in `packages/shared/src/schemas/recipe.ts` and
-   **update `docs/api.md`**.
-6. **Add the deprecation test file** and run
-   `make test-specific filter=apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts`.
+1. **Extend `paginated()` and `cursorPaginated()`** in
+   `apps/api/src/utils/response/index.ts` with the optional `{ headers }`
+   argument. `make check-api` must pass.
+2. **Add the `deprecations` detection + `warn` log** to
+   `service.listRecipes` and `service.listStarredRecipes`, including the
+   new `requestId?: string` parameter. `make check-api` and `make test-api`
+   must pass.
+3. **Update both controllers** in `apps/api/src/modules/recipe/index.ts` to
+   pass `requestId`, check the flag, and pass headers to both
+   `cursorPaginated` and `paginated` ( `/recipes`) or `paginated` only
+   (`/starred`). `make check-api` must pass.
+4. **Update `describeRoute` metadata** on both routes to add
+   `tasteNoteId`/`tasteNoteIds` parameters and the `Deprecation` response
+   header declaration.
+5. **Annotate the schema** in `packages/shared/src/schemas/recipe.ts` with
+   JSDoc `@deprecated` + `.meta({ deprecated: true })` and **update
+   `docs/api.md`**.
+6. **Add the deprecation test file** and extend the response-helper test.
 7. **Final verification** — `make check-api`, `make lint`, `make test-api`.
 
 ### Rollback
 
 A single `git revert` of the merge commit removes the header, the log line,
-the return-shape flag, the controller diff, the JSDoc tag, and the docs note
-atomically. No database state to undo.
+the return-shape flag, the controller diff, the `describeRoute` updates, the
+JSDoc tag, the `.meta()` call, and the docs note atomically. No database
+state to undo.
 
 ## Open Questions
 
 - **None blocking.** Whether to set a `Sunset` date is a Phase 2 decision and
-  is intentionally deferred. Whether to add a controller-level integration
-  test (over and above the service-level unit tests) is left to the
-  implementer's discretion.
+  is intentionally deferred. Whether to optionally replace the inline
+  anonymous filter type in `findStarred` with `RecipeFilterCriteria` is left
+  to the implementer's discretion.

--- a/openspec/changes/d28-remove-deprecated-taste-note-id/proposal.md
+++ b/openspec/changes/d28-remove-deprecated-taste-note-id/proposal.md
@@ -7,16 +7,17 @@ comment since the plural was introduced, but the deprecation lives only in the
 source — the API gives no runtime signal to callers that the parameter is on
 its way out.
 
-The backend honours the singular form via an `else if` branch in
-`apps/api/src/modules/recipe/service.ts:544-551` (inside `listRecipes`).
-Until D12 (separate change, in progress) lands, the same branch is missing
-from `apps/api/src/modules/recipe/model.ts:findStarred`. D12 fixes that parity
-gap. D12's `design.md:90` explicitly defers the deprecation cycle itself:
+D12 (recipe-filter-logic, merged and archived) extracted the shared
+`buildRecipeFilters` helper into `apps/api/src/modules/recipe/model.ts:83-179`
+and closed the parity gap between the `/recipes` and `/recipes/starred`
+endpoints. Both now honour the singular `tasteNoteId` via the same
+`else if (filters.tasteNoteId)` branch inside `buildRecipeFilters`
+(`model.ts:167-176`). D12 explicitly deferred the deprecation cycle itself:
 _"No removal of the deprecated `tasteNoteId` — that's a separate API
 deprecation cycle."_ This change is that cycle.
 
-None of D01-D11 plan the deprecation work either. With D12 closing the parity
-gap, the next required step is the deprecation signal: clients need a
+None of the earlier plans (D01–D11) address the deprecation work either. With
+D12 merged, the next required step is the deprecation signal: clients need a
 standards-aligned indicator so they can migrate before removal, and operations
 needs telemetry so they can decide when removal is safe. Today there is
 neither.
@@ -32,36 +33,60 @@ and deferred its removal to a separate plan rather than bundling the breakage.
 
 - Add an optional `deprecations?: { tasteNoteId?: boolean }` field to the
   return shapes of `apps/api/src/modules/recipe/service.ts:listRecipes` and
-  `apps/api/src/modules/recipe/model.ts:findStarred` (the latter once D12
-  has landed). The flag is set to `true` only when `tasteNoteId` is provided
-  **and** `tasteNoteIds` is absent — matching the existing `else if`
-  precedence so the plural form continues to take priority silently.
-- Emit a structured `warn` log line at the same point: `log.warn({ filter:
-  'tasteNoteId', userId, requestId }, 'Deprecated query parameter used')`.
-  No payload, no PII, traceable IDs only — per AGENTS.md logging rules.
-- Extend `paginated()` in `apps/api/src/utils/response/index.ts` to accept an
-  optional `{ headers?: Record<string, string> }` argument so the controller
-  layer can set arbitrary response headers without leaking HTTP plumbing into
-  the service layer. This is purely additive — all existing call sites work
-  unchanged.
-- Update both recipe controllers in `apps/api/src/modules/recipe/index.ts`
-  (lines 42-55 for `/recipes`, lines 72-82 for `/recipes/starred`) to check
-  `result.deprecations?.tasteNoteId === true` and pass
-  `{ headers: { Deprecation: 'true' } }` to `paginated()`. The `Deprecation:
-  true` header follows [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594).
-  No `Sunset` date is set in Phase 1 — that decision belongs to Phase 2.
-- Add a JSDoc `@deprecated` tag to the `tasteNoteId` field in
-  `packages/shared/src/schemas/recipe.ts:134-135` so generated TypeScript /
-  OpenAPI consumers see the deprecation in their toolchain.
+  `apps/api/src/modules/recipe/service.ts:listStarredRecipes`. The flag is set
+  to `true` only when `tasteNoteId` is provided **and** `tasteNoteIds` is
+  absent — matching the existing `else if` precedence in `buildRecipeFilters`
+  so the plural form continues to take priority silently. The detection
+  lives in the service layer (not in `buildRecipeFilters`, which is a pure
+  `SQL[]`-returning helper with no logger).
+- Emit a structured `warn` log line at the same point:
+  `logger.warn({ filter: 'tasteNoteId', userId, requestId }, 'Deprecated
+  query parameter used')`. No payload, no PII, traceable IDs only — per
+  AGENTS.md logging rules. `requestId` is plumbed through from the controller
+  via a new optional parameter on both service functions (the service layer
+  has no Hono context access today).
+- Extend both `paginated()` and `cursorPaginated()` in
+  `apps/api/src/utils/response/index.ts` to accept an optional
+  `{ headers?: Record<string, string> }` argument so the controller layer can
+  set arbitrary response headers without leaking HTTP plumbing into the
+  service layer. This is purely additive — all existing call sites work
+  unchanged. **Both** helpers must be extended because the `/recipes`
+  controller has a two-branch return (cursor mode via `cursorPaginated` at
+  `index.ts:87`, offset mode via `paginated` at `index.ts:94`); extending
+  only `paginated` would silently drop the header in cursor mode.
+- Update both recipe controllers in `apps/api/src/modules/recipe/index.ts`:
+  - `/recipes` handler (lines 73-107): pass `requestId` to the service,
+    check `result.deprecations?.tasteNoteId === true`, and pass
+    `{ headers: { Deprecation: 'true' } }` to **both** the `cursorPaginated`
+    and `paginated` branches.
+  - `/starred` handler (lines 124-134): same pattern, `paginated` only.
+  - The `Deprecation: true` header follows [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594).
+    No `Sunset` date is set in Phase 1 — that decision belongs to Phase 2.
+- Update the `describeRoute` metadata on both routes (per AGENTS.md's
+  mandatory OpenAPI rule) to:
+  1. Add `tasteNoteId` (with `deprecated: true`) and `tasteNoteIds` to the
+     `parameters` array — currently neither is documented in the OpenAPI spec.
+  2. Declare the `Deprecation` response header on the `200` response.
+- Add a JSDoc `@deprecated` tag and a Zod `.meta({ deprecated: true })` call
+  to the `tasteNoteId` field in `packages/shared/src/schemas/recipe.ts:134-135`.
+  The codebase uses Zod v4 (`zod@4.4.3`), whose `.meta()` method stores metadata
+  in the `globalRegistry` that `zod-openapi` v5 (pulled in by `hono-openapi`)
+  reads during OpenAPI generation — making the deprecation visible in
+  generated OpenAPI types. The JSDoc tag provides TypeScript editor strikethrough.
+  Note: `RecipeFilterCriteria` in `model.ts:73` already has a `@deprecated`
+  JSDoc tag — D28 brings the public Zod schema to the same level.
 - Update the documentation row for `tasteNoteId` in `docs/api.md:234` to add
   a "Will be removed in a future release" note and link to the OpenSpec
   change folder for D28.
 - Add a new test file
   `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts` covering
   the four deprecation cases (singular only → flag set; plural only → no
-  flag; both → no flag; neither → no flag) and, optionally, a controller-
-  level test that asserts the `Deprecation: true` header is present on the
-  response when the singular parameter is used.
+  flag; both → no flag; neither → no flag) for both `listRecipes` and
+  `listStarredRecipes`, plus a controller-level test asserting the
+  `Deprecation: true` header is present on the response when the singular
+  parameter is used (both offset and cursor modes).
+- Add a test for the `paginated()` / `cursorPaginated()` `headers` option in
+  `apps/api/src/utils/response/response.test.ts`.
 
 No filter semantics change. No SQL changes. No schema field added or removed.
 No breaking change for any client — the new header is additive and clients
@@ -80,10 +105,13 @@ that do not inspect it see no difference.
   1. When the deprecated singular `tasteNoteId` is the parameter that
      actually drove the query (i.e., set without `tasteNoteIds`), the API
      SHALL emit an RFC 8594 `Deprecation: true` HTTP response header and a
-     structured `warn` log line.
+     structured `warn` log line. The header SHALL be emitted on **both**
+     offset-paginated and cursor-paginated responses.
   2. The `RecipeFilterSchema.tasteNoteId` field SHALL carry a JSDoc
-     `@deprecated` tag pointing to `tasteNoteIds` and referencing D28.
-  3. A new test file SHALL cover the four deprecation cases.
+     `@deprecated` tag and Zod `.meta({ deprecated: true })` metadata
+     referencing `tasteNoteIds` and D28.
+  3. A new test file SHALL cover the four deprecation cases for both
+     endpoints, plus a controller-level header assertion.
 
   D28 also modifies one D12 requirement (the deprecated-singular behaviour
   scenario) to add the response-header obligation; the SQL behaviour itself

--- a/openspec/changes/d28-remove-deprecated-taste-note-id/specs/recipe-filter/spec.md
+++ b/openspec/changes/d28-remove-deprecated-taste-note-id/specs/recipe-filter/spec.md
@@ -2,40 +2,62 @@
 
 ### Requirement: Deprecation signal for singular `tasteNoteId`
 
-When a request to `GET /api/v1/recipes` or `GET /api/v1/recipes/starred`
-supplies the deprecated singular `tasteNoteId` query parameter **and** does
-not supply the canonical plural `tasteNoteIds`, the API response SHALL
-include an [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594) `Deprecation:
-true` HTTP response header. The API SHALL also emit exactly one structured
-`warn` log entry per such request, shaped as
+The API SHALL emit an [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594)
+`Deprecation: true` HTTP response header and exactly one structured `warn`
+log entry when a request to `GET /api/v1/recipes` or
+`GET /api/v1/recipes/starred` supplies the deprecated singular `tasteNoteId`
+query parameter **and** does not supply the canonical plural `tasteNoteIds`.
+The log entry SHALL be shaped as
 `{ filter: 'tasteNoteId', userId, requestId }`. No additional fields (and
 specifically no payload or PII) SHALL be logged.
 
 When the plural `tasteNoteIds` is supplied — whether on its own or alongside
 the singular — the plural form takes precedence per the existing `else if`
-filter branch, and the API SHALL NOT emit the `Deprecation` header and SHALL
-NOT emit the `warn` log entry. This preserves the precedence contract
-established by `apps/api/src/modules/recipe/service.ts:544-551` and by D12's
-`buildRecipeFilters` helper.
+filter branch in `buildRecipeFilters` (`apps/api/src/modules/recipe/model.ts:
+167-176`), and the API SHALL NOT emit the `Deprecation` header and SHALL NOT
+emit the `warn` log entry. This preserves the precedence contract
+established by D12's `buildRecipeFilters` helper.
 
 The header value SHALL be the literal token `true`. The API SHALL NOT set a
 `Sunset` companion header in Phase 1; the removal-date commitment that a
 `Sunset` value implies belongs to Phase 2 / D29+.
 
-The detection of the deprecated parameter SHALL live in the service / model
-layer (the same layer that owns the `else if` branch), surfaced to the
-controller via an optional `deprecations?: { tasteNoteId?: boolean }` field
-on the listing return shape. The controller SHALL NOT re-derive the
-precedence check; it SHALL set the header only when
-`result.deprecations?.tasteNoteId === true`.
+The `Deprecation` header SHALL be emitted on **both** offset-paginated
+responses (via `paginated()`) and cursor-paginated responses (via
+`cursorPaginated()`). The `/recipes` controller has a two-branch return
+(`index.ts:86-99`); both branches must check the deprecation flag and pass
+the header. Extending only `paginated()` would silently drop the header in
+cursor mode.
 
-#### Scenario: Singular parameter returns Deprecation header
+The detection of the deprecated parameter SHALL live in the service layer
+(`service.ts:listRecipes` and `service.ts:listStarredRecipes`), which is
+the layer that owns the `logger` and the return shape. The
+`buildRecipeFilters` helper in `model.ts` SHALL NOT be modified to emit logs
+or side effects — it is a pure `SQL[]`-returning data-access function (per
+`model.ts:2-4`). The controller SHALL NOT re-derive the precedence check; it
+SHALL set the header only when `result.deprecations?.tasteNoteId === true`.
+
+The `requestId` included in the log entry SHALL be obtained from the Hono
+context (`c.get('requestId')`) in the controller and plumbed through to the
+service via a new optional `requestId?: string` parameter on both
+`listRecipes` and `listStarredRecipes`.
+
+#### Scenario: Singular parameter returns Deprecation header (offset mode)
 
 - **WHEN** a client sends `GET /api/v1/recipes?tasteNoteId=<uuid>` (no
-  `tasteNoteIds` set)
+  `tasteNoteIds` set, no `cursor`)
 - **THEN** the response status is `200`, the response includes the header
   `Deprecation: true`, and exactly one `warn` log entry is emitted with
   `{ filter: 'tasteNoteId', userId, requestId }`
+
+#### Scenario: Singular parameter returns Deprecation header (cursor mode)
+
+- **WHEN** a client sends
+  `GET /api/v1/recipes?tasteNoteId=<uuid>&cursor=<cursor>&sortBy=createdAt`
+- **THEN** the response status is `200`, the response includes the header
+  `Deprecation: true` (set via the `cursorPaginated` branch), and exactly
+  one `warn` log entry is emitted with `{ filter: 'tasteNoteId', userId,
+  requestId }`
 
 #### Scenario: Plural parameter does not return Deprecation header
 
@@ -50,8 +72,9 @@ precedence check; it SHALL set the header only when
   `GET /api/v1/recipes?tasteNoteIds=<uuid-1>&tasteNoteId=<uuid-2>`
 - **THEN** the response status is `200`, the query filter is applied using
   the plural `tasteNoteIds` only (matching the `else if` precedence
-  established by D12), no `Deprecation` header is set, and no deprecation
-  `warn` log entry is emitted
+  established by `buildRecipeFilters` in `model.ts:155-176`), no
+  `Deprecation` header is set, and no deprecation `warn` log entry is
+  emitted
 
 #### Scenario: Neither parameter set — no Deprecation header
 
@@ -65,32 +88,79 @@ precedence check; it SHALL set the header only when
   instead of `GET /api/v1/recipes` (with appropriate auth)
 - **THEN** the same `Deprecation` header and `warn` log behaviour applies on
   the starred endpoint, because both controllers consume the same
-  `deprecations` flag on the service / model return shape
+  `deprecations` flag on the service return shape. The starred endpoint
+  uses offset pagination only (no cursor branch).
 
-#### Scenario: Detection lives in service / model, not the controller
+#### Scenario: Detection lives in service, not in controller or buildRecipeFilters
 
-- **WHEN** the implementation of `apps/api/src/modules/recipe/index.ts:42-55`
-  and `apps/api/src/modules/recipe/index.ts:72-82` is inspected
+- **WHEN** the implementation of `apps/api/src/modules/recipe/index.ts`
+  (lines 73-107 and 124-134) is inspected
 - **THEN** neither controller contains a reference to `filters.tasteNoteId`;
   both controllers determine whether to set the `Deprecation` header solely
   by checking `result.deprecations?.tasteNoteId === true`
 
+#### Scenario: buildRecipeFilters remains side-effect-free
+
+- **WHEN** the implementation of `buildRecipeFilters` in
+  `apps/api/src/modules/recipe/model.ts:83-179` is inspected
+- **THEN** it contains no `logger.warn` call, no `deprecations` field, and
+  no side effect — it remains a pure function returning `SQL[]`
+
+### Requirement: Both response helpers accept optional headers
+
+Both `paginated<T>()` and `cursorPaginated<T>()` SHALL accept an optional fourth argument `options?: { headers?: Record<string, string> }` in `apps/api/src/utils/response/index.ts`. When provided, the headers SHALL be applied via `c.header(name, value)` before `c.json()` is called. The extension SHALL be purely additive — every existing call site that passes only three arguments SHALL continue to work unchanged.
+
+#### Scenario: paginated with headers option
+
+- **WHEN** `paginated(c, data, meta, { headers: { Deprecation: 'true' } })`
+  is called
+- **THEN** the response includes the header `Deprecation: true` and the
+  response body is the standard `{ success, data, meta }` envelope
+
+#### Scenario: cursorPaginated with headers option
+
+- **WHEN** `cursorPaginated(c, data, cursorMeta, { headers: { Deprecation:
+  'true' } })` is called
+- **THEN** the response includes the header `Deprecation: true` and the
+  response body is the standard `{ success, data, meta: { cursor } }` envelope
+
+#### Scenario: Existing call sites unchanged
+
+- **WHEN** any existing `paginated(c, data, pagination)` or
+  `cursorPaginated(c, data, cursorMeta)` call site (passing only three
+  arguments) is invoked
+- **THEN** the response is identical to before — no headers are set, no
+  error is raised, the fourth argument defaults to `undefined`
+
 ### Requirement: Schema annotation for `tasteNoteId`
 
-The `RecipeFilterSchema.tasteNoteId` field in
-`packages/shared/src/schemas/recipe.ts` SHALL carry a JSDoc `@deprecated` tag
-that names the canonical replacement (`tasteNoteIds`) and references the D28
-change folder. The annotation SHALL be visible to TypeScript and OpenAPI
-consumers via the existing toolchain (i.e., it SHALL be a real `@deprecated`
-JSDoc tag, not only an inline comment).
+The `RecipeFilterSchema.tasteNoteId` field SHALL carry a JSDoc `@deprecated`
+tag and a Zod `.meta({ deprecated: true })` call in
+`packages/shared/src/schemas/recipe.ts`. The JSDoc tag SHALL name the
+canonical replacement (`tasteNoteIds`) and reference the D28 change folder.
+The `.meta({ deprecated: true })` call SHALL make the deprecation visible to
+`zod-openapi` v5 (pulled in by `hono-openapi`) in the generated OpenAPI
+document.
+
+The annotations SHALL be visible to TypeScript (editor strikethrough via
+JSDoc) and OpenAPI consumers ( `deprecated: true` in the schema/parameter
+object via `.meta()`). The inline `//` comment may be removed or retained
+alongside the JSDoc tag.
 
 #### Scenario: Schema field carries @deprecated JSDoc tag
 
 - **WHEN** the source of `packages/shared/src/schemas/recipe.ts` is inspected
   at the `tasteNoteId` field declaration (currently lines 134-135)
-- **THEN** the field's JSDoc block contains an `@deprecated` tag, the prose
-  references `tasteNoteIds` as the replacement, and the prose names the D28
-  OpenSpec change
+- **THEN** the field has a JSDoc block containing an `@deprecated` tag, the
+  prose references `tasteNoteIds` as the replacement, and the prose names
+  the D28 OpenSpec change
+
+#### Scenario: Schema field carries .meta({ deprecated: true })
+
+- **WHEN** the source of `packages/shared/src/schemas/recipe.ts` is inspected
+  at the `tasteNoteId` field declaration
+- **THEN** the field's Zod chain includes `.meta({ deprecated: true })` (or
+  `.meta({ deprecated: true, ... })` with additional metadata)
 
 #### Scenario: Deprecation visible to generated consumers
 
@@ -100,6 +170,36 @@ JSDoc tag, not only an inline comment).
 - **THEN** the `tasteNoteId` field is reported as deprecated by the
   toolchain (e.g., editor strikethrough on `RecipeFilterSchema.shape.tasteNoteId`,
   or `deprecated: true` in the OpenAPI parameter description)
+
+### Requirement: OpenAPI metadata for deprecated parameter and Deprecation header
+
+The `describeRoute` metadata on both the `/recipes` route and the `/recipes/starred` route SHALL add `tasteNoteId` (with `deprecated: true`) and `tasteNoteIds` to the `parameters` array. The `tasteNoteId` parameter entry SHALL include `deprecated: true` and a description pointing to `tasteNoteIds` as the replacement and referencing D28. Both routes SHALL declare the `Deprecation` response header on the `200` response via `headers: { Deprecation: { schema: { type: 'string' }, description: '...' } }`.
+
+This is mandatory per AGENTS.md: _"Every new route (or change to a route's
+request/response shape) MUST include OpenAPI metadata."_
+
+#### Scenario: tasteNoteId documented as deprecated in OpenAPI parameters
+
+- **WHEN** the `describeRoute` parameters array of the `/recipes` route
+  ( `index.ts:42-49`) is inspected
+- **THEN** it contains an entry for `tasteNoteId` with `deprecated: true`
+  and an entry for `tasteNoteIds`, both with appropriate `schema` and
+  `description` fields
+
+#### Scenario: Deprecation header declared in OpenAPI response
+
+- **WHEN** the `describeRoute` `200` response of the `/recipes` route is
+  inspected
+- **THEN** it declares a `Deprecation` header with a `schema` of type
+  `string` and a description referencing RFC 8594
+
+#### Scenario: Starred route metadata updated
+
+- **WHEN** the `describeRoute` parameters array and `200` response of the
+  `/starred` route (`index.ts:112-121`) is inspected
+- **THEN** it also contains the `tasteNoteId` (deprecated) and
+  `tasteNoteIds` parameter entries and the `Deprecation` response header
+  declaration
 
 ### Requirement: Test coverage for the deprecation cases
 
@@ -115,46 +215,75 @@ the four deprecation cases:
 4. Neither set → no flag, no header
 
 The same four cases SHALL be exercised against both `listRecipes` and
-`findStarred` (or `listStarredRecipes`) so that parity between the two
-endpoints established by D12 is preserved by D28.
+`listStarredRecipes` so that parity between the two endpoints established by
+D12 is preserved by D28.
 
-An optional controller-level smoke test MAY use Hono's test client to assert
-the presence (or absence) of the `Deprecation: true` HTTP header on a real
-request/response pair. This test is not required by the spec but is
-encouraged.
+A controller-level integration test SHALL use Hono's `app.request(...)` method
+to assert the presence (or absence) of the `Deprecation: true` HTTP header on
+a real request/response pair. This test SHALL cover:
 
-#### Scenario: Four service-level cases exist
+- `GET /api/v1/recipes?tasteNoteId=<uuid>` → header present
+- `GET /api/v1/recipes?tasteNoteIds=<uuid>` → header absent
+- `GET /api/v1/recipes?tasteNoteId=<uuid>&cursor=<...>&sortBy=createdAt` →
+  header present (exercises the `cursorPaginated` branch)
+
+The response-helper test file
+(`apps/api/src/utils/response/response.test.ts`) SHALL be extended to assert
+that `paginated()` and `cursorPaginated()` with the `{ headers }` option
+correctly call `c.header(name, value)` before responding.
+
+#### Scenario: Four service-level cases exist for listRecipes
 
 - **WHEN** `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts`
   is inspected
 - **THEN** it contains a `describe` block for `listRecipes` with one `it`
-  per case (singular-only, plural-only, both, neither) and a second
-  `describe` block for `findStarred` / `listStarredRecipes` with the same
-  four cases
+  per case (singular-only, plural-only, both, neither) asserting on
+  `result.deprecations?.tasteNoteId`
+
+#### Scenario: Four service-level cases exist for listStarredRecipes
+
+- **WHEN** the same test file is inspected
+- **THEN** it contains a second `describe` block for `listStarredRecipes`
+  with the same four cases
+
+#### Scenario: Controller-level header test exists
+
+- **WHEN** the test file is inspected
+- **THEN** it contains a `describe` block that uses `app.request(...)` to
+  assert the `Deprecation` header is present when `tasteNoteId` is used and
+  absent when `tasteNoteIds` is used, including a cursor-mode case
+
+#### Scenario: Response-helper test extended
+
+- **WHEN** `apps/api/src/utils/response/response.test.ts` is inspected
+- **THEN** it contains tests asserting that `paginated()` and
+  `cursorPaginated()` with `{ headers: { Deprecation: 'true' } }` set the
+  header on the response
 
 #### Scenario: Tests pass under `make test-api`
 
 - **WHEN** `make test-api` is invoked on a clean checkout that includes the
-  D28 changes (with D12 already merged)
+  D28 changes
 - **THEN** every test in
-  `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts` passes
-  and no pre-existing test regresses
+  `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts` and
+  `apps/api/src/utils/response/response.test.ts` passes and no pre-existing
+  test regresses
 
 ## MODIFIED Requirements
 
 ### Requirement: Deprecated `tasteNoteId` (singular) is honoured
 
-When `tasteNoteId` (singular) is provided AND `tasteNoteIds` (plural) is
-NOT, `buildRecipeFilters` SHALL generate a single taste-note condition
-equivalent to the legacy behaviour of `service.ts:listRecipes()`. When both
-`tasteNoteIds` and `tasteNoteId` are provided, the plural `tasteNoteIds`
-SHALL take precedence and `tasteNoteId` SHALL be ignored (matching the
-existing `else if` branch in `listRecipes`).
+`buildRecipeFilters` SHALL generate a single taste-note condition when
+`tasteNoteId` (singular) is provided AND `tasteNoteIds` (plural) is NOT.
+When both `tasteNoteIds` and `tasteNoteId` are provided, the plural
+`tasteNoteIds` SHALL take precedence and `tasteNoteId` SHALL be ignored
+(matching the existing `else if` branch in `buildRecipeFilters` at
+`model.ts:167-176`).
 
-This means `model.ts:findStarred()` — which previously dropped `tasteNoteId`
-silently — SHALL pick up the deprecated singular filter for free after the
-D12 refactor. This is an intentional parity fix against the public
-`RecipeFilterSchema` contract.
+This means `model.ts:findStarred()` — which previously dropped
+`tasteNoteId` silently — picks up the deprecated singular filter for free
+via the shared `buildRecipeFilters` helper (D12 parity fix). This is an
+intentional parity fix against the public `RecipeFilterSchema` contract.
 
 **MODIFIED by D28:** In addition to applying the filter, the API response
 for any request whose query used the deprecated singular `tasteNoteId`
@@ -162,7 +291,9 @@ without the plural `tasteNoteIds` SHALL include a `Deprecation: true` HTTP
 response header per the [Deprecation signal for singular `tasteNoteId`
 requirement above](#requirement-deprecation-signal-for-singular-tastenoteid).
 The SQL behaviour itself is unchanged; only the response headers and the
-service / model logging side-effect are added.
+service-layer logging side-effect are added. The detection lives in the
+service layer ( `listRecipes` / `listStarredRecipes`), not in
+`buildRecipeFilters` (which remains side-effect-free).
 
 #### Scenario: Singular tasteNoteId generates one condition
 
@@ -184,7 +315,7 @@ service / model logging side-effect are added.
 - **WHEN** a `GET /api/v1/recipes/starred?tasteNoteId=<uuid>` request is
   processed
 - **THEN** the resulting query includes the single-taste-note condition
-  (previously dropped silently on this endpoint)
+  (previously dropped silently on this endpoint, fixed by D12)
 
 #### Scenario: Singular tasteNoteId triggers Deprecation header (D28)
 
@@ -192,7 +323,7 @@ service / model logging side-effect are added.
   `GET /api/v1/recipes/starred?tasteNoteId=<uuid>` with auth) request is
   processed
 - **THEN** the SQL filter is applied as before AND the response includes
-  the `Deprecation: true` header AND the service / model layer emits a
+  the `Deprecation: true` header AND the service layer emits a
   `warn` log entry with `{ filter: 'tasteNoteId', userId, requestId }`
 
 #### Scenario: Plural tasteNoteIds does not trigger Deprecation header (D28)
@@ -201,3 +332,11 @@ service / model logging side-effect are added.
 - **THEN** the SQL filter is applied as before AND the response does NOT
   include the `Deprecation` header AND no deprecation `warn` log entry is
   emitted
+
+#### Scenario: Cursor mode preserves Deprecation header (D28)
+
+- **WHEN** a `GET /api/v1/recipes?tasteNoteId=<uuid>&cursor=<cursor>&sortBy=createdAt`
+  request is processed
+- **THEN** the response goes through the `cursorPaginated` branch AND still
+  includes the `Deprecation: true` header — the header is not silently
+  dropped in cursor mode

--- a/openspec/changes/d28-remove-deprecated-taste-note-id/tasks.md
+++ b/openspec/changes/d28-remove-deprecated-taste-note-id/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Extend `paginated()` and `cursorPaginated()` with optional `{ headers }` argument
 
-- [ ] 1.1 Open `apps/api/src/utils/response/index.ts`. Update the
+- [x] 1.1 Open `apps/api/src/utils/response/index.ts`. Update the
   `paginated()` function (currently lines 31-40) to accept an optional fourth
   argument `options?: { headers?: Record<string, string> }`. Apply the
   headers via `c.header(name, value)` before `c.json()`:
@@ -37,7 +37,7 @@
   }
   ```
 
-- [ ] 1.2 Update `cursorPaginated()` (currently lines 52-61) with the same
+- [x] 1.2 Update `cursorPaginated()` (currently lines 52-61) with the same
   optional `options` argument and the same header-application loop:
 
   ```ts
@@ -75,12 +75,12 @@
   }
   ```
 
-- [ ] 1.3 Run `make check-api` — must pass with zero new errors. The change
+- [x] 1.3 Run `make check-api` — must pass with zero new errors. The change
   is purely additive; no existing call site needs to change.
 
 ## 2. Add `deprecations` detection and `warn` log to `listRecipes`
 
-- [ ] 2.1 Open `apps/api/src/modules/recipe/service.ts`. Locate the
+- [x] 2.1 Open `apps/api/src/modules/recipe/service.ts`. Locate the
   `listRecipes` function (lines 492-568). Add `requestId?: string` as a new
   optional sixth parameter:
 
@@ -95,7 +95,7 @@
   ) {
   ```
 
-- [ ] 2.2 Inside `listRecipes`, after the `where` is assembled (line 504)
+- [x] 2.2 Inside `listRecipes`, after the `where` is assembled (line 504)
   and before the cursor/offset branching, add the deprecation detection:
 
   ```ts
@@ -109,7 +109,7 @@
   }
   ```
 
-- [ ] 2.3 Update **every return statement** in `listRecipes` to spread the
+- [x] 2.3 Update **every return statement** in `listRecipes` to spread the
   `deprecations` field when the flag is set. There are multiple return paths:
   - Line 528 (cursor fallback to offset when `sortBy !== 'createdAt'`):
     `return { ...result, ...(deprecations.tasteNoteId ? { deprecations } : {}) };`
@@ -123,12 +123,12 @@
   ```
   Then `return withDeprecations(result);` on each path.
 
-- [ ] 2.4 Run `make check-api` — must pass. The `logger.warn` call uses the
+- [x] 2.4 Run `make check-api` — must pass. The `logger.warn` call uses the
   existing `logger` at `service.ts:63` (`createLogger('recipe-service')`).
 
 ## 3. Add `deprecations` detection and `warn` log to `listStarredRecipes`
 
-- [ ] 3.1 Open `apps/api/src/modules/recipe/service.ts`. Locate
+- [x] 3.1 Open `apps/api/src/modules/recipe/service.ts`. Locate
   `listStarredRecipes` (lines 583-596). Add `requestId?: string` as a new
   optional fifth parameter:
 
@@ -142,7 +142,7 @@
   ) {
   ```
 
-- [ ] 3.2 Inside `listStarredRecipes`, before the call to
+- [x] 3.2 Inside `listStarredRecipes`, before the call to
   `model.findStarred`, add the deprecation detection (same logic as
   `listRecipes`):
 
@@ -157,7 +157,7 @@
   }
   ```
 
-- [ ] 3.3 Update the return statement (currently `return result;` at line
+- [x] 3.3 Update the return statement (currently `return result;` at line
   595) to spread the `deprecations` field:
 
   ```ts
@@ -167,13 +167,13 @@
   };
   ```
 
-- [ ] 3.4 Run `make check-api` and
+- [x] 3.4 Run `make check-api` and
   `make test-specific filter=apps/api/src/modules/recipe` — every existing
   test must continue to pass; no new ones yet.
 
 ## 4. Update the `/recipes` controller to pass `requestId` and set the `Deprecation` header
 
-- [ ] 4.1 Open `apps/api/src/modules/recipe/index.ts`. Locate the `/recipes`
+- [x] 4.1 Open `apps/api/src/modules/recipe/index.ts`. Locate the `/recipes`
   handler (lines 73-107). Inside the handler, read `requestId` from the
   context and pass it to `listRecipes`:
 
@@ -235,11 +235,11 @@
   `paginated` branches. Extending only `paginated` would silently drop the
   header in cursor mode.
 
-- [ ] 4.2 Run `make check-api` — must pass.
+- [x] 4.2 Run `make check-api` — must pass.
 
 ## 5. Update the `/recipes/starred` controller
 
-- [ ] 5.1 Locate the `/starred` handler (lines 124-134). Apply the same
+- [x] 5.1 Locate the `/starred` handler (lines 124-134). Apply the same
   pattern — read `requestId`, pass to `listStarredRecipes`, check flag,
   pass headers to `paginated`:
 
@@ -271,11 +271,11 @@
   },
   ```
 
-- [ ] 5.2 Run `make check-api` — must pass.
+- [x] 5.2 Run `make check-api` — must pass.
 
 ## 6. Update `describeRoute` OpenAPI metadata on both routes
 
-- [ ] 6.1 In the `/recipes` `describeRoute` (lines 37-70), add
+- [x] 6.1 In the `/recipes` `describeRoute` (lines 37-70), add
   `tasteNoteId` (with `deprecated: true`) and `tasteNoteIds` to the
   `parameters` array (currently lines 42-49, which only lists 6 params).
   Insert after the existing `includeTotal` entry:
@@ -306,7 +306,7 @@
   ],
   ```
 
-- [ ] 6.2 In the `/recipes` `describeRoute` `200` response (lines 50-64),
+- [x] 6.2 In the `/recipes` `describeRoute` `200` response (lines 50-64),
   add a `headers` field declaring the `Deprecation` header:
 
   ```ts
@@ -333,7 +333,7 @@
   },
   ```
 
-- [ ] 6.3 In the `/starred` `describeRoute` (lines 112-121), add the same
+- [x] 6.3 In the `/starred` `describeRoute` (lines 112-121), add the same
   `tasteNoteId` (deprecated) and `tasteNoteIds` parameter entries and the
   same `Deprecation` header declaration on the `200` response. Also add a
   typed `200` response schema (currently it's just a description string):
@@ -396,14 +396,14 @@
   untyped — AGENTS.md mandates `resolver(ErrorEnvelopeSchema)` for every
   documented error on auth-guarded routes).
 
-- [ ] 6.4 Run `make check-api` — must pass. Run
+- [x] 6.4 Run `make check-api` — must pass. Run
   `make test-specific filter=apps/api/src/routes/openapi.coverage.test.ts`
   — the coverage test should continue to pass (it does not inspect response
   headers, and `/api/v1/recipes` is not in `IN_SCOPE_BASE_PATHS`).
 
 ## 7. Add `@deprecated` JSDoc tag and `.meta({ deprecated: true })` to the schema field
 
-- [ ] 7.1 Open `packages/shared/src/schemas/recipe.ts` and locate lines
+- [x] 7.1 Open `packages/shared/src/schemas/recipe.ts` and locate lines
   134-135:
 
   ```ts
@@ -436,12 +436,12 @@
     visible in the generated OpenAPI spec.
   - The codebase uses Zod v4.4.3; `.meta()` is available on all Zod schemas.
 
-- [ ] 7.2 Run `make check` — must pass across all workspaces (the schema
+- [x] 7.2 Run `make check` — must pass across all workspaces (the schema
   is consumed by both API and web).
 
 ## 8. Update `docs/api.md`
 
-- [ ] 8.1 Open `docs/api.md` and locate line 234:
+- [x] 8.1 Open `docs/api.md` and locate line 234:
 
   ```
   | `tasteNoteId`  | —             | Single taste note UUID (deprecated, use tasteNoteIds)  |
@@ -461,7 +461,7 @@
 
 ## 9. Add `recipe-filter-deprecation.test.ts`
 
-- [ ] 9.1 Create
+- [x] 9.1 Create
   `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts` with
   the standard header (matching the convention from
   `apps/api/src/modules/recipe/service.preservation.test.ts`):
@@ -487,7 +487,7 @@
   import { expect } from 'jsr:@std/expect';
   ```
 
-- [ ] 9.2 Add the four service-level cases for `listRecipes`. Use the mock
+- [x] 9.2 Add the four service-level cases for `listRecipes`. Use the mock
   pattern from `service.preservation.test.ts` (hand-rolled Drizzle-like
   stubs + mock `model.findMany` that captures the WHERE clause). Since
   `listRecipes` calls `model.buildListRecipesWhere` (which calls
@@ -557,7 +557,7 @@
   (`!filters.tasteNoteIds && filters.tasteNoteId`) runs before any DB
   query, so even if the DB returns empty results the flag is still set.
 
-- [ ] 9.3 Mirror the same four cases for `listStarredRecipes`:
+- [x] 9.3 Mirror the same four cases for `listStarredRecipes`:
 
   ```ts
   describe('listStarredRecipes deprecation flag (D28)', () => {
@@ -572,7 +572,7 @@
   });
   ```
 
-- [ ] 9.4 Add a controller-level integration test using Hono's
+- [x] 9.4 Add a controller-level integration test using Hono's
   `app.request(...)` (following the pattern from
   `apps/api/src/modules/recipe/index_test.ts` — no `hono/testing` import;
   use a stub middleware that sets `requestId` / `userId` on context):
@@ -633,13 +633,13 @@
   correct behaviour — the error response is not the deprecated query's
   "success" response). Adjust the assertion based on what makes sense.
 
-- [ ] 9.5 Run
+- [x] 9.5 Run
   `make test-specific filter=apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts`
   — every new test must pass.
 
 ## 10. Extend `response.test.ts` with header-option tests
 
-- [ ] 10.1 Open `apps/api/src/utils/response/response.test.ts`. Add tests
+- [x] 10.1 Open `apps/api/src/utils/response/response.test.ts`. Add tests
   asserting that `paginated()` and `cursorPaginated()` with the `{ headers }`
   option correctly set the header on the response. Use the existing test
   pattern in this file (construct a mock `Context` or a minimal Hono app):
@@ -686,33 +686,33 @@
   Hono app pattern. Follow the same approach. The `CursorPaginationMeta`
   type requires `nextCursor` and `hasMore`; `total` is optional.
 
-- [ ] 10.2 Run
+- [x] 10.2 Run
   `make test-specific filter=apps/api/src/utils/response/response.test.ts`
   — must pass.
 
 ## 11. Final verification
 
-- [ ] 11.1 Run `make check-api` — zero type errors across all workspaces.
-- [ ] 11.2 Run `make lint` — zero warnings on:
+- [x] 11.1 Run `make check-api` — zero type errors across all workspaces.
+- [x] 11.2 Run `make lint` — zero warnings on:
   - `apps/api/src/utils/response/index.ts`
   - `apps/api/src/modules/recipe/service.ts`
   - `apps/api/src/modules/recipe/index.ts`
   - `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts`
   - `apps/api/src/utils/response/response.test.ts`
   - `packages/shared/src/schemas/recipe.ts`
-- [ ] 11.3 Run `make test-api` — every test in
+- [x] 11.3 Run `make test-api` — every test in
   `apps/api/src/modules/recipe/*.test.ts` and
   `apps/api/src/utils/response/response.test.ts` passes, including the new
   deprecation test file. No existing tests regress.
-- [ ] 11.4 Run
+- [x] 11.4 Run
   `make test-specific filter=apps/api/src/routes/openapi.coverage.test.ts`
   — the OpenAPI coverage test continues to pass.
-- [ ] 11.5 Manual smoke (optional): with the API running, hit
+- [x] 11.5 Manual smoke (optional): with the API running, hit
   `GET /api/v1/recipes?tasteNoteId=<any-uuid>` and confirm the response
   carries `Deprecation: true`. Hit
   `GET /api/v1/recipes?tasteNoteIds=<any-uuid>` and confirm it does not.
   Hit `GET /api/v1/recipes/openapi.json` and confirm the `tasteNoteId`
   parameter is listed with `deprecated: true`.
-- [ ] 11.6 Confirm the Phase 2 deprecation removal is left as a separate
+- [x] 11.6 Confirm the Phase 2 deprecation removal is left as a separate
   change. Do NOT remove the `tasteNoteId` field, the `buildRecipeFilters`
   branch, or the docs row in this PR.

--- a/openspec/changes/d28-remove-deprecated-taste-note-id/tasks.md
+++ b/openspec/changes/d28-remove-deprecated-taste-note-id/tasks.md
@@ -1,114 +1,20 @@
-## 1. Add `deprecations` field to `listRecipes` and `findStarred` return shapes
+## 1. Extend `paginated()` and `cursorPaginated()` with optional `{ headers }` argument
 
-- [ ] 1.1 Open `apps/api/src/modules/recipe/service.ts` and locate the
-  `listRecipes` function (lines 478-601). Add (or update) the explicit
-  return type to include the new optional `deprecations` discriminator:
-
-  ```ts
-  export interface ListRecipesResult {
-    recipes: Awaited<ReturnType<typeof model.findMany>>['recipes'];
-    total: number;
-    /**
-     * Per-request deprecation flags. Populated by the service when the
-     * request exercised a deprecated input. Controllers translate these
-     * into response headers (e.g., RFC 8594 `Deprecation`). The HTTP layer
-     * never reaches into the service to make this decision.
-     */
-    deprecations?: {
-      /**
-       * True when the request used the deprecated singular `tasteNoteId`
-       * (and not the plural `tasteNoteIds`). See D28.
-       */
-      tasteNoteId?: boolean;
-    };
-  }
-
-  export async function listRecipes(
-    filters: /* existing type */,
-    page: number,
-    perPage: number,
-    _requestingUserId: string | null,
-    isAdmin: boolean,
-  ): Promise<ListRecipesResult> {
-    // ... existing body ...
-  }
-  ```
-
-- [ ] 1.2 Open `apps/api/src/modules/recipe/model.ts` and locate
-  `findStarred` (after D12 lands, around lines 539-735). Add the same
-  optional `deprecations` field to its return shape. Either reuse the
-  `ListRecipesResult`-style interface from service (export and import) or
-  declare a local `FindStarredResult` interface — whichever matches D12's
-  final structure. Note: D28 depends on D12; if D12 is still in flight,
-  rebase D28 on top of it before this task.
-
-- [ ] 1.3 Run `make check-api` — must pass with zero new errors.
-
-## 2. Detect the deprecated parameter and emit the `warn` log
-
-- [ ] 2.1 In `apps/api/src/modules/recipe/service.ts:listRecipes`, locate
-  the existing `else if (filters.tasteNoteId)` branch at lines 544-551.
-  Immediately after the branch's `conditions.push(...)` block (still
-  inside the branch), add:
+- [ ] 1.1 Open `apps/api/src/utils/response/index.ts`. Update the
+  `paginated()` function (currently lines 31-40) to accept an optional fourth
+  argument `options?: { headers?: Record<string, string> }`. Apply the
+  headers via `c.header(name, value)` before `c.json()`:
 
   ```ts
-  // Inside listRecipes, after the deprecated-singular conditions.push:
-  } else if (filters.tasteNoteId) {
-    // Backward compatibility: single taste note filter
-    conditions.push(
-      inArray(
-        recipes.currentVersionId,
-        db.select({ id: recipeTasteNotes.recipeVersionId }).from(recipeTasteNotes).where(
-          eq(recipeTasteNotes.tasteNoteId, filters.tasteNoteId),
-        ),
-      ),
-    );
-    deprecations.tasteNoteId = true;
-    log.warn(
-      { filter: 'tasteNoteId', userId: _requestingUserId, requestId },
-      'Deprecated query parameter used',
-    );
-  }
-  ```
-
-  Declare `const deprecations: NonNullable<ListRecipesResult['deprecations']> = {};`
-  near the top of `listRecipes` (alongside the existing `conditions` /
-  `where` locals). Obtain `requestId` via the existing logger context if
-  available, otherwise via the request's `c.get('requestId')` plumbed
-  through — service-layer logging in this module already takes
-  `_requestingUserId` as an argument, so add `requestId?: string` as an
-  optional argument or read it from the existing log context already on
-  `log`.
-
-- [ ] 2.2 In the same function, change the return statement to include the
-  `deprecations` field only when at least one flag is set:
-
-  ```ts
-  return {
-    recipes: result.recipes,
-    total: result.total,
-    ...(deprecations.tasteNoteId ? { deprecations } : {}),
-  };
-  ```
-
-- [ ] 2.3 Mirror tasks 2.1 and 2.2 inside
-  `apps/api/src/modules/recipe/model.ts:findStarred` (after D12 has landed
-  and the `else if (filters.tasteNoteId)` branch exists there). The
-  detection logic, the log shape, and the return-shape augmentation are
-  identical.
-
-- [ ] 2.4 Run `make check-api` and
-  `make test-specific filter=apps/api/src/modules/recipe` — every existing
-  test must continue to pass; no new ones yet.
-
-## 3. Extend `paginated()` to accept optional response headers
-
-- [ ] 3.1 Open `apps/api/src/utils/response/index.ts` and update the
-  `paginated()` signature to accept an optional `{ headers }` argument.
-  Replace the existing definition (lines 30-40) with:
-
-  ```ts
-  /** Return a success envelope with pagination metadata and optional response headers. */
+  /**
+   * Return a success envelope with pagination metadata and optional response
+   * headers. Shorthand for success() with pagination.
+   *
+   * @param c - Hono request context.
+   * @param data - Items on the current page.
+   * @param pagination - Offset pagination metadata.
+   * @param options - Optional response headers (e.g., `Deprecation`).
+   */
   export function paginated<T>(
     c: Context,
     data: T[],
@@ -131,74 +37,373 @@
   }
   ```
 
-  Notes:
-  - The change is purely additive — every existing
-    `paginated(c, data, pagination)` call site works unchanged because the
-    new fourth argument is optional.
-  - `c.header(name, value)` is the Hono idiom for setting a single response
-    header before `c.json()` is called.
-
-- [ ] 3.2 Run `make check-api` — must pass; no other files change yet.
-
-## 4. Update both recipe controllers to set the `Deprecation` header
-
-- [ ] 4.1 Open `apps/api/src/modules/recipe/index.ts` and locate the
-  `/recipes` handler at lines 42-55. Update the `return paginated(...)`
-  call to pass the optional `{ headers }` argument when the service
-  reports the flag:
+- [ ] 1.2 Update `cursorPaginated()` (currently lines 52-61) with the same
+  optional `options` argument and the same header-application loop:
 
   ```ts
-  const result = await service.listRecipes(
-    filters,
-    filters.page,
-    filters.perPage,
-    userId,
-    isAdmin,
-  );
-  return paginated(
-    c,
-    result.recipes,
-    {
-      page: filters.page,
-      perPage: filters.perPage,
-      total: result.total,
-      totalPages: Math.ceil(result.total / filters.perPage),
-    },
-    result.deprecations?.tasteNoteId === true
-      ? { headers: { Deprecation: 'true' } }
-      : undefined,
-  );
+  /**
+   * Return a success envelope with cursor-pagination metadata and optional
+   * response headers.
+   *
+   * Use this for cursor-based list endpoints. The response shape is
+   * `{ success: true, data, meta: { requestId, cursor: { nextCursor, hasMore, total? } } }`.
+   *
+   * @param c - Hono request context.
+   * @param data - Items on the current page.
+   * @param cursorMeta - Cursor pagination metadata.
+   * @param options - Optional response headers (e.g., `Deprecation`).
+   */
+  export function cursorPaginated<T>(
+    c: Context,
+    data: T[],
+    cursorMeta: CursorPaginationMeta,
+    options?: { headers?: Record<string, string> },
+  ) {
+    if (options?.headers) {
+      for (const [name, value] of Object.entries(options.headers)) {
+        c.header(name, value);
+      }
+    }
+    return c.json({
+      success: true as const,
+      data,
+      meta: {
+        requestId: c.get('requestId'),
+        cursor: cursorMeta,
+      },
+    }, 200);
+  }
   ```
 
-- [ ] 4.2 Locate the `/recipes/starred` handler at lines 72-82. Apply the
-  same change:
+- [ ] 1.3 Run `make check-api` — must pass with zero new errors. The change
+  is purely additive; no existing call site needs to change.
+
+## 2. Add `deprecations` detection and `warn` log to `listRecipes`
+
+- [ ] 2.1 Open `apps/api/src/modules/recipe/service.ts`. Locate the
+  `listRecipes` function (lines 492-568). Add `requestId?: string` as a new
+  optional sixth parameter:
 
   ```ts
-  const result = await service.listStarredRecipes(filters, filters.page, filters.perPage, userId);
-  return paginated(
-    c,
-    result.recipes,
-    {
-      page: filters.page,
-      perPage: filters.perPage,
-      total: result.total,
-      totalPages: Math.ceil(result.total / filters.perPage),
-    },
-    result.deprecations?.tasteNoteId === true
-      ? { headers: { Deprecation: 'true' } }
-      : undefined,
-  );
+  export async function listRecipes(
+    filters: z.infer<typeof RecipeFilterSchema>,
+    page: number,
+    perPage: number,
+    _requestingUserId: string | null = null,
+    isAdmin: boolean = false,
+    requestId?: string,
+  ) {
   ```
 
-- [ ] 4.3 If `service.listStarredRecipes` does not currently surface the
-  `deprecations` field (because D12 left it implicit), update its return
-  shape to propagate the field straight through from `model.findStarred`.
+- [ ] 2.2 Inside `listRecipes`, after the `where` is assembled (line 504)
+  and before the cursor/offset branching, add the deprecation detection:
 
-- [ ] 4.4 Run `make check-api` and `make test-api` — must pass.
+  ```ts
+  const deprecations: { tasteNoteId?: boolean } = {};
+  if (!filters.tasteNoteIds && filters.tasteNoteId) {
+    deprecations.tasteNoteId = true;
+    logger.warn(
+      { filter: 'tasteNoteId', userId: _requestingUserId, requestId },
+      'Deprecated query parameter used',
+    );
+  }
+  ```
 
-## 5. Add `@deprecated` JSDoc tag to the schema field
+- [ ] 2.3 Update **every return statement** in `listRecipes` to spread the
+  `deprecations` field when the flag is set. There are multiple return paths:
+  - Line 528 (cursor fallback to offset when `sortBy !== 'createdAt'`):
+    `return { ...result, ...(deprecations.tasteNoteId ? { deprecations } : {}) };`
+  - Line 559 (cursor success path): same spread
+  - Line 567 (offset path): same spread
 
-- [ ] 5.1 Open `packages/shared/src/schemas/recipe.ts` and locate lines
+  Use a local helper to avoid repeating the conditional spread:
+  ```ts
+  const withDeprecations = <T>(result: T): T & { deprecations?: { tasteNoteId?: boolean } } =>
+    deprecations.tasteNoteId ? { ...result, deprecations } : result;
+  ```
+  Then `return withDeprecations(result);` on each path.
+
+- [ ] 2.4 Run `make check-api` — must pass. The `logger.warn` call uses the
+  existing `logger` at `service.ts:63` (`createLogger('recipe-service')`).
+
+## 3. Add `deprecations` detection and `warn` log to `listStarredRecipes`
+
+- [ ] 3.1 Open `apps/api/src/modules/recipe/service.ts`. Locate
+  `listStarredRecipes` (lines 583-596). Add `requestId?: string` as a new
+  optional fifth parameter:
+
+  ```ts
+  export async function listStarredRecipes(
+    filters: z.infer<typeof RecipeFilterSchema>,
+    page: number,
+    perPage: number,
+    userId: string,
+    requestId?: string,
+  ) {
+  ```
+
+- [ ] 3.2 Inside `listStarredRecipes`, before the call to
+  `model.findStarred`, add the deprecation detection (same logic as
+  `listRecipes`):
+
+  ```ts
+  const deprecations: { tasteNoteId?: boolean } = {};
+  if (!filters.tasteNoteIds && filters.tasteNoteId) {
+    deprecations.tasteNoteId = true;
+    logger.warn(
+      { filter: 'tasteNoteId', userId, requestId },
+      'Deprecated query parameter used',
+    );
+  }
+  ```
+
+- [ ] 3.3 Update the return statement (currently `return result;` at line
+  595) to spread the `deprecations` field:
+
+  ```ts
+  return {
+    ...result,
+    ...(deprecations.tasteNoteId ? { deprecations } : {}),
+  };
+  ```
+
+- [ ] 3.4 Run `make check-api` and
+  `make test-specific filter=apps/api/src/modules/recipe` — every existing
+  test must continue to pass; no new ones yet.
+
+## 4. Update the `/recipes` controller to pass `requestId` and set the `Deprecation` header
+
+- [ ] 4.1 Open `apps/api/src/modules/recipe/index.ts`. Locate the `/recipes`
+  handler (lines 73-107). Inside the handler, read `requestId` from the
+  context and pass it to `listRecipes`:
+
+  ```ts
+  async (c) => {
+    const filters = c.req.valid('query');
+    const userId = c.get('userId') ?? null;
+    const isAdmin = c.get('user')?.isAdmin ?? false;
+    const requestId = c.get('requestId');
+    try {
+      const result = await service.listRecipes(
+        filters,
+        filters.page,
+        filters.perPage,
+        userId,
+        isAdmin,
+        requestId,
+      );
+
+      const depHeaders = result.deprecations?.tasteNoteId === true
+        ? { headers: { Deprecation: 'true' } }
+        : undefined;
+
+      if ('hasMore' in result) {
+        return cursorPaginated(
+          c,
+          result.recipes,
+          {
+            nextCursor: result.nextCursor,
+            hasMore: result.hasMore,
+            total: result.total,
+          },
+          depHeaders,
+        );
+      }
+
+      return paginated(
+        c,
+        result.recipes,
+        {
+          page: filters.page,
+          perPage: filters.perPage,
+          total: result.total,
+          totalPages: Math.ceil(result.total / filters.perPage),
+        },
+        depHeaders,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'VALIDATION_ERROR: INVALID_CURSOR') {
+        return invalidCursor(c);
+      }
+      throw err;
+    }
+  },
+  ```
+
+  **Critical:** `depHeaders` is passed to **both** the `cursorPaginated` and
+  `paginated` branches. Extending only `paginated` would silently drop the
+  header in cursor mode.
+
+- [ ] 4.2 Run `make check-api` — must pass.
+
+## 5. Update the `/recipes/starred` controller
+
+- [ ] 5.1 Locate the `/starred` handler (lines 124-134). Apply the same
+  pattern — read `requestId`, pass to `listStarredRecipes`, check flag,
+  pass headers to `paginated`:
+
+  ```ts
+  async (c) => {
+    const userId = c.get('userId') as string;
+    const filters = c.req.valid('query');
+    const requestId = c.get('requestId');
+    const result = await service.listStarredRecipes(
+      filters,
+      filters.page,
+      filters.perPage,
+      userId,
+      requestId,
+    );
+    return paginated(
+      c,
+      result.recipes,
+      {
+        page: filters.page,
+        perPage: filters.perPage,
+        total: result.total,
+        totalPages: Math.ceil(result.total / filters.perPage),
+      },
+      result.deprecations?.tasteNoteId === true
+        ? { headers: { Deprecation: 'true' } }
+        : undefined,
+    );
+  },
+  ```
+
+- [ ] 5.2 Run `make check-api` — must pass.
+
+## 6. Update `describeRoute` OpenAPI metadata on both routes
+
+- [ ] 6.1 In the `/recipes` `describeRoute` (lines 37-70), add
+  `tasteNoteId` (with `deprecated: true`) and `tasteNoteIds` to the
+  `parameters` array (currently lines 42-49, which only lists 6 params).
+  Insert after the existing `includeTotal` entry:
+
+  ```ts
+  parameters: [
+    { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+    { name: 'sortBy', in: 'query', required: false, schema: { type: 'string' } },
+    { name: 'sortOrder', in: 'query', required: false, schema: { type: 'string' } },
+    { name: 'cursor', in: 'query', required: false, schema: { type: 'string' } },
+    { name: 'includeTotal', in: 'query', required: false, schema: { type: 'boolean' } },
+    {
+      name: 'tasteNoteId',
+      in: 'query',
+      required: false,
+      deprecated: true,
+      description: 'Deprecated. Use tasteNoteIds instead. See D28.',
+      schema: { type: 'string', format: 'uuid' },
+    },
+    {
+      name: 'tasteNoteIds',
+      in: 'query',
+      required: false,
+      description: 'Comma-separated taste note UUIDs (AND logic, max 10)',
+      schema: { type: 'string' },
+    },
+  ],
+  ```
+
+- [ ] 6.2 In the `/recipes` `describeRoute` `200` response (lines 50-64),
+  add a `headers` field declaring the `Deprecation` header:
+
+  ```ts
+  200: {
+    description:
+      'Paginated list of recipes. Returns `meta.cursor` when cursor pagination is active, or `meta.pagination` when offset pagination is active.',
+    headers: {
+      Deprecation: {
+        schema: { type: 'string' },
+        description:
+          'Present (value "true") when the deprecated tasteNoteId parameter is used. See RFC 8594.',
+      },
+    },
+    content: {
+      'application/json': {
+        schema: resolver(
+          z.union([
+            cursorEnvelope(FeedRecipeOutputSchema),
+            paginatedEnvelope(FeedRecipeOutputSchema),
+          ]),
+        ),
+      },
+    },
+  },
+  ```
+
+- [ ] 6.3 In the `/starred` `describeRoute` (lines 112-121), add the same
+  `tasteNoteId` (deprecated) and `tasteNoteIds` parameter entries and the
+  same `Deprecation` header declaration on the `200` response. Also add a
+  typed `200` response schema (currently it's just a description string):
+
+  ```ts
+  describeRoute({
+    tags: ['Recipes'],
+    summary: 'List starred (favourited) recipes',
+    description: 'Paginated, filterable list of recipes the current user has starred.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'perPage', in: 'query', required: false, schema: { type: 'integer', minimum: 1 } },
+      { name: 'sortBy', in: 'query', required: false, schema: { type: 'string' } },
+      { name: 'sortOrder', in: 'query', required: false, schema: { type: 'string' } },
+      {
+        name: 'tasteNoteId',
+        in: 'query',
+        required: false,
+        deprecated: true,
+        description: 'Deprecated. Use tasteNoteIds instead. See D28.',
+        schema: { type: 'string', format: 'uuid' },
+      },
+      {
+        name: 'tasteNoteIds',
+        in: 'query',
+        required: false,
+        description: 'Comma-separated taste note UUIDs (AND logic, max 10)',
+        schema: { type: 'string' },
+      },
+    ],
+    responses: {
+      200: {
+        description: 'Paginated list of starred recipes',
+        headers: {
+          Deprecation: {
+            schema: { type: 'string' },
+            description:
+              'Present (value "true") when the deprecated tasteNoteId parameter is used. See RFC 8594.',
+          },
+        },
+        content: {
+          'application/json': {
+            schema: resolver(paginatedEnvelope(FeedRecipeOutputSchema)),
+          },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  ```
+
+  Note: The `/starred` route currently has a thin `200` response (just a
+  description). D28 upgrades it to a typed response with the
+  `paginatedEnvelope(FeedRecipeOutputSchema)` schema and an `ErrorEnvelopeSchema`
+  for `401` (it already declares `security` but the `401` response is
+  untyped — AGENTS.md mandates `resolver(ErrorEnvelopeSchema)` for every
+  documented error on auth-guarded routes).
+
+- [ ] 6.4 Run `make check-api` — must pass. Run
+  `make test-specific filter=apps/api/src/routes/openapi.coverage.test.ts`
+  — the coverage test should continue to pass (it does not inspect response
+  headers, and `/api/v1/recipes` is not in `IN_SCOPE_BASE_PATHS`).
+
+## 7. Add `@deprecated` JSDoc tag and `.meta({ deprecated: true })` to the schema field
+
+- [ ] 7.1 Open `packages/shared/src/schemas/recipe.ts` and locate lines
   134-135:
 
   ```ts
@@ -220,21 +425,23 @@
    *
    * @deprecated Use `tasteNoteIds` instead. See D28.
    */
-  tasteNoteId: z.uuid().optional(),
+  tasteNoteId: z.uuid().optional().meta({ deprecated: true }),
   ```
 
   Notes:
-  - The `@deprecated` tag is the part visible to generated TypeScript and
-    OpenAPI consumers.
-  - The surrounding prose stays in place so anyone reading the schema file
-    has the full context without leaving the source.
+  - The `@deprecated` tag is the part visible to the TypeScript language
+    server (editor strikethrough).
+  - The `.meta({ deprecated: true })` is read by `zod-openapi` v5 (pulled in
+    by `hono-openapi`) during OpenAPI generation, making the deprecation
+    visible in the generated OpenAPI spec.
+  - The codebase uses Zod v4.4.3; `.meta()` is available on all Zod schemas.
 
-- [ ] 5.2 Run `make check` — must pass across all workspaces (the schema
+- [ ] 7.2 Run `make check` — must pass across all workspaces (the schema
   is consumed by both API and web).
 
-## 6. Update `docs/api.md`
+## 8. Update `docs/api.md`
 
-- [ ] 6.1 Open `docs/api.md` and locate line 234:
+- [ ] 8.1 Open `docs/api.md` and locate line 234:
 
   ```
   | `tasteNoteId`  | —             | Single taste note UUID (deprecated, use tasteNoteIds)  |
@@ -252,9 +459,9 @@
     table renderer enforces an alignment, allow the row to wrap or extend
     the column width consistently.
 
-## 7. Add `recipe-filter-deprecation.test.ts`
+## 9. Add `recipe-filter-deprecation.test.ts`
 
-- [ ] 7.1 Create
+- [ ] 9.1 Create
   `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts` with
   the standard header (matching the convention from
   `apps/api/src/modules/recipe/service.preservation.test.ts`):
@@ -271,105 +478,241 @@
    *  - Both set (plural wins per the existing `else if`) → no flag
    *  - Neither set → no flag
    *
-   * Optionally exercises the controller boundary via Hono's test client to
-   * assert the `Deprecation: true` header is present on the response.
+   * Also exercises the controller boundary via Hono's `app.request(...)` to
+   * assert the `Deprecation: true` header is present on the response (both
+   * offset and cursor modes).
    */
 
   import { describe, it } from 'jsr:@std/testing/bdd';
   import { expect } from 'jsr:@std/expect';
   ```
 
-- [ ] 7.2 Add the four service-level cases. Each constructs the filter,
-  invokes `listRecipes` (with a stubbed `model.findMany` returning an
-  empty page so the test runs without DB), and asserts the
-  `deprecations.tasteNoteId` field on the result. Use the existing mock
-  pattern from `service.preservation.test.ts:22-44` for the Drizzle
-  surface.
+- [ ] 9.2 Add the four service-level cases for `listRecipes`. Use the mock
+  pattern from `service.preservation.test.ts` (hand-rolled Drizzle-like
+  stubs + mock `model.findMany` that captures the WHERE clause). Since
+  `listRecipes` calls `model.buildListRecipesWhere` (which calls
+  `buildRecipeFilters`), and the real `buildRecipeFilters` imports from
+  `@brewform/db`, the test must either:
+  - Use a real DB (integration test pattern with
+    `import '../../test-setup.ts';` and `sanitizeResources: false,
+    sanitizeOps: false`), OR
+  - Stub the service's internal `model` import (not feasible in Deno without
+    injection), OR
+  - Call the real `service.listRecipes` against a real test DB.
+
+  **Recommended approach:** Use the integration-test pattern (real DB via
+  Docker, `make test-specific` runs inside Docker with `postgres` up).
+  Import `test-setup.ts`, create a test user and test recipe with taste
+  notes, then call `service.listRecipes` with various filter combinations
+  and assert on `result.deprecations?.tasteNoteId`.
 
   ```ts
+  import '../../test-setup.ts';
+  import { describe, it } from 'jsr:@std/testing/bdd';
+  import { expect } from 'jsr:@std/expect';
+  import * as service from './service.ts';
+  import { db } from '@brewform/db';
+  // ... test helpers for creating users/recipes/taste notes ...
+
   describe('listRecipes deprecation flag (D28)', () => {
     it('sets deprecations.tasteNoteId when only the singular form is used', async () => {
-      const result = await callListRecipes({ tasteNoteId: 'some-uuid' });
+      const result = await service.listRecipes(
+        { tasteNoteId: 'some-uuid', page: 1, perPage: 20, sortBy: 'createdAt', sortOrder: 'desc' } as any,
+        1, 20, null, false, 'test-request-id',
+      );
       expect(result.deprecations?.tasteNoteId).toBe(true);
     });
 
     it('does not set deprecations when only the plural form is used', async () => {
-      const result = await callListRecipes({ tasteNoteIds: 'a,b' });
+      const result = await service.listRecipes(
+        { tasteNoteIds: 'a,b', page: 1, perPage: 20, sortBy: 'createdAt', sortOrder: 'desc' } as any,
+        1, 20, null, false, 'test-request-id',
+      );
       expect(result.deprecations?.tasteNoteId).toBeFalsy();
     });
 
     it('does not set deprecations when both forms are provided (plural wins)', async () => {
-      const result = await callListRecipes({ tasteNoteIds: 'a,b', tasteNoteId: 'c' });
+      const result = await service.listRecipes(
+        { tasteNoteIds: 'a,b', tasteNoteId: 'c', page: 1, perPage: 20, sortBy: 'createdAt', sortOrder: 'desc' } as any,
+        1, 20, null, false, 'test-request-id',
+      );
       expect(result.deprecations?.tasteNoteId).toBeFalsy();
     });
 
     it('does not set deprecations when neither form is provided', async () => {
-      const result = await callListRecipes({});
+      const result = await service.listRecipes(
+        { page: 1, perPage: 20, sortBy: 'createdAt', sortOrder: 'desc' } as any,
+        1, 20, null, false, 'test-request-id',
+      );
       expect(result.deprecations?.tasteNoteId).toBeFalsy();
     });
   });
   ```
 
-  `callListRecipes(partialFilters)` is a small helper in the same file
-  that fills in the schema's defaults (`page: 1`, `perPage: 20`, etc.) and
-  invokes `service.listRecipes` with a stubbed model.
+  Note: The test calls the **real** `service.listRecipes` (not an inline
+  copy), so it exercises the real deprecation detection. The `filters`
+  argument is cast `as any` to avoid constructing a full
+  `RecipeFilterSchema`-valid object in each test — the service accepts
+  `z.infer<typeof RecipeFilterSchema>` but the deprecation check
+  (`!filters.tasteNoteIds && filters.tasteNoteId`) runs before any DB
+  query, so even if the DB returns empty results the flag is still set.
 
-- [ ] 7.3 Mirror the same four cases for the starred endpoint via
-  `service.listStarredRecipes` (or directly against `model.findStarred`,
-  whichever D12 made the public surface). Group into a second `describe`
-  block:
+- [ ] 9.3 Mirror the same four cases for `listStarredRecipes`:
 
   ```ts
-  describe('findStarred deprecation flag (D28)', () => {
-    it('sets deprecations.tasteNoteId when only the singular form is used', async () => { /* ... */ });
-    it('does not set deprecations when only the plural form is used', async () => { /* ... */ });
-    it('does not set deprecations when both forms are provided', async () => { /* ... */ });
-    it('does not set deprecations when neither form is provided', async () => { /* ... */ });
+  describe('listStarredRecipes deprecation flag (D28)', () => {
+    it('sets deprecations.tasteNoteId when only the singular form is used', async () => {
+      const result = await service.listStarredRecipes(
+        { tasteNoteId: 'some-uuid', page: 1, perPage: 20, sortBy: 'createdAt', sortOrder: 'desc' } as any,
+        1, 20, 'test-user-id', 'test-request-id',
+      );
+      expect(result.deprecations?.tasteNoteId).toBe(true);
+    });
+    // ... same three more cases ...
   });
   ```
 
-- [ ] 7.4 (Optional) Add a controller-level smoke test using Hono's test
-  client:
+- [ ] 9.4 Add a controller-level integration test using Hono's
+  `app.request(...)` (following the pattern from
+  `apps/api/src/modules/recipe/index_test.ts` — no `hono/testing` import;
+  use a stub middleware that sets `requestId` / `userId` on context):
 
   ```ts
+  import { Hono } from 'hono';
+  import type { AppEnv } from '../../types/hono.ts';
+  import recipeRouter from './index.ts';
+
+  function createTestApp() {
+    const app = new Hono<AppEnv>();
+    app.use('*', async (c, next) => {
+      c.set('requestId', crypto.randomUUID());
+      c.set('userId', null); // anonymous for /recipes (optionalAuth)
+      await next();
+    });
+    app.route('/api/v1/recipes', recipeRouter);
+    return app;
+  }
+
   describe('Deprecation response header (D28)', () => {
     it('sets Deprecation: true on /api/v1/recipes when tasteNoteId is used', async () => {
-      const res = await app.request('/api/v1/recipes?tasteNoteId=' + SOME_UUID);
+      const app = createTestApp();
+      const res = await app.request('/api/v1/recipes?tasteNoteId=00000000-0000-0000-0000-000000000001');
+      expect(res.status).toBe(200);
       expect(res.headers.get('Deprecation')).toBe('true');
     });
 
-    it('does not set Deprecation header on /api/v1/recipes when tasteNoteIds is used', async () => {
-      const res = await app.request('/api/v1/recipes?tasteNoteIds=' + SOME_UUID);
+    it('does not set Deprecation header when tasteNoteIds is used', async () => {
+      const app = createTestApp();
+      const res = await app.request('/api/v1/recipes?tasteNoteIds=00000000-0000-0000-0000-000000000001');
+      expect(res.status).toBe(200);
       expect(res.headers.get('Deprecation')).toBeNull();
+    });
+
+    it('sets Deprecation: true in cursor mode when tasteNoteId is used', async () => {
+      const app = createTestApp();
+      const res = await app.request(
+        '/api/v1/recipes?tasteNoteId=00000000-0000-0000-0000-000000000001&cursor=invalid&sortBy=createdAt',
+      );
+      // Even if the cursor is invalid (400), the header should not be set
+      // in the error path. Use a valid scenario or assert on 200 path only.
+      // Adjust based on whether the invalid-cursor error path should
+      // include the header (it should NOT — the deprecation detection
+      // happens before the cursor is decoded, but the error response goes
+      // through `invalidCursor(c)` which does not pass headers).
+      expect(res.headers.get('Deprecation')).toBeNull(); // error path, no header
     });
   });
   ```
 
-  This block can be skipped if wiring a full controller fixture would
-  duplicate too much existing test infrastructure — the four service-level
-  cases above are the contract.
+  Note: The cursor-mode test is tricky because an invalid cursor returns
+  a 400 error (via `invalidCursor(c)`) which does not pass the `depHeaders`.
+  The `deprecations` flag is computed in the service **before** the cursor
+  is decoded, but the error response short-circuits the `paginated`/
+  `cursorPaginated` call. The test should use a valid cursor scenario or
+  assert that the 400 error path does NOT include the header (which is the
+  correct behaviour — the error response is not the deprecated query's
+  "success" response). Adjust the assertion based on what makes sense.
 
-- [ ] 7.5 Run
+- [ ] 9.5 Run
   `make test-specific filter=apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts`
   — every new test must pass.
 
-## 8. Final verification
+## 10. Extend `response.test.ts` with header-option tests
 
-- [ ] 8.1 Run `make check-api` — zero type errors across all workspaces.
-- [ ] 8.2 Run `make lint` — zero warnings on
-  `apps/api/src/modules/recipe/service.ts`,
-  `apps/api/src/modules/recipe/model.ts`,
-  `apps/api/src/modules/recipe/index.ts`,
-  `apps/api/src/utils/response/index.ts`,
-  `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts`,
-  `packages/shared/src/schemas/recipe.ts`.
-- [ ] 8.3 Run `make test-api` — every test in
-  `apps/api/src/modules/recipe/*.test.ts` passes, including the new
+- [ ] 10.1 Open `apps/api/src/utils/response/response.test.ts`. Add tests
+  asserting that `paginated()` and `cursorPaginated()` with the `{ headers }`
+  option correctly set the header on the response. Use the existing test
+  pattern in this file (construct a mock `Context` or a minimal Hono app):
+
+  ```ts
+  describe('paginated with headers option (D28)', () => {
+    it('sets response headers when options.headers is provided', () => {
+      // Use a minimal Hono app or mock context
+      const app = new Hono();
+      app.get('/test', (c) =>
+        paginated(c, [], { page: 1, perPage: 20, total: 0, totalPages: 0 }, {
+          headers: { Deprecation: 'true' },
+        }),
+      );
+      const res = await app.request('/test');
+      expect(res.headers.get('Deprecation')).toBe('true');
+    });
+
+    it('does not set headers when options is not provided', () => {
+      const app = new Hono();
+      app.get('/test', (c) =>
+        paginated(c, [], { page: 1, perPage: 20, total: 0, totalPages: 0 }),
+      );
+      const res = await app.request('/test');
+      expect(res.headers.get('Deprecation')).toBeNull();
+    });
+  });
+
+  describe('cursorPaginated with headers option (D28)', () => {
+    it('sets response headers when options.headers is provided', () => {
+      const app = new Hono();
+      app.get('/test', (c) =>
+        cursorPaginated(c, [], { nextCursor: null, hasMore: false }, {
+          headers: { Deprecation: 'true' },
+        }),
+      );
+      const res = await app.request('/test');
+      expect(res.headers.get('Deprecation')).toBe('true');
+    });
+  });
+  ```
+
+  Note: The existing `response.test.ts` tests (lines 51-60) use a minimal
+  Hono app pattern. Follow the same approach. The `CursorPaginationMeta`
+  type requires `nextCursor` and `hasMore`; `total` is optional.
+
+- [ ] 10.2 Run
+  `make test-specific filter=apps/api/src/utils/response/response.test.ts`
+  — must pass.
+
+## 11. Final verification
+
+- [ ] 11.1 Run `make check-api` — zero type errors across all workspaces.
+- [ ] 11.2 Run `make lint` — zero warnings on:
+  - `apps/api/src/utils/response/index.ts`
+  - `apps/api/src/modules/recipe/service.ts`
+  - `apps/api/src/modules/recipe/index.ts`
+  - `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts`
+  - `apps/api/src/utils/response/response.test.ts`
+  - `packages/shared/src/schemas/recipe.ts`
+- [ ] 11.3 Run `make test-api` — every test in
+  `apps/api/src/modules/recipe/*.test.ts` and
+  `apps/api/src/utils/response/response.test.ts` passes, including the new
   deprecation test file. No existing tests regress.
-- [ ] 8.4 Manual smoke (optional): with the API running, hit
+- [ ] 11.4 Run
+  `make test-specific filter=apps/api/src/routes/openapi.coverage.test.ts`
+  — the OpenAPI coverage test continues to pass.
+- [ ] 11.5 Manual smoke (optional): with the API running, hit
   `GET /api/v1/recipes?tasteNoteId=<any-uuid>` and confirm the response
   carries `Deprecation: true`. Hit
   `GET /api/v1/recipes?tasteNoteIds=<any-uuid>` and confirm it does not.
-- [ ] 8.5 Confirm the phase-2 deprecation removal is left as a separate
-  change. Do NOT remove the `tasteNoteId` field, the service / model
+  Hit `GET /api/v1/recipes/openapi.json` and confirm the `tasteNoteId`
+  parameter is listed with `deprecated: true`.
+- [ ] 11.6 Confirm the Phase 2 deprecation removal is left as a separate
+  change. Do NOT remove the `tasteNoteId` field, the `buildRecipeFilters`
   branch, or the docs row in this PR.

--- a/packages/shared/src/schemas/recipe.ts
+++ b/packages/shared/src/schemas/recipe.ts
@@ -131,8 +131,18 @@ export const RecipeFilterSchema = z.object({
     },
     { message: 'tasteNoteIds must be at most 10 comma-separated UUIDs' },
   ),
-  // Keep tasteNoteId for backward compatibility (deprecated)
-  tasteNoteId: z.uuid().optional(),
+  /**
+   * Deprecated single-taste-note UUID filter. Use the plural `tasteNoteIds`
+   * (comma-separated, AND logic, max 10) instead. The API still applies this
+   * filter when set, but every response emits an RFC 8594 `Deprecation: true`
+   * header and a `warn` log line. Tracked by OpenSpec change
+   * `d28-remove-deprecated-taste-note-id`; the field itself will be removed
+   * in a follow-up change (D29 or later) once production telemetry confirms
+   * no significant callers remain.
+   *
+   * @deprecated Use `tasteNoteIds` instead. See D28.
+   */
+  tasteNoteId: z.uuid().optional().meta({ deprecated: true }),
   grinder: z.string().optional(),
   mainBrewer: z.string().max(200).optional(),
   coffeeVarietyId: z.uuid().optional(),

--- a/plans/D28-remove-deprecated-taste-note-id.md
+++ b/plans/D28-remove-deprecated-taste-note-id.md
@@ -21,30 +21,38 @@ in a code comment (`// Keep tasteNoteId for backward compatibility (deprecated)`
 but the deprecation lives only in the source — nothing about the runtime
 behaviour signals to the caller that the parameter is on the way out.
 
-The backend honours the singular form via an `else if` branch in
-`apps/api/src/modules/recipe/service.ts:544-551` (inside `listRecipes`). Until
-D12 (separate change, in progress) lands, the same branch is **missing** from
-`apps/api/src/modules/recipe/model.ts:findStarred` — that endpoint silently
-drops the singular form. D12 closes that parity gap; with D12 merged, both
-listing endpoints honour the deprecated parameter identically. D12's
-`design.md:90` explicitly notes: _"No removal of the deprecated `tasteNoteId` —
-that's a separate API deprecation cycle."_ This plan is that cycle.
+D12 (recipe-filter-logic, merged and archived at
+`openspec/changes/archive/2026-06-06-d12-recipe-filter-logic/`) extracted the
+shared filter-building helper `buildRecipeFilters` into
+`apps/api/src/modules/recipe/model.ts:83-179` and closed the parity gap between
+`listRecipes` and `findStarred`. Both listing endpoints now honour the deprecated
+singular parameter via the same `else if (filters.tasteNoteId)` branch inside
+`buildRecipeFilters` at `model.ts:167-176`. The `RecipeFilterCriteria` interface
+at `model.ts:67-77` already carries a JSDoc `@deprecated` tag on its `tasteNoteId`
+field (line 73). However, the public Zod schema in `packages/shared` — the one
+that drives OpenAPI generation and the TypeScript types seen by API consumers —
+has only an inline `//` comment, not a `@deprecated` JSDoc tag or Zod `.meta()`
+metadata. D12's `design.md` explicitly deferred the deprecation cycle:
+_"No removal of the deprecated `tasteNoteId` — that's a separate API
+deprecation cycle."_ D28 is that cycle.
 
-D28 introduces the two missing runtime signals: a standards-aligned HTTP
-response header (`Deprecation: true` per RFC 8594) and a structured `warn` log
-line. Both are emitted only when the deprecated singular parameter is the one
-actually used (i.e., when `tasteNoteId` is set and `tasteNoteIds` is not). When
-both are present the plural takes precedence (matching the `else if` branch),
-so no signal is emitted in that case either.
+D28 introduces the missing runtime signals: a standards-aligned HTTP response
+header (`Deprecation: true` per RFC 8594) and a structured `warn` log line. Both
+are emitted only when the deprecated singular parameter is the one actually
+used (i.e., when `tasteNoteId` is set and `tasteNoteIds` is not). When both are
+present the plural takes precedence (matching the `else if` branch in
+`buildRecipeFilters`), so no signal is emitted in that case either.
 
 The frontend has been audited and never sends the singular form — only
 `tasteNoteIds` is used across `apps/web/src/components/recipe-list/useRecipeFilters.ts`,
 `RecipeListView.tsx`, `RecipeCreatePage.tsx`, `RecipeEditPage.tsx`,
-`TasteNotesPage.tsx`, and `TastingNotesSection.tsx`. Any usage of the singular
-form therefore comes from third-party API clients, and the only way to find out
-how many such clients exist (and when removal becomes safe) is to emit
-deprecation telemetry in production. None of D01-D11 plans this work; D12
-defers it; D28 fills the gap.
+`TasteNotesPage.tsx`, and `TastingNotesSection.tsx`. (The singular `tasteNoteId`
+that appears in `TastingNotesSection.tsx` and `radar-chart-data.ts` is a property
+on the `TasteNote` domain object, not a filter query parameter.) Any usage of the
+singular form as a filter parameter therefore comes from third-party API clients,
+and the only way to find out how many such clients exist (and when removal becomes
+safe) is to emit deprecation telemetry in production. D12 deferred this work;
+D28 fills the gap.
 
 ## Impact
 
@@ -53,26 +61,36 @@ defers it; D28 fills the gap.
   envelope.
 - Operations cannot estimate when removing the field is safe because no
   production signal exists to count or attribute callers.
-- Documentation drifts away from runtime behaviour:
-  `docs/api.md:234` says _"deprecated, use tasteNoteIds"_ but the API itself
-  produces no observable indication of that status.
+- Documentation drifts away from runtime behaviour: `docs/api.md:234` says
+  _"deprecated, use tasteNoteIds"_ but the API itself produces no observable
+  indication of that status.
 - The schema's deprecation comment at
   `packages/shared/src/schemas/recipe.ts:134` is invisible to consumers who
   rely on generated OpenAPI / TypeScript types because there is no `@deprecated`
-  JSDoc tag attached to the field.
+  JSDoc tag and no Zod `.meta({ deprecated: true })` metadata attached to the
+  field.
+- The `/recipes` route's `describeRoute` at `index.ts:42-49` does not document
+  `tasteNoteId` (or `tasteNoteIds`) as a query parameter in its `parameters`
+  array — the deprecated parameter is invisible in the generated OpenAPI spec.
 
 ## Affected Files
 
-| File                                                       | Lines    | Change type                                                |
-| ---------------------------------------------------------- | -------- | ---------------------------------------------------------- |
-| `apps/api/src/modules/recipe/service.ts`                   | 544-551  | Set `deprecations.tasteNoteId = true`; emit `warn` log     |
-| `apps/api/src/modules/recipe/model.ts` (`findStarred`)     | ~539-735 | Same flag + log (after D12 lands and the branch exists)    |
-| `apps/api/src/modules/recipe/index.ts`                     | 42-55    | `/recipes` controller reads flag, sets `Deprecation` header |
-| `apps/api/src/modules/recipe/index.ts`                     | 72-82    | `/recipes/starred` controller reads flag, sets header      |
-| `apps/api/src/utils/response/index.ts`                     | 30-40    | Extend `paginated()` to accept optional response headers   |
-| `packages/shared/src/schemas/recipe.ts`                    | 134-135  | Add `@deprecated` JSDoc tag referencing D28                |
-| `docs/api.md`                                              | 234      | Add "Will be removed in a future release" note + OpenSpec link |
-| `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts` | new   | New test file covering the four deprecation cases          |
+| File | Lines (current) | Change type |
+| --- | --- | --- |
+| `apps/api/src/utils/response/index.ts` | 31-40, 52-61 | Extend `paginated()` and `cursorPaginated()` to accept optional `{ headers }` arg |
+| `apps/api/src/modules/recipe/model.ts` | 155-176 | Add `deprecations` field to `buildRecipeFilters` return or add a sibling detection function |
+| `apps/api/src/modules/recipe/model.ts` | 853-903 | Update `findStarred` return shape to carry `deprecations` |
+| `apps/api/src/modules/recipe/model.ts` | 855-866 | Replace inline anonymous filter type with `RecipeFilterCriteria` (+ `sortBy`/`sortOrder`) |
+| `apps/api/src/modules/recipe/service.ts` | 492-568 | Add `deprecations` to `listRecipes` return; emit `warn` log; accept `requestId` param |
+| `apps/api/src/modules/recipe/service.ts` | 583-596 | Propagate `deprecations` through `listStarredRecipes`; accept `requestId` param |
+| `apps/api/src/modules/recipe/index.ts` | 73-107 | `/recipes` controller: pass `requestId`, check flag, set `Deprecation` header on both cursor and offset branches |
+| `apps/api/src/modules/recipe/index.ts` | 124-134 | `/starred` controller: pass `requestId`, check flag, set `Deprecation` header |
+| `apps/api/src/modules/recipe/index.ts` | 37-70 | `/recipes` `describeRoute`: add `tasteNoteId`/`tasteNoteIds` to `parameters` with `deprecated: true` on singular |
+| `apps/api/src/modules/recipe/index.ts` | 112-121 | `/starred` `describeRoute`: add `tasteNoteId`/`tasteNoteIds` to `parameters` with `deprecated: true` on singular |
+| `packages/shared/src/schemas/recipe.ts` | 134-135 | Add JSDoc `@deprecated` tag + `.meta({ deprecated: true })` for OpenAPI |
+| `docs/api.md` | 234 | Add "Will be removed in a future release" note + OpenSpec link |
+| `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts` | new | New test file covering deprecation detection + header emission |
+| `apps/api/src/utils/response/response.test.ts` | 51-60 | Add test for `paginated` / `cursorPaginated` with `headers` option |
 
 ## Fix Approach
 
@@ -92,66 +110,117 @@ are unaffected, and the query continues to filter exactly as before.
 
 ## Technical Approach
 
-1. Extend the `listRecipes` and `findStarred` return types with an optional
-   `deprecations` discriminator (`{ tasteNoteId?: boolean }`). The flag is set
-   to `true` inside the existing `else if (filters.tasteNoteId)` branch.
-2. Emit the `warn` log line at the same point in the service / model so the
-   log fires once per request that uses the deprecated parameter — never on
-   the plural path, never when both are set.
-3. Extend `paginated()` in `apps/api/src/utils/response/index.ts` to accept an
-   optional `headers?: Record<string, string>` argument so the controller can
-   declare the `Deprecation` header in one place without leaking response
-   plumbing into the service layer.
-4. In both controllers (`apps/api/src/modules/recipe/index.ts:42-55` for the
-   public list and lines 72-82 for the starred list), check
-   `result.deprecations?.tasteNoteId === true` and pass `{ headers:
-   { Deprecation: 'true' } }` to `paginated()`. The service / model layer
-   stays HTTP-agnostic.
-5. Annotate `packages/shared/src/schemas/recipe.ts:134-135` with a JSDoc
-   `@deprecated` tag so downstream OpenAPI / generated type consumers see the
-   deprecation in their toolchain.
-6. Update `docs/api.md:234` to add a "Will be removed in a future release"
-   note and link to `openspec/changes/d28-remove-deprecated-taste-note-id/`.
+### Detection site — service layer, not `buildRecipeFilters`
+
+D12 moved the `else if (filters.tasteNoteId)` branch into
+`buildRecipeFilters` (`model.ts:167-176`). That function is a pure
+data-access helper that returns `SQL[]` and has no logger — adding a `warn`
+log there would violate the layering (model.ts lines 2-4 declare it a pure
+Drizzle layer). Instead, the deprecation detection lives in the **service**
+layer (`listRecipes` and `listStarredRecipes`), where:
+
+- The `logger` is already instantiated (`createLogger('recipe-service')` at
+  `service.ts:63`).
+- The precedence check (`!filters.tasteNoteIds && filters.tasteNoteId`) is a
+  single boolean expression — trivially expressible at the call site without
+  duplicating the `else if` branch's SQL logic.
+- The result is surfaced to the controller via an optional `deprecations`
+  field on the return shape.
+
+### Return shape — union-aware
+
+`listRecipes` currently returns a **union** of two shapes:
+- Offset mode: `{ recipes, total }` (from `model.findMany`)
+- Cursor mode: `{ recipes, hasMore, nextCursor, total? }` (from `model.findCursor`)
+
+The `deprecations` field is added as an optional property on **both** branches.
+No explicit `ListRecipesResult` interface is introduced (the current code has
+no explicit return type annotation; adding one is out of scope for D28).
+Instead, the service spreads `deprecations` into both return statements.
+
+### `requestId` plumbing
+
+`requestId` is available on the Hono context (`c.get('requestId')`) but the
+service layer has no access to it. D28 adds an optional `requestId?: string`
+parameter to both `listRecipes` and `listStarredRecipes`, passed from the
+controller. The `warn` log shape is `{ filter: 'tasteNoteId', userId, requestId }`.
+
+### `paginated()` and `cursorPaginated()` extension
+
+Both response helpers are extended with an optional 4th argument:
+`options?: { headers?: Record<string, string> }`. The headers are applied via
+`c.header(name, value)` before `c.json()`. This is purely additive — all
+existing call sites work unchanged.
+
+The `/recipes` controller has a **two-branch return** (cursor mode at
+`index.ts:87` via `cursorPaginated`, offset mode at `index.ts:94` via
+`paginated`). Both branches must check the `deprecations` flag and pass the
+`Deprecation` header — otherwise the header is silently dropped in cursor
+mode.
+
+### OpenAPI metadata
+
+AGENTS.md mandates: _"Every new route (or change to a route's request/response
+shape) MUST include OpenAPI metadata."_ Adding a `Deprecation` response header
+changes the response shape. The `describeRoute` on both routes must:
+
+1. Add `tasteNoteId` and `tasteNoteIds` to the `parameters` array (currently
+   undocumented). The `tasteNoteId` parameter entry includes
+   `deprecated: true`.
+2. Declare the `Deprecation` header on the `200` response via
+   `headers: { Deprecation: { schema: { type: 'string' } } }`.
+
+### Schema annotation — Zod `.meta()` + JSDoc
+
+The codebase uses **Zod v4** (`zod@4.4.3`). Zod v4's `.meta()` method stores
+metadata in the `globalRegistry`, which `zod-openapi` v5 (pulled in by
+`hono-openapi`) reads during OpenAPI generation. Adding
+`.meta({ deprecated: true })` to the `tasteNoteId` field makes the
+deprecation visible in generated OpenAPI types. A JSDoc `@deprecated` tag is
+also added for TypeScript consumers (editor strikethrough).
 
 ## Proposed Code Sketches
 
-### 1. New return-type shape
+### 1. Service-layer detection + log
 
 ```ts
-// apps/api/src/modules/recipe/service.ts
-export interface ListRecipesResult {
-  recipes: Recipe[];
-  total: number;
-  /**
-   * Per-request deprecation flags. Populated by the service when the request
-   * exercised a deprecated input. Controllers translate these into response
-   * headers (e.g., RFC 8594 `Deprecation`). HTTP layer never reaches here.
-   */
-  deprecations?: {
-    /** True when the request used `tasteNoteId` (singular) and not `tasteNoteIds` (plural). */
-    tasteNoteId?: boolean;
-  };
-}
+// apps/api/src/modules/recipe/service.ts — inside listRecipes
+export async function listRecipes(
+  filters: z.infer<typeof RecipeFilterSchema>,
+  page: number,
+  perPage: number,
+  _requestingUserId: string | null = null,
+  isAdmin: boolean = false,
+  requestId?: string,
+) {
+  // ... existing body up to the where/filter assembly ...
 
-export async function listRecipes(/* ... */): Promise<ListRecipesResult> {
-  // ... existing filter assembly ...
-  const deprecations: ListRecipesResult['deprecations'] = {};
+  const deprecations: { tasteNoteId?: boolean } = {};
   if (!filters.tasteNoteIds && filters.tasteNoteId) {
     deprecations.tasteNoteId = true;
-    log.warn(
+    logger.warn(
       { filter: 'tasteNoteId', userId: _requestingUserId, requestId },
       'Deprecated query parameter used',
     );
   }
-  // ... existing call to model.findMany ...
-  return { recipes: result.recipes, total: result.total, ...(deprecations.tasteNoteId ? { deprecations } : {}) };
+
+  // ... existing cursor/offset branching ...
+
+  // On each return path, spread deprecations:
+  if (filters.cursor && sortBy === 'createdAt') {
+    // ... cursor path ...
+    return { ...result, ...(deprecations.tasteNoteId ? { deprecations } : {}) };
+  }
+  // ... offset path ...
+  return { ...result, ...(deprecations.tasteNoteId ? { deprecations } : {}) };
 }
 ```
 
-The same shape is added to `findStarred` in `apps/api/src/modules/recipe/model.ts`
-after D12 lands and the `else if (filters.tasteNoteId)` branch exists there.
+The same pattern applies to `listStarredRecipes`, which propagates
+`model.findStarred`'s result. The `deprecations` field is computed in the
+service (not in `model.findStarred`) so the model layer stays side-effect-free.
 
-### 2. Extended `paginated()` helper
+### 2. Extended `paginated()` and `cursorPaginated()` helpers
 
 ```ts
 // apps/api/src/utils/response/index.ts
@@ -170,101 +239,189 @@ export function paginated<T>(
   return c.json({
     success: true as const,
     data,
-    meta: {
-      requestId: c.get('requestId'),
-      pagination,
-    },
+    meta: { requestId: c.get('requestId'), pagination },
+  }, 200);
+}
+
+/** Return a success envelope with cursor-pagination metadata and optional response headers. */
+export function cursorPaginated<T>(
+  c: Context,
+  data: T[],
+  cursorMeta: CursorPaginationMeta,
+  options?: { headers?: Record<string, string> },
+) {
+  if (options?.headers) {
+    for (const [name, value] of Object.entries(options.headers)) {
+      c.header(name, value);
+    }
+  }
+  return c.json({
+    success: true as const,
+    data,
+    meta: { requestId: c.get('requestId'), cursor: cursorMeta },
   }, 200);
 }
 ```
 
-This is purely additive — all existing call sites continue to work unchanged.
-
-### 3. Structured `warn` log call
+### 3. Controller — `/recipes` (both cursor and offset branches)
 
 ```ts
-// inside listRecipes / findStarred
-log.warn(
-  { filter: 'tasteNoteId', userId, requestId },
-  'Deprecated query parameter used',
-);
+// apps/api/src/modules/recipe/index.ts — handler at lines 73-107
+async (c) => {
+  const filters = c.req.valid('query');
+  const userId = c.get('userId') ?? null;
+  const isAdmin = c.get('user')?.isAdmin ?? false;
+  const requestId = c.get('requestId');
+  try {
+    const result = await service.listRecipes(
+      filters,
+      filters.page,
+      filters.perPage,
+      userId,
+      isAdmin,
+      requestId,
+    );
+
+    const depHeaders = result.deprecations?.tasteNoteId === true
+      ? { headers: { Deprecation: 'true' } }
+      : undefined;
+
+    if ('hasMore' in result) {
+      return cursorPaginated(c, result.recipes, {
+        nextCursor: result.nextCursor,
+        hasMore: result.hasMore,
+        total: result.total,
+      }, depHeaders);
+    }
+
+    return paginated(c, result.recipes, {
+      page: filters.page,
+      perPage: filters.perPage,
+      total: result.total,
+      totalPages: Math.ceil(result.total / filters.perPage),
+    }, depHeaders);
+  } catch (err) {
+    // ... existing error handling ...
+  }
+},
 ```
 
-The shape matches the AGENTS.md logging rules: structured object with
-traceable IDs, no payload data, no PII, `warn` level (recoverable, request
-still succeeds).
-
-## Refactored Usage
+### 4. Controller — `/recipes/starred`
 
 ```ts
-// apps/api/src/modules/recipe/index.ts (lines 42-55, /recipes)
-const result = await service.listRecipes(
-  filters,
-  filters.page,
-  filters.perPage,
-  userId,
-  isAdmin,
-);
-return paginated(c, result.recipes, {
-  page: filters.page,
-  perPage: filters.perPage,
-  total: result.total,
-  totalPages: Math.ceil(result.total / filters.perPage),
-}, result.deprecations?.tasteNoteId ? { headers: { Deprecation: 'true' } } : undefined);
+// apps/api/src/modules/recipe/index.ts — handler at lines 124-134
+async (c) => {
+  const userId = c.get('userId') as string;
+  const filters = c.req.valid('query');
+  const requestId = c.get('requestId');
+  const result = await service.listStarredRecipes(filters, filters.page, filters.perPage, userId, requestId);
+  return paginated(c, result.recipes, {
+    page: filters.page,
+    perPage: filters.perPage,
+    total: result.total,
+    totalPages: Math.ceil(result.total / filters.perPage),
+  }, result.deprecations?.tasteNoteId === true
+    ? { headers: { Deprecation: 'true' } }
+    : undefined);
+},
 ```
 
+### 5. Schema annotation
+
 ```ts
-// apps/api/src/modules/recipe/index.ts (lines 72-82, /recipes/starred)
-const result = await service.listStarredRecipes(filters, filters.page, filters.perPage, userId);
-return paginated(c, result.recipes, {
-  page: filters.page,
-  perPage: filters.perPage,
-  total: result.total,
-  totalPages: Math.ceil(result.total / filters.perPage),
-}, result.deprecations?.tasteNoteId ? { headers: { Deprecation: 'true' } } : undefined);
+// packages/shared/src/schemas/recipe.ts — lines 134-135
+/**
+ * Deprecated single-taste-note UUID filter. Use the plural `tasteNoteIds`
+ * (comma-separated, AND logic, max 10) instead. The API still applies this
+ * filter when set, but every response emits an RFC 8594 `Deprecation: true`
+ * header and a `warn` log line. Tracked by OpenSpec change
+ * `d28-remove-deprecated-taste-note-id`; the field itself will be removed
+ * in a follow-up change (D29 or later) once production telemetry confirms
+ * no significant callers remain.
+ *
+ * @deprecated Use `tasteNoteIds` instead. See D28.
+ */
+tasteNoteId: z.uuid().optional().meta({ deprecated: true }),
+```
+
+### 6. OpenAPI `describeRoute` — add deprecated parameter
+
+```ts
+// apps/api/src/modules/recipe/index.ts — /recipes describeRoute parameters
+parameters: [
+  // ... existing 6 params ...
+  {
+    name: 'tasteNoteId',
+    in: 'query',
+    required: false,
+    deprecated: true,
+    description: 'Deprecated. Use tasteNoteIds instead. See D28.',
+    schema: { type: 'string', format: 'uuid' },
+  },
+  {
+    name: 'tasteNoteIds',
+    in: 'query',
+    required: false,
+    description: 'Comma-separated taste note UUIDs (AND logic, max 10)',
+    schema: { type: 'string' },
+  },
+],
 ```
 
 ## Implementation Steps
 
-1. Extend `paginated()` in `apps/api/src/utils/response/index.ts` to accept the
-   optional `{ headers }` argument and apply it via `c.header()` before
-   `c.json()`. Run `make check-api`.
-2. Add the `ListRecipesResult` / `ListStarredRecipesResult` typed return
-   shapes (including the `deprecations` discriminator) and update the service
-   / model return statements.
-3. Inside `service.ts:listRecipes` (around lines 544-551) set
-   `deprecations.tasteNoteId = true` when `tasteNoteIds` is absent **and**
-   `tasteNoteId` is present, and emit the `warn` log line.
-4. After D12 lands, mirror the same flag + log in
-   `apps/api/src/modules/recipe/model.ts:findStarred`. If D12 has not landed
-   yet, either rebase D28 on top of D12 or sequence D28's `findStarred` edit
-   into the D12 branch.
-5. Update both controllers in `apps/api/src/modules/recipe/index.ts` (lines
-   42-55 and 72-82) to pass the optional `headers` argument to `paginated()`
-   when the service reports the flag.
-6. Add the `@deprecated` JSDoc tag in
-   `packages/shared/src/schemas/recipe.ts:134-135` and update
-   `docs/api.md:234`.
-7. Create `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts`
-   covering the four cases (singular only → flag set; plural only → no flag;
-   both → no flag; neither → no flag). Optionally add an end-to-end
+1. Extend `paginated()` and `cursorPaginated()` in
+   `apps/api/src/utils/response/index.ts` with optional `{ headers }` arg.
+   Run `make check-api`.
+2. Add the `deprecations` detection + `warn` log to `service.listRecipes`
+   (lines 492-568). Add `requestId?: string` parameter. Spread `deprecations`
+   into both cursor and offset return paths.
+3. Add the same to `service.listStarredRecipes` (lines 583-596). Add
+   `requestId?: string` parameter. Compute `deprecations` and spread into
+   return.
+4. Update both controllers in `apps/api/src/modules/recipe/index.ts`:
+   - `/recipes` (lines 73-107): pass `requestId`, check `deprecations` flag,
+     pass `{ headers: { Deprecation: 'true' } }` to **both** `cursorPaginated`
+     and `paginated` branches.
+   - `/starred` (lines 124-134): pass `requestId`, check flag, pass headers to
+     `paginated`.
+5. Update both `describeRoute` blocks to add `tasteNoteId` (with
+   `deprecated: true`) and `tasteNoteIds` to the `parameters` array. Add
+   `Deprecation` header declaration to the `200` response.
+6. Annotate `packages/shared/src/schemas/recipe.ts:134-135` with JSDoc
+   `@deprecated` tag and `.meta({ deprecated: true })`.
+7. Update `docs/api.md:234` to add "Will be removed in a future release" note
+   and link to the OpenSpec change folder.
+8. Create `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts`
+   covering the four deprecation cases for both endpoints, plus a
    controller-level test asserting the `Deprecation` header.
+9. Add a test for `paginated()` / `cursorPaginated()` with the `headers`
+   option in `apps/api/src/utils/response/response.test.ts`.
+10. Final verification: `make check-api`, `make lint`, `make test-api`.
 
 ## Testing Strategy
 
-- **Unit (service / model)** — assert `result.deprecations?.tasteNoteId` is
-  `true` when only `tasteNoteId` is provided, and `undefined` (or absent) in
-  the other three cases.
-- **Unit (controller helper)** — assert that `paginated(c, data, meta, {
-  headers: { Deprecation: 'true' } })` calls `c.header('Deprecation', 'true')`
-  exactly once before responding.
-- **Integration (Hono test client, optional)** — `GET /api/v1/recipes?tasteNoteId=<uuid>`
-  returns a 200 response with the `Deprecation: true` header set.
+- **Unit (service)** — assert `result.deprecations?.tasteNoteId` is `true`
+  when only `tasteNoteId` is provided, and `undefined`/absent in the other
+  three cases (plural only, both, neither). Test both `listRecipes` and
+  `listStarredRecipes`.
+- **Unit (response helpers)** — assert that
+  `paginated(c, data, meta, { headers: { Deprecation: 'true' } })` and
+  `cursorPaginated(c, data, meta, { headers: { Deprecation: 'true' } })`
+  call `c.header('Deprecation', 'true')` before responding.
+- **Integration (Hono test client)** — `GET /api/v1/recipes?tasteNoteId=<uuid>`
+  returns 200 with the `Deprecation: true` header set.
   `GET /api/v1/recipes?tasteNoteIds=<uuid>` does NOT include the header.
-- **Log assertion** — capture the test logger and assert exactly one `warn`
-  entry with `{ filter: 'tasteNoteId' }` per deprecated request.
-- **Regression** — existing tests in `apps/api/src/modules/recipe/*.test.ts`
-  continue to pass; no existing behaviour changes.
+  Same for `/recipes/starred` (with auth).
+- **Cursor mode** — `GET /api/v1/recipes?tasteNoteId=<uuid>&cursor=<...>&sortBy=createdAt`
+  returns 200 with `Deprecation: true` (exercises the `cursorPaginated`
+  branch).
+- **Log assertion** — the `warn` log is emitted (silenced in tests via
+  `LOG_LEVEL=silent` but the `deprecations` flag on the return shape is the
+  contract the test asserts on).
+- **Regression** — existing tests in
+  `apps/api/src/modules/recipe/*.test.ts` continue to pass; no existing
+  behaviour changes.
 
 ## Risk Assessment
 
@@ -280,27 +437,55 @@ touching the header behaviour.
 
 ## Dependencies
 
-- **D12 (recipe-filter-logic)** — must land first so that
-  `apps/api/src/modules/recipe/model.ts:findStarred` actually applies the
-  singular `tasteNoteId` filter. Before D12, emitting the deprecation header
-  on `/recipes/starred` would be misleading because the parameter is silently
-  dropped there. With D12 merged, both endpoints honour the parameter
-  identically and both can emit the deprecation signal identically.
+- **D12 (recipe-filter-logic)** — **MERGED and archived.** The
+  `buildRecipeFilters` helper exists at `model.ts:83-179`, the `else if`
+  branch for singular `tasteNoteId` is at `model.ts:167-176`, and both
+  listing endpoints honour the parameter identically. D28 builds on this
+  stable foundation.
 
 ## Out of Scope
 
 - **Phase 2: field removal.** Removing the singular `tasteNoteId` from the
-  schema, the service branch, the model branch, and the docs is a separate
-  plan (D29 or later) that triggers only after production telemetry confirms
-  no significant callers remain.
+  schema, the `buildRecipeFilters` branch, the docs, and any remaining
+  consumers is a separate plan (D29 or later) that triggers only after
+  production telemetry confirms no significant callers remain.
 - **Other deprecations.** The `Deprecation` header pattern established here
   may be reused by future plans, but D28 only addresses `tasteNoteId`. Other
   deprecated fields (if any) get their own plans.
 - **Third-party client outreach.** D28 emits the signal; deciding which API
   consumers to notify (and how) is an operations / product concern, not a
   code change.
+- **`findStarred` filter type cleanup.** The inline anonymous filter type at
+  `model.ts:855-866` is a pre-existing drift from `RecipeFilterCriteria`. D28
+  may optionally replace it with `RecipeFilterCriteria & { sortBy?: string;
+  sortOrder?: string }` but this is not required for the deprecation signal.
 
 ## Validation Notes
 
-_(none — all line numbers and behaviours referenced above were verified
-against `main` at plan-authoring time)_
+All line numbers, function signatures, and code references in this revised
+plan were verified against `main` on 2026-06-22. Key facts:
+
+- D12 is merged (commit `08930b3`, archived at
+  `openspec/changes/archive/2026-06-06-d12-recipe-filter-logic/`).
+- `buildRecipeFilters` is at `model.ts:83-179`; the `else if` branch for
+  singular `tasteNoteId` is at `model.ts:167-176`.
+- `listRecipes` is at `service.ts:492-568`; returns a union of offset and
+  cursor shapes.
+- `listStarredRecipes` is at `service.ts:583-596`; thin wrapper around
+  `model.findStarred`.
+- `/recipes` controller handler is at `index.ts:73-107` (two-branch return:
+  cursor at line 87, offset at line 94).
+- `/starred` controller handler is at `index.ts:124-134`.
+- `paginated()` is at `response/index.ts:31-40`; `cursorPaginated()` at
+  `response/index.ts:52-61`. Neither accepts a `headers` argument.
+- `RecipeFilterCriteria` at `model.ts:67-77` already has `@deprecated` JSDoc
+  on `tasteNoteId` (line 73).
+- `RecipeFilterSchema` at `packages/shared/src/schemas/recipe.ts:117-153`;
+  the singular `tasteNoteId` field is at lines 134-135 with only an inline
+  comment.
+- Zod v4.4.3 is in use; `.meta()` is available for OpenAPI metadata.
+- The `/recipes` `describeRoute` at `index.ts:42-49` does not document
+  `tasteNoteId` or `tasteNoteIds` in its `parameters` array.
+- `requestId` is set via `requestIdMiddleware` (`hono/request-id`) and
+  available as `c.get('requestId')` in controllers.
+- No `feat/d28` branch exists; D28 has not been started.


### PR DESCRIPTION
# D28: Deprecation Signal for `tasteNoteId` (Phase 1)

## Summary

Emits an [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594) `Deprecation: true`
HTTP response header and a structured `warn` log line when a request to
`GET /api/v1/recipes` or `GET /api/v1/recipes/starred` uses the deprecated
singular `tasteNoteId` query parameter **without** the canonical plural
`tasteNoteIds`.

This is **Phase 1 of a two-phase deprecation cycle** — it emits the signal
but does **not** remove the field. Phase 2 (a follow-up change, D29 or later)
will remove the field once production telemetry confirms no significant
callers remain.

## Background

The recipe filter schema at `packages/shared/src/schemas/recipe.ts` exposes
a singular `tasteNoteId` query parameter alongside the canonical plural
`tasteNoteIds`. The singular form has been annotated as deprecated in a code
comment since the plural was introduced, but the API gave no runtime signal
to callers that the parameter was on its way out. D12 (recipe-filter-logic,
merged) extracted the shared `buildRecipeFilters` helper and closed the
parity gap between `/recipes` and `/recipes/starred` but explicitly deferred
the deprecation cycle itself. This change is that deferred cycle.

## Changes

### Response helpers (`apps/api/src/utils/response/index.ts`)
- Extended `paginated<T>()` and `cursorPaginated<T>()` with an optional
  `options?: { headers?: Record<string, string> }` argument. When provided,
  headers are applied via `c.header(name, value)` before `c.json()`. Purely
  additive — all existing 3-argument call sites work unchanged.

### Service layer (`apps/api/src/modules/recipe/service.ts`)
- Added `requestId?: string` optional parameter to `listRecipes` and
  `listStarredRecipes`.
- Both functions now detect when `tasteNoteId` is set without `tasteNoteIds`
  and set a `deprecations: { tasteNoteId: true }` field on the return shape.
- A structured `warn` log line is emitted:
  `logger.warn({ filter: 'tasteNoteId', userId, requestId }, 'Deprecated query parameter used')`
  — traceable IDs only, no payload or PII.
- All return paths spread `deprecations` onto the result when the flag is set.

### Controllers (`apps/api/src/modules/recipe/index.ts`)
- `/recipes` handler: passes `requestId` from `c.get('requestId')` to the
  service, checks `result.deprecations?.tasteNoteId === true`, and passes
  `{ headers: { Deprecation: 'true' } }` to **both** the `cursorPaginated` and
  `paginated` response branches.
- `/starred` handler: same pattern, `paginated` only (starred uses offset
  pagination).
- Neither controller references `filters.tasteNoteId` directly — the
  deprecation decision is driven solely by the service-layer flag.

### OpenAPI metadata (`describeRoute` on both routes)
- Added `tasteNoteId` (with `deprecated: true`) and `tasteNoteIds` to the
  `parameters` array on both `/recipes` and `/starred`.
- Declared the `Deprecation` response header on the `200` response of both
  routes (schema: `{ type: 'string' }`, description references RFC 8594).
- Upgraded the `/starred` route's `200` response from an untyped description
  string to a typed `paginatedEnvelope(FeedRecipeOutputSchema)` response, and
  added `ErrorEnvelopeSchema` for the `401` response (per AGENTS.md mandate).

### Schema annotation (`packages/shared/src/schemas/recipe.ts`)
- Replaced the inline `//` comment on `tasteNoteId` with a JSDoc block
  containing an `@deprecated` tag (names `tasteNoteIds` as replacement,
  references D28).
- Added `.meta({ deprecated: true })` to the Zod chain — read by
  `zod-openapi` v5 (pulled in by `hono-openapi`) during OpenAPI generation,
  making the deprecation visible in generated types.

### Documentation (`docs/api.md`)
- Updated the `tasteNoteId` query parameter row to note the `Deprecation: true`
  header (RFC 8594), the future removal, and link to the OpenSpec change folder.

### Tests
- **New file:** `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts`
  — 15 test cases covering:
  - 4 service-level deprecation cases for `listRecipes` (singular-only → flag
    set; plural-only → no flag; both → plural wins, no flag; neither → no flag)
  - 4 service-level deprecation cases for `listStarredRecipes` (same matrix)
  - 7 controller-level integration tests via `app.request(...)`:
    - Offset mode: `Deprecation: true` present with `tasteNoteId`, absent
      with `tasteNoteIds`, absent with no filter
    - Cursor mode success path: `Deprecation: true` present with valid cursor +
      `tasteNoteId` + `sortBy=createdAt` (exercises `cursorPaginated` branch)
    - Cursor mode error path: invalid cursor → 400, no `Deprecation` header
    - `/starred` with auth: `Deprecation: true` present with `tasteNoteId`,
      absent with `tasteNoteIds`
- **Extended:** `apps/api/src/utils/response/response.test.ts` — 4 new tests
  for `paginated()` and `cursorPaginated()` with the `{ headers }` option
  (header set when provided, absent when not provided).

## What Does NOT Change

- **No field removal.** The `tasteNoteId` field, the `buildRecipeFilters`
  `else if` branch, and the docs row all remain. Phase 2 handles removal.
- **No `Sunset` header.** Phase 1 emits `Deprecation: true` only. Setting a
  `Sunset` date implies a removal commitment that belongs to Phase 2.
- **No filter semantics change.** No SQL changes. The existing `else if`
  precedence (plural wins) in `buildRecipeFilters` is preserved exactly.
- **`buildRecipeFilters` remains side-effect-free.** No logger, no
  `deprecations` field, no side effects — still a pure `SQL[]`-returning
  function. Detection lives in the service layer.

## Verification

| Check | Result |
|-------|--------|
| `make check-api` | Zero type errors |
| `make check` (all workspaces) | Zero type errors |
| `make lint` | 958 files checked, zero warnings |
| `make test-api` | 85 passed (799 steps), 0 failed |
| `make test-shared` | 103 passed (512 steps), 0 failed |
| OpenAPI coverage test | 19 steps, 0 failed |

## Files Changed

| File | Change |
|------|--------|
| `apps/api/src/utils/response/index.ts` | Extended `paginated`/`cursorPaginated` with `{ headers }` option |
| `apps/api/src/modules/recipe/service.ts` | Added deprecation detection + `warn` log + `requestId` param |
| `apps/api/src/modules/recipe/index.ts` | Updated controllers + OpenAPI `describeRoute` metadata |
| `packages/shared/src/schemas/recipe.ts` | JSDoc `@deprecated` + `.meta({ deprecated: true })` |
| `docs/api.md` | Updated `tasteNoteId` row with deprecation notice |
| `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts` | **New** — 15 deprecation test cases |
| `apps/api/src/utils/response/response.test.ts` | Extended — 4 header-option tests |

## OpenSpec

- Change: `d28-remove-deprecated-taste-note-id`
- Schema: `spec-driven`
- Progress: 35/35 tasks complete
- Spec: `openspec/changes/d28-remove-deprecated-taste-note-id/specs/recipe-filter/spec.md`
- Design: `openspec/changes/d28-remove-deprecated-taste-note-id/design.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recipe filter endpoints now emit a deprecation notice when the legacy `tasteNoteId` query parameter is used. Migrate to `tasteNoteIds` to prepare for future removal.

* **Documentation**
  * Updated API documentation and OpenAPI specs to mark `tasteNoteId` as deprecated and document the deprecation response header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->