### PR TITLE
D32: reconcile deploy plan & local-dev with Deno 2.9 / workspaces

### DIFF
--- a/apps/api/scripts/build-email-templates.ts
+++ b/apps/api/scripts/build-email-templates.ts
@@ -40,6 +40,13 @@ export const template = \`${escapeBackticks(html)}\`;
   await Deno.writeTextFile(join(outputDir, `${name}.ts`), tsContent);
 }
 
+/**
+ * Escapes characters significant inside a JS template literal so a raw HTML/MJML string can be
+ * embedded safely between backticks: backslashes, backticks, and `$` (which would otherwise begin
+ * a `${...}` interpolation).
+ * @param str Raw string to escape.
+ * @returns The escaped string, safe to embed in a template literal.
+ */
 function escapeBackticks(str: string): string {
   return str.replace(/\\/g, '\\\\').replace(/\`/g, '\\`').replace(/\$/g, '\\$');
 }

--- a/compose.yml
+++ b/compose.yml
@@ -48,7 +48,7 @@ services:
       - ADMIN_PASSWORD=admin123456
     volumes:
       - .:/app
-      - deno_cache:/root/.cache/deno
+      - deno_cache:/deno-dir
       - node_modules:/app/node_modules
     depends_on:
       postgres:
@@ -92,7 +92,7 @@ services:
         condition: service_started
     volumes:
       - .:/app
-      - deno_cache:/root/.cache/deno
+      - deno_cache:/deno-dir
       - node_modules:/app/node_modules
     profiles:
       - dev
@@ -213,7 +213,7 @@ services:
   # Serves the built React SPA on :8080 alongside app-preview on :8000.
   # Start with: make preview  (builds the web app first, then starts both)
   web:
-    image: caddy:2-alpine
+    image: caddy:2.11.4-alpine
     ports:
       - "8080:8080"
     volumes:

--- a/coolify_deployment_plan.md
+++ b/coolify_deployment_plan.md
@@ -124,17 +124,21 @@ merged to `main` *before* you start any Coolify step (see
 the **Status** column marks which files are already committed versus which still need to be
 written.
 
+> **Install command:** the Docker `deps` stages and CI install dependencies with `deno ci`
+> (a frozen, lockfile-strict install — `rm -rf node_modules && deno install --frozen`), not
+> `deno install`. `deno ci` fails fast if `deno.lock` is missing or out of date.
+
 | # | Change | File(s) | Status |
 |---|--------|---------|--------|
-| 1 | API Dockerfile: `builder` stage now runs `deno task email-build` (compiles MJML templates) + `drizzle-kit generate` (migration SQL); `runner` stage uses `ENTRYPOINT ["/app/docker-entrypoint.sh"]` instead of `CMD`, runs with `--unstable-cron --unstable-kv` | `Dockerfile`, `docker-entrypoint.sh` | Not yet implemented |
-| 2 | `docker-entrypoint.sh`: runs `drizzle-kit migrate` (always), checks `SELECT count(*) FROM users` and runs seed only if empty (first boot), then `exec`s the API server | `docker-entrypoint.sh` | Not yet implemented |
-| 3 | Web Dockerfile: 3-stage build (deps → vite build with `VITE_*` ARGs → `caddy:2-alpine` serving `dist/` on port 80) | `Dockerfile.web` | Not yet implemented |
-| 4 | `compose.yml` `prod` profile (`app-prod`, `web-prod` referencing GHCR images) + `denokv` sidecar service (shared across profiles, pinned to `0.14.0`) | `compose.yml` | Not yet implemented |
-| 5 | `Deno.openKv(DENO_KV_URL ?? 'http://denokv:4512')` in `main.ts` and `flush-cache.ts`; `--allow-net` added to `make flush-cache` | `apps/api/src/main.ts`, `apps/api/scripts/flush-cache.ts`, `Makefile` | Not yet implemented |
-| 6 | `DENO_KV_URL` + `DENO_KV_ACCESS_TOKEN` added to Zod env schema (both `z.string().optional()`) | `apps/api/src/config/env.ts` | Not yet implemented |
+| 1 | API Dockerfile: `builder` stage now runs `deno task email-build` (compiles MJML templates) + `drizzle-kit generate` (migration SQL); `runner` stage uses `ENTRYPOINT ["/app/docker-entrypoint.sh"]` instead of `CMD`, runs with `--unstable-cron --unstable-kv` | `Dockerfile`, `docker-entrypoint.sh` | Done (shipped in D30/D31) |
+| 2 | `docker-entrypoint.sh`: runs `drizzle-kit migrate` (always), checks `SELECT count(*) FROM users` and runs seed only if empty (first boot), then `exec`s the API server | `docker-entrypoint.sh` | Done (shipped in D30/D31) |
+| 3 | Web Dockerfile: 3-stage build (deps → vite build with `VITE_*` ARGs → `caddy:2.11.4-alpine` serving `dist/` on port 80) | `Dockerfile.web` | Done (shipped in D30/D31) |
+| 4 | `compose.yml` `prod` profile (`app-prod`, `web-prod` referencing GHCR images) + `denokv` sidecar service (shared across profiles, pinned to `0.14.0`) | `compose.yml` | Done (shipped in D30/D31) |
+| 5 | `Deno.openKv(DENO_KV_URL ?? 'http://denokv:4512')` in `main.ts` and `flush-cache.ts`; `--allow-net` added to `make flush-cache` | `apps/api/src/main.ts`, `apps/api/scripts/flush-cache.ts`, `Makefile` | Done (shipped in D30/D31) |
+| 6 | `DENO_KV_URL` + `DENO_KV_ACCESS_TOKEN` added to Zod env schema (both `z.string().optional()`) | `apps/api/src/config/env.ts` | Done (shipped in D30/D31) |
 | 7 | `.env.example` split into three files: root (local-dev infra), `apps/api/.env.example` (API runtime for Coolify), `apps/web/.env.example` (web build-time for GitHub Secrets) | `.env.example`, `apps/api/.env.example`, `apps/web/.env.example` | Already committed (on disk) |
-| 8 | `release.yml` workflow (build + push to GHCR on `main`/tags, with `cache-from/to: type=gha`, optional Coolify webhook deploy job) | `.github/workflows/release.yml` | Not yet implemented |
-| 9 | Makefile targets (`images`, `images-push`, `prod-up`, `prod-up-build`, `prod-down`, `release`) | `Makefile` | Not yet implemented |
+| 8 | `release.yml` workflow (build + push to GHCR on `main`/tags, with `cache-from/to: type=gha`, optional Coolify webhook deploy job) | `.github/workflows/release.yml` | Done (shipped in D30/D31) |
+| 9 | Makefile targets (`images`, `images-push`, `prod-up`, `prod-up-build`, `prod-down`, `release`) | `Makefile` | Done (shipped in D30/D31) |
 | 10 | This document | `coolify_deployment_plan.md` | Already committed (on disk) |
 
 **Health endpoints** (verified in `apps/api/src/routes/health.ts`):
@@ -181,6 +185,10 @@ default to **private**, flip them to **public** once:
 ---
 
 ## Step 0 — Pre-flight (before any Coolify work)
+
+> **Pinned runtime:** BrewForm runs on **Deno 2.9.0**. Both images build from
+> `denoland/deno:debian-2.9.0` (API `Dockerfile`, web `Dockerfile.web`), and CI pins
+> `deno-version: v2.9.0`. If you fork or rebuild an image, keep the base tag on `2.9.0`.
 
 Do all of this **before** you touch the Coolify panel. The web image bakes its config at build
 time, so getting these wrong means rebuilding and republishing images later.
@@ -522,11 +530,16 @@ To verify:
 
 ## Step 7 — First deploy: migrations & seed
 
+> **Workspace layout:** this is a native Deno workspace (root `deno.json`
+> `workspace.members = ["apps/*", "packages/*"]`; not Turborepo). The migrate/seed commands below
+> run from the repo root and reference `packages/db/` paths; the `cd packages/db && deno run -A
+> npm:drizzle-kit@0.31 …` form is equivalent and also correct.
+
 The API's `docker-entrypoint.sh` handles this automatically. Here's what happens on the first
 deploy (Step 3 above):
 
 1. **Container starts** → `docker-entrypoint.sh` runs.
-2. **Migrations:** `deno run -A npm:drizzle-kit@0.31.10 migrate` runs against `DATABASE_URL`.
+2. **Migrations:** `deno run -A npm:drizzle-kit@0.31 migrate` runs against `DATABASE_URL`.
    Drizzle applies any pending migration SQL files in `packages/db/drizzle/`. This creates all
    tables.
 3. **Seed check:** The script runs `SELECT count(*) FROM users`. If the count is `0`:
@@ -534,6 +547,9 @@ deploy (Step 3 above):
      equipment catalog, coffee varieties, seed users/recipes, and social data.
    - The admin credentials are logged once.
 4. **API starts:** `exec deno run --unstable-cron --unstable-kv apps/api/src/main.ts`.
+
+   > The `--unstable-cron` and `--unstable-kv` flags are still **required on Deno 2.9** — `Deno.cron`
+   > and Deno KV remain unstable APIs. Do not remove them.
 
 On subsequent restarts/redeploys:
 - Migrations run again (no-op if nothing pending).
@@ -741,7 +757,7 @@ missing or invalid required var causes an immediate exit with the field errors l
 - **Cause:** Usually a DB connectivity issue, or a migration file is missing from the image.
 - **Fix:** Verify `DATABASE_URL` is correct and the DB is reachable. If the image is missing
   migration files, the `Dockerfile` builder stage didn't run
-  `cd packages/db && deno run -A npm:drizzle-kit@0.31.10 generate` — rebuild and repush the
+  `cd packages/db && deno run -A npm:drizzle-kit@0.31 generate` — rebuild and repush the
   image.
 
 ### Seed runs on every restart (not just first boot)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -24,9 +24,9 @@ Overlays the container's own `node_modules` directory, **hiding** the host's `no
 Error: Cannot find module '@rolldown/binding-linux-arm64-gnu'
 ```
 
-### Deno Cache Volume (`deno_cache:/root/.cache/deno`)
+### Deno Cache Volume (`deno_cache:/deno-dir`)
 
-A persistent named volume for the global Deno cache (`/root/.cache/deno`). This avoids re-downloading JSR and npm packages on every container restart.
+A persistent named volume for the global Deno cache. The `denoland/deno:debian` image sets `DENO_DIR=/deno-dir`, so the cache is mounted there. This avoids re-downloading JSR and npm packages on every container restart.
 
 ### Volume Resolution Order
 

--- a/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/design.md
+++ b/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/design.md
@@ -1,0 +1,270 @@
+# Design — d32 Deploy plan & local-dev reconciliation with Deno 2.9 / workspaces
+
+## Context
+
+`d31` bumped the runtime to Deno 2.9.0, swapped Docker/CI installs to `deno ci`, and added
+workspace-management features. The operator guide (`coolify_deployment_plan.md`, authored by `d30`)
+and a couple of local-dev compose details were not updated in lockstep. This change is a focused
+reconciliation: fix one real local-dev bug (the dev Deno cache mount), pin one floating image,
+update the deployment guide to match the code, and add the docblocks + a guard test the standing
+project conventions require.
+
+Inputs that shaped the decisions below: a working-tree audit of `Dockerfile`, `Dockerfile.web`,
+`compose.yml`, `docker-entrypoint.sh`, `.dockerignore`, both CI workflows, the `Makefile`, and the
+two prior change folders; an empirical GNU Make compatibility test; a Deno-docs confirmation that
+cron/KV remain unstable on 2.9; and a line-precise extraction of `coolify_deployment_plan.md`
+(captured verbatim in Appendix A).
+
+## Decisions
+
+### Decision 1 — Mount the dev `deno_cache` volume at `/deno-dir`
+
+The `denoland/deno:debian` base image sets `DENO_DIR=/deno-dir`. The Dockerfiles already honor this
+(`COPY --from=deps /deno-dir /deno-dir`). But the dev compose services (`app`, `web-dev`) mount the
+`deno_cache` named volume at `/root/.cache/deno` — the *upstream default* Deno cache path, NOT the
+path this image uses. The result: Deno caches to `/deno-dir` (the container's writable layer, lost
+on recreate) while the named volume sits unused at `/root/.cache/deno`. Dependencies are re-fetched
+on every `docker compose down && up`.
+
+**Fix:** change both mounts to `deno_cache:/deno-dir`. This matches the image `DENO_DIR`, the
+Dockerfile stage copies, and the previously-recorded project note. No `DENO_DIR` env override is
+added — relying on the image default keeps a single source of truth.
+
+**Verification:** confirmed the image default by the Dockerfile's own `/deno-dir` copies and the
+recorded project memory; the guard test (Decision 6) asserts the corrected mount string.
+
+### Decision 2 — Keep dash-separated Makefile targets (rename dropped)
+
+The original ask was to rename dash targets to colon form (`serena-index` → `serena:index`) to
+match the `deno.json` task convention. **Empirically tested and dropped.**
+
+```
+GNU Make 3.81 (the developer's make):
+  serena:index:  →  *** target pattern contains no `%'.  Stop.   (parsed as a static pattern rule)
+  serena.index:  →  works
+  serena/index:  →  works
+  serena\:index: →  works; invokable as `make serena:index`      (backslash-escaped)
+```
+
+A bare colon is Make's rule separator, so `name:sub:` is read as `targets: target-pattern:
+prereqs` — a static pattern rule, which errors when the pattern has no `%`. This is grammar, not a
+version quirk. The backslash-escaped form gives the exact `make serena:index` UX, but requires
+`\:` on every target and prerequisite plus a rewrite of the `help` target's `grep`/`awk` (which
+splits on the first colon and would truncate `serena:up` → `serena`). Judged not worth the noise.
+
+**Consequence:** the existing dash targets stay. The deployment guide's `prod-up` / `images-push` /
+`prod-up-build` references remain correct, so no rename-driven doc churn is needed.
+
+### Decision 3 — Reconcile the drizzle-kit pin to `@0.31` (code is source of truth)
+
+The codebase pins `npm:drizzle-kit@0.31` in three places (`Makefile:121` `DRIZZLE_KIT`, the
+`Dockerfile` builder stage, `docker-entrypoint.sh`). The guide pins `@0.31.10` (lines ~529, ~744).
+The guide is the outlier and the over-specified one (the lockfile already nails the exact patch).
+Align the guide to `@0.31` so an operator copy-pasting a command from the guide runs the same
+version the image does.
+
+### Decision 4 — Pin the compose preview Caddy to `2.11.4-alpine`
+
+`Dockerfile.web` (production web image) pins `caddy:2.11.4-alpine`; the compose preview `web`
+service floats `caddy:2-alpine` (`compose.yml:216`). Pin the preview service to `2.11.4-alpine` so
+`make preview` exercises the same Caddy the published image uses. Low-risk reproducibility fix. The
+guide's §2 prerequisites table (line ~131) carries the same floating `caddy:2-alpine` string and is
+aligned too.
+
+### Decision 5 — Leave the unstable flags and `.dockerignore` alone (verified)
+
+Deno docs (current, covering 2.9) confirm `Deno.cron` and Deno KV are still unstable and require
+`--unstable-cron` / `--unstable-kv` (or the `deno.json` `"unstable"` array). The entrypoint flags
+and the guide's references are correct — no change, but a one-line note is added to the guide so a
+future reader does not "modernize" them away. `.dockerignore` still excludes `.env`/`*.env` and
+re-includes `*.env.example` — `d30`'s "no secrets in images" requirement holds. Recorded so a
+reviewer does not re-investigate.
+
+### Decision 6 — Hermetic, dependency-free guard test for the compose invariants
+
+The mount-path bug was invisible because nothing asserted it. Add a Deno test under
+`packages/shared/src/` (so it runs in CI's `test-unit` job, which already grants `--allow-read`)
+that reads the root `compose.yml` and asserts: the `deno_cache` volume mounts at `/deno-dir`, the
+old `/root/.cache/deno` mount string is absent, and the preview Caddy image is pinned. **Text-based
+assertions, not a YAML parse** — parsing would pull in `@std/yaml` (a new dependency + lockfile
+churn) for no real gain. The test resolves `compose.yml` from `import.meta.url` (three levels up
+from `packages/shared/src/`, mirroring `workspace.test.ts`) and follows the BDD convention. See the
+turnkey sketch in Appendix B.
+
+### Decision 7 — Doc-sync scope: live files only
+
+Update only live, executable, or current-doc surfaces: `compose.yml` and
+`coolify_deployment_plan.md`. Historical records (`openspec/changes/archive/**`, completed
+`plans/*.md`) and unrelated in-flight changes (`d27`, `d29`) are left untouched — rewriting them
+would muddy their diffs and falsify a historical record for no benefit.
+
+### Decision 8 — Correct the §2 prerequisites table status column
+
+The guide's §2 "Codebase prerequisites (implement & merge first)" table marks the D30 rows
+"Not yet implemented", but those shipped (D30 = commit `8a07857`, plus D31 = `eaffcdf`). Update the
+Status column so an operator is not told to implement already-shipped infra. Find with
+`grep -n 'Not yet implemented' coolify_deployment_plan.md`.
+
+## Risks
+
+- **Dev cache mount change forces a one-time re-cache.** Existing `deno_cache` volumes hold data at
+  the old path; after the change the first `make up`/`make dev` re-populates `/deno-dir`. One slow
+  startup, then persistent thereafter. Acceptable and self-correcting.
+- **Guard test brittleness.** Text assertions key off the exact mount/image strings; a benign
+  reformat of `compose.yml` could trip them. Mitigated by asserting on stable substrings
+  (`deno_cache:/deno-dir`, `caddy:2.11.4-alpine`) rather than whole lines, with a clear failure
+  message.
+
+## Open questions
+
+None blocking. (Possible tiny follow-up, out of scope: `d31`'s `deno-workspace-management`
+capability summary still mentions an "optional `deno ci --prod` runtime image" although its detailed
+requirement records that `--prod` was evaluated and rejected — a cosmetic inconsistency inside
+`d31`, not this change's concern.)
+
+---
+
+## Appendix A: Apply edit-map (verbatim) — `coolify_deployment_plan.md`
+
+> Line numbers are authoring-time hints; match on the quoted strings. Apply top-to-bottom.
+
+**A · drizzle-kit pin (2 replacements)**
+
+- Line ~529 — FIND `deno run -A npm:drizzle-kit@0.31.10 migrate` → REPLACE `deno run -A npm:drizzle-kit@0.31 migrate`
+- Line ~744 — FIND `cd packages/db && deno run -A npm:drizzle-kit@0.31.10 generate` → REPLACE `cd packages/db && deno run -A npm:drizzle-kit@0.31 generate`
+
+**B · Caddy pin (1 replacement, §2 table row 3, line ~131)**
+
+- FIND `caddy:2-alpine` (in the "Web Dockerfile: 3-stage build … serving `dist/` on port 80" row) → REPLACE `caddy:2.11.4-alpine`
+
+**Block A1 — insert after the `## Step 0 — Pre-flight (before any Coolify work)` heading (line ~183):**
+
+```markdown
+> **Pinned runtime:** BrewForm runs on **Deno 2.9.0**. Both images build from
+> `denoland/deno:debian-2.9.0` (API `Dockerfile`, web `Dockerfile.web`), and CI pins
+> `deno-version: v2.9.0`. If you fork or rebuild an image, keep the base tag on `2.9.0`.
+```
+
+**Block A2 — insert near the §2 Dockerfile prerequisite rows (lines ~129–131):**
+
+```markdown
+> **Install command:** the Docker `deps` stages and CI install dependencies with `deno ci`
+> (a frozen, lockfile-strict install — `rm -rf node_modules && deno install --frozen`), not
+> `deno install`. `deno ci` fails fast if `deno.lock` is missing or out of date.
+```
+
+**Block A3 — insert after the `## Step 7 — First deploy: migrations & seed` heading (line ~523):**
+
+```markdown
+> **Workspace layout:** this is a native Deno workspace (root `deno.json`
+> `workspace.members = ["apps/*", "packages/*"]`; not Turborepo). The migrate/seed commands below
+> run from the repo root and reference `packages/db/` paths; the `cd packages/db && deno run -A
+> npm:drizzle-kit@0.31 …` form is equivalent and also correct.
+```
+
+**Block A4 — insert immediately after the API-start line (line ~536, `exec deno run --unstable-cron --unstable-kv apps/api/src/main.ts`):**
+
+```markdown
+   > The `--unstable-cron` and `--unstable-kv` flags are still **required on Deno 2.9** — `Deno.cron`
+   > and Deno KV remain unstable APIs. Do not remove them.
+```
+
+**C · §2 prerequisites table Status column** — `grep -n 'Not yet implemented' coolify_deployment_plan.md`; replace each `Not yet implemented` with `Done (shipped in D30/D31)`.
+
+**Post-edit verification greps (all should return nothing):**
+
+```
+grep -n 'drizzle-kit@0.31.10' coolify_deployment_plan.md
+grep -n 'caddy:2-alpine' coolify_deployment_plan.md
+grep -n 'Not yet implemented' coolify_deployment_plan.md
+```
+
+---
+
+## Appendix B: Guard-test sketch — `packages/shared/src/compose-config.test.ts`
+
+```ts
+/**
+ * @module
+ * Compose-config guard: asserts the local-dev Deno cache mount and pinned images in the
+ * repo-root `compose.yml` so the d32 reconciliation fixes cannot silently regress.
+ */
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+
+/**
+ * Reads the repo-root `compose.yml` as raw text. This file lives at `packages/shared/src/`,
+ * three levels below the workspace root, so the path is resolved from `import.meta.url`
+ * (independent of the `deno test` working directory).
+ * @returns The full text of `compose.yml`.
+ */
+async function readComposeFile(): Promise<string> {
+  return await Deno.readTextFile(new URL('../../../compose.yml', import.meta.url));
+}
+
+describe('compose.yml local-dev invariants', () => {
+  it('mounts the Deno cache at the image DENO_DIR (/deno-dir)', async () => {
+    const compose = await readComposeFile();
+    expect(compose).toContain('deno_cache:/deno-dir');
+    expect(compose).not.toContain('deno_cache:/root/.cache/deno');
+  });
+
+  it('pins the preview Caddy image to match Dockerfile.web', async () => {
+    const compose = await readComposeFile();
+    expect(compose).toContain('caddy:2.11.4-alpine');
+    expect(compose).not.toContain('image: caddy:2-alpine');
+  });
+});
+```
+
+Runs under `deno task test:shared` / `make test-shared` (and the CI `test-unit` job, which grants
+`--allow-read`). No new dependency.
+
+---
+
+## Appendix C: Suggested docblocks
+
+**`packages/db/src/seed.ts`** (top of file):
+
+```ts
+/**
+ * @module
+ * Idempotent database seed for BrewForm. Populates reference data (taste notes, brew-method
+ * compatibility, badges, equipment + coffee-variety catalogs) plus a baseline admin user, vendors,
+ * beans, recipes, and social/setup sample data. Every insert uses `onConflictDoNothing`, so it is
+ * safe to re-run; invoked on first container boot (when the users table is empty) and via `make db-seed`.
+ */
+```
+
+**`packages/shared/src/workspace.test.ts`** (top of file):
+
+```ts
+/**
+ * @module
+ * Workspace-integrity test: asserts every Deno workspace member declares a `name` and `version`,
+ * the root `catalog` is internally consistent and covers every cross-member duplicated dependency,
+ * and member names are unique. Guards the workspace-management configuration added in d31.
+ */
+```
+
+**`scripts/generate-icons.ts`** (top of file):
+
+```ts
+/**
+ * @module
+ * Generates raster PNG app icons from `apps/web/public/favicon.svg` using resvg. Run via
+ * `make generate-icons`; writes the sized PNGs into the web public assets directory.
+ */
+```
+
+**`apps/api/scripts/build-email-templates.ts`** (before `function escapeBackticks`):
+
+```ts
+/**
+ * Escapes characters significant inside a JS template literal so a raw HTML/MJML string can be
+ * embedded safely between backticks: backslashes, backticks, and `$` (which would otherwise begin
+ * a `${...}` interpolation).
+ * @param str Raw string to escape.
+ * @returns The escaped string, safe to embed in a template literal.
+ */
+```

--- a/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/proposal.md
+++ b/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/proposal.md
@@ -1,0 +1,120 @@
+## Why
+
+`d30` (Coolify + GHCR deployment) and `d31` (Deno 2.7.14 → 2.9.0 + workspace management)
+landed back-to-back. `d30` authored the operator guide `coolify_deployment_plan.md` and the
+production Docker/compose topology; `d31` then bumped the runtime to **2.9.0**, swapped the Docker
+`deps` stages and CI to `deno ci`, and layered workspace-management features on top. The
+deployment guide and a few local-dev infra details were **never reconciled** with `d31`, leaving
+concrete drift between what the docs say and what the code does.
+
+A cross-check of both changes against the working tree found:
+
+1. **Dev Deno cache mounted at the wrong path.** The `denoland/deno:debian` image sets
+   `DENO_DIR=/deno-dir` (the Dockerfiles correctly `COPY --from=… /deno-dir /deno-dir` between
+   stages), but the dev compose services mount the `deno_cache` named volume at
+   `/root/.cache/deno` — `compose.yml:50` (`app`) and `compose.yml:94` (`web-dev`). Deno writes to
+   `/deno-dir` inside the container, so the named volume holds nothing useful and dependencies are
+   re-fetched on every `docker compose down && up`. The cache volume is effectively a no-op in dev.
+2. **`coolify_deployment_plan.md` is stale vs `d31`.** It pins `npm:drizzle-kit@0.31.10`
+   (lines ~529, ~745) while the codebase pins `npm:drizzle-kit@0.31` (`Makefile:121` `DRIZZLE_KIT`,
+   the `Dockerfile` builder stage, and `docker-entrypoint.sh`). It also never mentions the pinned
+   Deno **2.9.0** runtime, the `deno ci` install used by Docker/CI, or the Deno workspace layout
+   that the migrate/seed steps run inside.
+3. **Caddy pin inconsistency.** `Dockerfile.web` pins `caddy:2.11.4-alpine` (the published
+   production web image) while the compose preview `web` service floats `caddy:2-alpine`
+   (`compose.yml:215`) — a reproducibility gap between local preview and production.
+4. **Missing docblocks** on `d30`/`d31`-era scripts (`packages/db/src/seed.ts`,
+   `packages/shared/src/workspace.test.ts`, `scripts/generate-icons.ts` lack module docblocks; the
+   `escapeBackticks` helper in `apps/api/scripts/build-email-templates.ts` lacks a function docblock).
+5. **`d31` close-out leftover** (its task §14.1, 49/50): close superseded PR #54 and delete the
+   stale `feat/workspace-management` branch.
+
+### Verified NON-issues (investigated, no change needed — recorded so they are not re-litigated)
+
+- **`--unstable-cron` / `--unstable-kv` are still required on 2.9.** Confirmed via the Deno docs:
+  `Deno.cron` and Deno KV remain unstable in 2.9 and require the flags (or the `deno.json`
+  `"unstable"` array). The entrypoint flags and the plan's references are correct.
+- **`.dockerignore` `.env` exclusion is intact** (`.env`, `*.env`, `**/*.env` excluded;
+  `*.env.example` re-included) — `d30`'s "no secrets in images" requirement holds.
+- **Deno `2.9.0` and `deno ci` are already consistent** across both Dockerfiles and both CI
+  workflows — `d31` applied these correctly; nothing to fix there.
+- **The Makefile dash → colon target rename was considered and dropped.** GNU Make 3.81 (the
+  developer's `make`) cannot parse a bare-colon target name (`serena:index:` errors with `target
+  pattern contains no '%'` — it is read as a static pattern rule). A backslash-escaped form
+  (`serena\:index:`, invoked as `make serena:index`) does work, but was judged not worth the
+  Makefile noise and `help`-target rewrite. The existing dash-separated targets are kept as-is, so
+  the plan's `prod-up` / `images-push` references remain accurate. See `design.md` Decision 2.
+
+## What Changes
+
+- **Fix the dev Deno cache mount** — `compose.yml` `app` and `web-dev` services: mount the
+  `deno_cache` named volume at `/deno-dir` (the image `DENO_DIR`) instead of `/root/.cache/deno`,
+  so the dev dependency cache actually persists across container recreation.
+- **Pin the compose preview Caddy image** — `compose.yml` `web` (preview) service:
+  `caddy:2-alpine` → `caddy:2.11.4-alpine`, matching the pinned production `Dockerfile.web` base.
+- **Reconcile `coolify_deployment_plan.md` with `d31`**:
+  - `npm:drizzle-kit@0.31.10` → `npm:drizzle-kit@0.31` (match `Makefile`/`Dockerfile`/entrypoint).
+  - Add the pinned Deno **2.9.0** runtime to the prerequisites/pre-flight section and note the
+    `denoland/deno:debian-2.9.0` base images.
+  - Note that Docker `deps` stages and CI install via `deno ci` (frozen) wherever the guide
+    references building/rebuilding images.
+  - Note the Deno workspace layout (root `deno.json` `workspace.members`, `apps/*` + `packages/*`)
+    where the guide describes the migrate/seed steps that run inside it.
+  - Align any Caddy reference with the pinned `caddy:2.11.4-alpine`.
+- **Add missing docblocks** — module docblocks for `packages/db/src/seed.ts`,
+  `packages/shared/src/workspace.test.ts`, and `scripts/generate-icons.ts`; a function docblock for
+  `escapeBackticks()` in `apps/api/scripts/build-email-templates.ts`.
+- **Add a hermetic infra guard test** — a Deno test asserting the dev `deno_cache` mounts at
+  `/deno-dir` (and not the old path) and that the preview Caddy image is pinned, so this drift
+  cannot silently regress.
+- **Close out `d31`** — close PR #54 and delete the stale branch (tracked here for completeness;
+  ownership stays with `d31` §14.1).
+
+## Capabilities
+
+### New Capabilities
+
+- `local-dev-environment`: The Docker Compose dev profile persists the Deno dependency cache at the
+  image's `DENO_DIR` (`/deno-dir`) so the `deno_cache` volume is effective across container
+  recreation, and compose image references are version-pinned for reproducibility with the
+  published images. A hermetic test guards both invariants.
+- `deployment-guide`: The operator deployment guide (`coolify_deployment_plan.md`) accurately
+  reflects the current build/runtime reality established by `d31` — the pinned Deno 2.9.0 base
+  images, the `deno ci` frozen install, the Deno workspace layout the migrate/seed steps run in,
+  and the `npm:drizzle-kit@0.31` pin used by the codebase.
+
+### Modified Capabilities
+
+None as formal main specs. This change **touches** files owned by `d30`'s `container-deployment`
+capability (`compose.yml`, the Caddy image pin) and `d30`'s deployment guide, but the changes are
+corrective/additive: they fix a non-functional dev cache mount, pin a floating preview image, and
+align documentation with code. They do not alter `d30`'s deployment behavior, image topology,
+entrypoint, or the `denokv` sidecar, nor `d31`'s runtime version or `deno ci` adoption.
+
+## Impact
+
+- **compose.yml**: `app` + `web-dev` `deno_cache` mount → `/deno-dir`; preview `web` image →
+  `caddy:2.11.4-alpine`.
+- **coolify_deployment_plan.md**: drizzle-kit pin reconciled; Deno 2.9.0 / `deno ci` / workspace
+  layout notes added; Caddy reference aligned.
+- **packages/db/src/seed.ts**: `+ module docblock`.
+- **packages/shared/src/workspace.test.ts**: `+ module docblock`.
+- **scripts/generate-icons.ts**: `+ module docblock`.
+- **apps/api/scripts/build-email-templates.ts**: `+ docblock` on `escapeBackticks()`.
+- **packages/shared/src/** (new test): hermetic compose-config guard test (text-based assertions,
+  no new dependency).
+- **No application logic changes** — no API/runtime behavior changes.
+- **No database schema changes.**
+
+## Non-Goals
+
+- **Renaming Makefile targets to colon form** — GNU Make 3.81 is incompatible with bare-colon
+  target names; the existing dash targets are kept. (See `design.md` Decision 2.)
+- **Re-doing `d31`** — no change to the Deno version, the `deno ci` adoption, the catalog,
+  member `version` fields, `bump:*` tasks, or sanitizers. Those are `d31`'s and are correct.
+- **Changing deployment behavior** — the entrypoint, `--unstable-cron`/`--unstable-kv` flags, the
+  `denokv` sidecar, GHCR publishing (`release.yml`), and the compose `prod` profile are unchanged.
+- **Rewriting historical records** — `openspec/changes/archive/**`, completed `plans/*.md`, and the
+  other in-flight changes (`d27`, `d29`) are left as-is; they describe what was true at the time.
+- **No dependency version upgrades** and **no new runtime dependency** (the guard test uses
+  text-based assertions, not a YAML parser).

--- a/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/specs/deployment-guide/spec.md
+++ b/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/specs/deployment-guide/spec.md
@@ -1,0 +1,90 @@
+# Deployment Guide
+
+The operator deployment guide (`coolify_deployment_plan.md`) is the canonical instructions for
+self-hosting BrewForm on Coolify. It must stay consistent with the build/runtime reality that `d31`
+established, so an operator copy-pasting from it runs exactly what the images run.
+
+## ADDED Requirements
+
+### Requirement: Guide pins drizzle-kit consistently with the codebase
+
+The deployment guide SHALL reference `npm:drizzle-kit@0.31` for the migrate and generate commands,
+matching the pin used by `Makefile` (`DRIZZLE_KIT`), the `Dockerfile` builder stage, and
+`docker-entrypoint.sh`. The guide SHALL NOT pin a different drizzle-kit version (e.g. `@0.31.10`)
+than the one the images actually run.
+
+#### Scenario: Operator commands match image behavior
+
+- **WHEN** an operator copies a `drizzle-kit` migrate or generate command from the guide
+- **THEN** the version pin equals the codebase pin (`npm:drizzle-kit@0.31`)
+- **AND** running it reproduces the migration the image's entrypoint runs
+
+### Requirement: Guide reflects the pinned Deno 2.9.0 runtime
+
+The deployment guide SHALL state that the runtime is pinned to Deno **2.9.0** and that both images
+build from `denoland/deno:debian-2.9.0`. The prerequisites / pre-flight section SHALL surface this
+version so an operator validating the build environment knows the expected runtime.
+
+#### Scenario: Runtime version is discoverable in the guide
+
+- **WHEN** an operator reads the prerequisites / pre-flight section
+- **THEN** the pinned Deno runtime version (2.9.0) and the `denoland/deno:debian-2.9.0` base images
+  are stated
+
+### Requirement: Guide reflects the deno ci install and the workspace layout
+
+The deployment guide SHALL describe dependency installation in Docker `deps` stages and CI as
+`deno ci` (a frozen, lockfile-strict install), not `deno install`, wherever it covers building or
+rebuilding images. Where the guide describes the migrate/seed steps, it SHALL note that they run
+inside the Deno workspace (root `deno.json` `workspace.members` = `apps/*`, `packages/*`) and that
+the `cd packages/db && deno run -A npm:drizzle-kit@0.31 …` form is correct under that layout.
+
+#### Scenario: Build instructions reference deno ci
+
+- **WHEN** an operator reads the image build/rebuild or maintenance instructions
+- **THEN** they describe installs as `deno ci` (frozen), consistent with the Dockerfiles and CI
+
+#### Scenario: Migrate/seed steps acknowledge the workspace
+
+- **WHEN** an operator reads the first-deploy migrate/seed steps
+- **THEN** the guide notes the workspace layout and that the `packages/db` migrate/seed commands run
+  correctly within it
+
+### Requirement: Guide retains the required unstable runtime flags
+
+The deployment guide SHALL continue to show `--unstable-cron` and `--unstable-kv` on the API start
+command, because `Deno.cron` and Deno KV remain unstable on Deno 2.9 and require those flags (or the
+`deno.json` `"unstable"` array). The guide SHALL note this so the flags are not mistakenly removed
+as obsolete.
+
+#### Scenario: Unstable flags are preserved with rationale
+
+- **WHEN** a reader reviews the API start command in the guide
+- **THEN** `--unstable-cron` and `--unstable-kv` are present
+- **AND** a note explains they are still required on Deno 2.9
+
+### Requirement: Guide reflects that shipped codebase prerequisites are implemented
+
+The deployment guide's §2 "Codebase prerequisites" table SHALL NOT mark prerequisites that have
+already shipped as "Not yet implemented". The D30 deployment infra (Dockerfiles, entrypoint,
+`compose.yml` prod profile, `release.yml`, split `.env.example` files) and the D31 runtime upgrade
+shipped on `main` (D30 = commit `8a07857`, D31 = `eaffcdf`), so their rows SHALL show an
+implemented/done status.
+
+#### Scenario: Shipped prerequisites are not flagged as pending
+
+- **WHEN** an operator reads the §2 codebase-prerequisites table
+- **THEN** the rows for the shipped D30/D31 infra show an implemented status
+- **AND** none of them read "Not yet implemented"
+
+### Requirement: Guide aligns the Caddy image pin
+
+The deployment guide SHALL reference the web image's Caddy base as `caddy:2.11.4-alpine`, matching
+`Dockerfile.web` and the pinned compose preview service, rather than a floating `caddy:2-alpine`
+tag.
+
+#### Scenario: Caddy reference matches the pinned base
+
+- **WHEN** an operator reads the §2 web-Dockerfile prerequisite row
+- **THEN** it references `caddy:2.11.4-alpine`
+- **AND** it does not reference a floating `caddy:2-alpine` tag

--- a/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/specs/local-dev-environment/spec.md
+++ b/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/specs/local-dev-environment/spec.md
@@ -1,0 +1,59 @@
+# Local Development Environment
+
+The Docker Compose dev profile is the canonical local environment (all `make` targets run Deno
+inside these containers). Its Deno dependency cache must persist across container recreation, and
+its image references must be pinned for parity with the published production images.
+
+## ADDED Requirements
+
+### Requirement: Dev containers persist the Deno cache at the image DENO_DIR
+
+The Compose dev services (`app` and `web-dev`) SHALL mount the `deno_cache` named volume at the
+path the base image uses for `DENO_DIR` (`/deno-dir`), not the upstream default `/root/.cache/deno`.
+The `denoland/deno:debian` image sets `DENO_DIR=/deno-dir`, so a volume mounted anywhere else holds
+no cache and dependencies are re-fetched on every container recreation. No `DENO_DIR` environment
+override is introduced; the image default remains the single source of truth, matching the
+`Dockerfile`/`Dockerfile.web` `COPY … /deno-dir /deno-dir` stage copies.
+
+#### Scenario: Cache survives container recreation
+
+- **WHEN** a developer runs `make up`/`make dev`, lets dependencies cache, then runs `make down`
+  followed by `make up` again
+- **THEN** the second start reuses the `deno_cache` volume contents from `/deno-dir`
+- **AND** no full dependency re-fetch occurs
+
+#### Scenario: Dev mount path matches the image DENO_DIR
+
+- **WHEN** the `app` and `web-dev` service volume mounts in `compose.yml` are inspected
+- **THEN** each mounts `deno_cache` at `/deno-dir`
+- **AND** neither mounts `deno_cache` at `/root/.cache/deno`
+
+### Requirement: Compose image references are version-pinned for reproducibility
+
+The Compose preview `web` service SHALL pin its Caddy image to the same version the published web
+image uses (`caddy:2.11.4-alpine`, matching `Dockerfile.web`), rather than a floating
+`caddy:2-alpine` tag, so `make preview` exercises the same Caddy as production.
+
+#### Scenario: Preview Caddy matches the production pin
+
+- **WHEN** the preview `web` service image in `compose.yml` is compared with the `Dockerfile.web`
+  runner base image
+- **THEN** both reference `caddy:2.11.4-alpine`
+- **AND** the preview service does not use a floating `caddy:2-alpine` tag
+
+### Requirement: Compose configuration drift is covered by a test
+
+A test SHALL assert the local-dev compose invariants so they cannot silently regress: the dev
+`deno_cache` volume mounts at `/deno-dir`, the old `/root/.cache/deno` mount is absent, and the
+preview Caddy image is pinned to `caddy:2.11.4-alpine`. The test SHALL be hermetic and
+dependency-free (text-based assertions over the `compose.yml` contents, not a YAML parser), SHALL
+resolve `compose.yml` from `import.meta.url` so it passes regardless of the test working directory,
+and SHALL follow the repo's BDD convention (`jsr:@std/testing/bdd` + `jsr:@std/expect`). It SHALL
+live under `packages/shared/src/` so it runs in the existing shared-package test suite.
+
+#### Scenario: Reverting the cache mount fails the test
+
+- **WHEN** a `compose.yml` edit restores `deno_cache:/root/.cache/deno` or floats the preview Caddy
+  back to `caddy:2-alpine`
+- **THEN** the compose-config test fails
+- **AND** the failure message identifies the offending invariant

--- a/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/tasks.md
+++ b/openspec/changes/archive/2026-06-27-d32-deploy-plan-deno29-sync/tasks.md
@@ -1,0 +1,60 @@
+# Tasks — d32 Deploy plan & local-dev reconciliation
+
+> All line numbers are hints from the working tree at change-authoring time; they shift as edits
+> are applied. **Prefer string-based find/replace** (the exact before→after strings are in
+> `design.md` → "Appendix A: Apply edit-map"). After each section, re-grep to confirm no stragglers.
+
+## 1. Local-dev Deno cache mount fix (`compose.yml`)
+
+- [x] 1.1 `app` service (line ~51): `      - deno_cache:/root/.cache/deno` → `      - deno_cache:/deno-dir`.
+- [x] 1.2 `web-dev` service (line ~95): `      - deno_cache:/root/.cache/deno` → `      - deno_cache:/deno-dir`.
+- [x] 1.3 Confirm zero remaining wrong-path mounts: `grep -rn '/root/.cache/deno' compose.yml docs README.md coolify_deployment_plan.md` returns nothing.
+
+## 2. Compose image pinning (`compose.yml`)
+
+- [x] 2.1 Preview `web` service (line ~216): `    image: caddy:2-alpine` → `    image: caddy:2.11.4-alpine` (match `Dockerfile.web`).
+- [x] 2.2 Confirm: `grep -n 'caddy:' compose.yml` shows only `caddy:2.11.4-alpine` (no bare `caddy:2-alpine`).
+
+## 3. Hermetic compose-config guard test
+
+- [x] 3.1 Add `packages/shared/src/compose-config.test.ts` per the sketch in `design.md` → "Appendix B".
+      BDD (`jsr:@std/testing/bdd` + `jsr:@std/expect`); resolve `compose.yml` from `import.meta.url`
+      (`../../../compose.yml`, mirroring `workspace.test.ts`). Text assertions only — no `@std/yaml`.
+- [x] 3.2 Assert `deno_cache:/deno-dir` present AND `deno_cache:/root/.cache/deno` absent.
+- [x] 3.3 Assert `caddy:2.11.4-alpine` present AND `image: caddy:2-alpine` absent.
+- [x] 3.4 Module docblock on the test + docblock on the `readComposeFile` helper.
+- [x] 3.5 `deno task test:shared` (or `make test-shared`) collects and passes the new test.
+
+## 4. Deployment guide reconciliation (`coolify_deployment_plan.md`)
+
+> Verbatim before→after strings and insertion blocks: `design.md` → "Appendix A".
+
+- [x] 4.1 drizzle-kit pin: replace `npm:drizzle-kit@0.31.10` → `npm:drizzle-kit@0.31` (line ~529 migrate, line ~744 generate). Verify: `grep -n 'drizzle-kit@0.31.10' coolify_deployment_plan.md` returns nothing.
+- [x] 4.2 Caddy pin: `caddy:2-alpine` → `caddy:2.11.4-alpine` (line ~131, §2 prerequisites table).
+- [x] 4.3 Insert the Deno-2.9.0 runtime note after the "## Step 0 — Pre-flight" heading (line ~183) — Appendix A, block A1.
+- [x] 4.4 Insert the `deno ci` build note near the §2 Dockerfile prerequisite rows (lines ~129–131) — Appendix A, block A2.
+- [x] 4.5 Insert the workspace-layout note after the "## Step 7 — First deploy: migrations & seed" heading (line ~523) — Appendix A, block A3.
+- [x] 4.6 Insert the unstable-flags note after the API-start line (line ~536, `exec deno run --unstable-cron --unstable-kv apps/api/src/main.ts`) — Appendix A, block A4. Do NOT remove the flags.
+- [x] 4.7 Refresh the §2 "Codebase prerequisites" table **Status** column: the D30/D31 rows still read "Not yet implemented" but shipped (D30 = commit `8a07857`, D31 = `eaffcdf`). `grep -n 'Not yet implemented' coolify_deployment_plan.md`; change each to `Done (shipped in D30/D31)` (or equivalent).
+
+## 5. Docblocks (project convention)
+
+> Suggested docblock text: `design.md` → "Appendix C".
+
+- [x] 5.1 `packages/db/src/seed.ts` (top of file, before line 1 `import …`): add a `@module` docblock describing the idempotent seed.
+- [x] 5.2 `packages/shared/src/workspace.test.ts` (top of file, before line 1): add a `@module` docblock for the workspace-integrity suite (the `readJson` helper + constants are already documented).
+- [x] 5.3 `scripts/generate-icons.ts` (top of file, before line 1): add a `@module` docblock for the icon-generation script.
+- [x] 5.4 `apps/api/scripts/build-email-templates.ts` (before line ~43 `function escapeBackticks`): add a function docblock (escapes `\`, backtick, `$` for safe template-literal embedding).
+
+## 6. Verification
+
+- [x] 6.1 `deno fmt --check` passes (or run `deno fmt`).
+- [x] 6.2 `deno lint apps/ packages/` passes.
+- [x] 6.3 `deno task check` passes.
+- [x] 6.4 `deno task test:shared` passes (includes the new guard test + `workspace.test.ts`).
+- [x] 6.5 `openspec validate d32-deploy-plan-deno29-sync --strict` passes.
+- [ ] 6.6 Manual smoke: `make up && make dev`, then `make down && make up` — the second start reuses the cache (no full dependency re-fetch), proving the `/deno-dir` mount persists.
+
+## 7. d31 close-out (cross-reference)
+
+- [ ] 7.1 Close PR #54 (`feat/workspace-management`) with a note pointing to `d31-deno-29-upgrade` as its superseding change, and delete the stale branch. (Owned by `d31` §14.1; tracked here so the loose end is not lost.)

--- a/openspec/specs/deployment-guide/spec.md
+++ b/openspec/specs/deployment-guide/spec.md
@@ -1,0 +1,88 @@
+# deployment-guide Specification
+
+## Purpose
+TBD - created by archiving change d32-deploy-plan-deno29-sync. Update Purpose after archive.
+## Requirements
+### Requirement: Guide pins drizzle-kit consistently with the codebase
+
+The deployment guide SHALL reference `npm:drizzle-kit@0.31` for the migrate and generate commands,
+matching the pin used by `Makefile` (`DRIZZLE_KIT`), the `Dockerfile` builder stage, and
+`docker-entrypoint.sh`. The guide SHALL NOT pin a different drizzle-kit version (e.g. `@0.31.10`)
+than the one the images actually run.
+
+#### Scenario: Operator commands match image behavior
+
+- **WHEN** an operator copies a `drizzle-kit` migrate or generate command from the guide
+- **THEN** the version pin equals the codebase pin (`npm:drizzle-kit@0.31`)
+- **AND** running it reproduces the migration the image's entrypoint runs
+
+### Requirement: Guide reflects the pinned Deno 2.9.0 runtime
+
+The deployment guide SHALL state that the runtime is pinned to Deno **2.9.0** and that both images
+build from `denoland/deno:debian-2.9.0`. The prerequisites / pre-flight section SHALL surface this
+version so an operator validating the build environment knows the expected runtime.
+
+#### Scenario: Runtime version is discoverable in the guide
+
+- **WHEN** an operator reads the prerequisites / pre-flight section
+- **THEN** the pinned Deno runtime version (2.9.0) and the `denoland/deno:debian-2.9.0` base images
+  are stated
+
+### Requirement: Guide reflects the deno ci install and the workspace layout
+
+The deployment guide SHALL describe dependency installation in Docker `deps` stages and CI as
+`deno ci` (a frozen, lockfile-strict install), not `deno install`, wherever it covers building or
+rebuilding images. Where the guide describes the migrate/seed steps, it SHALL note that they run
+inside the Deno workspace (root `deno.json` `workspace.members` = `apps/*`, `packages/*`) and that
+the `cd packages/db && deno run -A npm:drizzle-kit@0.31 …` form is correct under that layout.
+
+#### Scenario: Build instructions reference deno ci
+
+- **WHEN** an operator reads the image build/rebuild or maintenance instructions
+- **THEN** they describe installs as `deno ci` (frozen), consistent with the Dockerfiles and CI
+
+#### Scenario: Migrate/seed steps acknowledge the workspace
+
+- **WHEN** an operator reads the first-deploy migrate/seed steps
+- **THEN** the guide notes the workspace layout and that the `packages/db` migrate/seed commands run
+  correctly within it
+
+### Requirement: Guide retains the required unstable runtime flags
+
+The deployment guide SHALL continue to show `--unstable-cron` and `--unstable-kv` on the API start
+command, because `Deno.cron` and Deno KV remain unstable on Deno 2.9 and require those flags (or the
+`deno.json` `"unstable"` array). The guide SHALL note this so the flags are not mistakenly removed
+as obsolete.
+
+#### Scenario: Unstable flags are preserved with rationale
+
+- **WHEN** a reader reviews the API start command in the guide
+- **THEN** `--unstable-cron` and `--unstable-kv` are present
+- **AND** a note explains they are still required on Deno 2.9
+
+### Requirement: Guide reflects that shipped codebase prerequisites are implemented
+
+The deployment guide's §2 "Codebase prerequisites" table SHALL NOT mark prerequisites that have
+already shipped as "Not yet implemented". The D30 deployment infra (Dockerfiles, entrypoint,
+`compose.yml` prod profile, `release.yml`, split `.env.example` files) and the D31 runtime upgrade
+shipped on `main` (D30 = commit `8a07857`, D31 = `eaffcdf`), so their rows SHALL show an
+implemented/done status.
+
+#### Scenario: Shipped prerequisites are not flagged as pending
+
+- **WHEN** an operator reads the §2 codebase-prerequisites table
+- **THEN** the rows for the shipped D30/D31 infra show an implemented status
+- **AND** none of them read "Not yet implemented"
+
+### Requirement: Guide aligns the Caddy image pin
+
+The deployment guide SHALL reference the web image's Caddy base as `caddy:2.11.4-alpine`, matching
+`Dockerfile.web` and the pinned compose preview service, rather than a floating `caddy:2-alpine`
+tag.
+
+#### Scenario: Caddy reference matches the pinned base
+
+- **WHEN** an operator reads the §2 web-Dockerfile prerequisite row
+- **THEN** it references `caddy:2.11.4-alpine`
+- **AND** it does not reference a floating `caddy:2-alpine` tag
+

--- a/openspec/specs/local-dev-environment/spec.md
+++ b/openspec/specs/local-dev-environment/spec.md
@@ -1,0 +1,57 @@
+# local-dev-environment Specification
+
+## Purpose
+TBD - created by archiving change d32-deploy-plan-deno29-sync. Update Purpose after archive.
+## Requirements
+### Requirement: Dev containers persist the Deno cache at the image DENO_DIR
+
+The Compose dev services (`app` and `web-dev`) SHALL mount the `deno_cache` named volume at the
+path the base image uses for `DENO_DIR` (`/deno-dir`), not the upstream default `/root/.cache/deno`.
+The `denoland/deno:debian` image sets `DENO_DIR=/deno-dir`, so a volume mounted anywhere else holds
+no cache and dependencies are re-fetched on every container recreation. No `DENO_DIR` environment
+override is introduced; the image default remains the single source of truth, matching the
+`Dockerfile`/`Dockerfile.web` `COPY … /deno-dir /deno-dir` stage copies.
+
+#### Scenario: Cache survives container recreation
+
+- **WHEN** a developer runs `make up`/`make dev`, lets dependencies cache, then runs `make down`
+  followed by `make up` again
+- **THEN** the second start reuses the `deno_cache` volume contents from `/deno-dir`
+- **AND** no full dependency re-fetch occurs
+
+#### Scenario: Dev mount path matches the image DENO_DIR
+
+- **WHEN** the `app` and `web-dev` service volume mounts in `compose.yml` are inspected
+- **THEN** each mounts `deno_cache` at `/deno-dir`
+- **AND** neither mounts `deno_cache` at `/root/.cache/deno`
+
+### Requirement: Compose image references are version-pinned for reproducibility
+
+The Compose preview `web` service SHALL pin its Caddy image to the same version the published web
+image uses (`caddy:2.11.4-alpine`, matching `Dockerfile.web`), rather than a floating
+`caddy:2-alpine` tag, so `make preview` exercises the same Caddy as production.
+
+#### Scenario: Preview Caddy matches the production pin
+
+- **WHEN** the preview `web` service image in `compose.yml` is compared with the `Dockerfile.web`
+  runner base image
+- **THEN** both reference `caddy:2.11.4-alpine`
+- **AND** the preview service does not use a floating `caddy:2-alpine` tag
+
+### Requirement: Compose configuration drift is covered by a test
+
+A test SHALL assert the local-dev compose invariants so they cannot silently regress: the dev
+`deno_cache` volume mounts at `/deno-dir`, the old `/root/.cache/deno` mount is absent, and the
+preview Caddy image is pinned to `caddy:2.11.4-alpine`. The test SHALL be hermetic and
+dependency-free (text-based assertions over the `compose.yml` contents, not a YAML parser), SHALL
+resolve `compose.yml` from `import.meta.url` so it passes regardless of the test working directory,
+and SHALL follow the repo's BDD convention (`jsr:@std/testing/bdd` + `jsr:@std/expect`). It SHALL
+live under `packages/shared/src/` so it runs in the existing shared-package test suite.
+
+#### Scenario: Reverting the cache mount fails the test
+
+- **WHEN** a `compose.yml` edit restores `deno_cache:/root/.cache/deno` or floats the preview Caddy
+  back to `caddy:2-alpine`
+- **THEN** the compose-config test fails
+- **AND** the failure message identifies the offending invariant
+

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,9 +1,11 @@
 /**
  * @module
- * Idempotent database seed for BrewForm. Populates reference data (taste notes, brew-method
+ * Re-runnable database seed for BrewForm. Populates reference data (taste notes, brew-method
  * compatibility, badges, equipment + coffee-variety catalogs) plus a baseline admin user, vendors,
- * beans, recipes, and social/setup sample data. Every insert uses `onConflictDoNothing`, so it is
- * safe to re-run; invoked on first container boot (when the users table is empty) and via `make db-seed`.
+ * beans, recipes, and social/setup sample data. Idempotent where supported: inserts use
+ * `onConflictDoNothing` on tables with unique constraints and fall back to select-before-insert
+ * existence checks for tables without them. Invoked on first container boot (when the users table is
+ * empty) and via `make db-seed`.
  */
 import { and, eq, ilike, sql } from 'drizzle-orm';
 import {

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,3 +1,10 @@
+/**
+ * @module
+ * Idempotent database seed for BrewForm. Populates reference data (taste notes, brew-method
+ * compatibility, badges, equipment + coffee-variety catalogs) plus a baseline admin user, vendors,
+ * beans, recipes, and social/setup sample data. Every insert uses `onConflictDoNothing`, so it is
+ * safe to re-run; invoked on first container boot (when the users table is empty) and via `make db-seed`.
+ */
 import { and, eq, ilike, sql } from 'drizzle-orm';
 import {
   badges,

--- a/packages/shared/src/compose-config.test.ts
+++ b/packages/shared/src/compose-config.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @module
+ * Compose-config guard: asserts the local-dev Deno cache mount and pinned images in the
+ * repo-root `compose.yml` so the d32 reconciliation fixes cannot silently regress.
+ */
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+
+/**
+ * Reads the repo-root `compose.yml` as raw text. This file lives at `packages/shared/src/`,
+ * three levels below the workspace root, so the path is resolved from `import.meta.url`
+ * (independent of the `deno test` working directory).
+ * @returns The full text of `compose.yml`.
+ */
+async function readComposeFile(): Promise<string> {
+  return await Deno.readTextFile(new URL('../../../compose.yml', import.meta.url));
+}
+
+describe('compose.yml local-dev invariants', () => {
+  it('mounts the Deno cache at the image DENO_DIR (/deno-dir)', async () => {
+    const compose = await readComposeFile();
+    expect(compose).toContain('deno_cache:/deno-dir');
+    expect(compose).not.toContain('deno_cache:/root/.cache/deno');
+  });
+
+  it('pins the preview Caddy image to match Dockerfile.web', async () => {
+    const compose = await readComposeFile();
+    expect(compose).toContain('caddy:2.11.4-alpine');
+    expect(compose).not.toContain('image: caddy:2-alpine');
+  });
+});

--- a/packages/shared/src/workspace.test.ts
+++ b/packages/shared/src/workspace.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @module
+ * Workspace-integrity test: asserts every Deno workspace member declares a `name` and `version`,
+ * the root `catalog` is internally consistent and covers every cross-member duplicated dependency,
+ * and member names are unique. Guards the workspace-management configuration added in d31.
+ */
 import { describe, it } from 'jsr:@std/testing/bdd';
 import { expect } from 'jsr:@std/expect';
 

--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -1,3 +1,8 @@
+/**
+ * @module
+ * Generates raster PNG app icons from `apps/web/public/favicon.svg` using resvg. Run via
+ * `make generate-icons`; writes the sized PNGs into the web public assets directory.
+ */
 import { Resvg } from 'npm:@resvg/resvg-js';
 import { join } from 'jsr:@std/path';
 


### PR DESCRIPTION
## Why

`d30` (Coolify + GHCR deployment) and `d31` (Deno 2.7.14 → 2.9.0 + workspace management) landed back-to-back, but the operator guide and a few local-dev infra details were never reconciled with `d31`. This change closes that drift. It also surfaced and fixed a stale-dev-image issue along the way (see Notes).

## What changed

**Local-dev (`compose.yml`)**
- Mount the dev `deno_cache` volume at the image `DENO_DIR` (`/deno-dir`) instead of the unused `/root/.cache/deno` for both `app` and `web-dev` — the cache volume was previously a no-op, re-fetching deps on every `down && up`.
- Pin the preview `web` service to `caddy:2.11.4-alpine` to match `Dockerfile.web`.
- New hermetic, dependency-free guard test `packages/shared/src/compose-config.test.ts` so the two invariants can't silently regress.

**Deployment guide (`coolify_deployment_plan.md`)**
- `npm:drizzle-kit@0.31.10` → `@0.31` (matches `Makefile`/`Dockerfile`/`docker-entrypoint.sh`).
- Align the Caddy pin; mark the shipped D30/D31 prerequisites **Done** (were "Not yet implemented").
- Add notes: pinned Deno **2.9.0** runtime + `denoland/deno:debian-2.9.0` base, the `deno ci` frozen install, the workspace layout under the migrate/seed steps, and why `--unstable-cron`/`--unstable-kv` are still required on 2.9 (flags retained).

**Docs & docblocks**
- `docs/docker.md`: document the corrected `/deno-dir` cache volume path.
- `@module` docblocks on `seed.ts`, `workspace.test.ts`, `generate-icons.ts`; function docblock on `escapeBackticks()` in `build-email-templates.ts`.

**OpenSpec**
- Archived `d32-deploy-plan-deno29-sync`; promoted two new capabilities into `openspec/specs/` (`local-dev-environment` 3 reqs, `deployment-guide` 6 reqs).

## Verification

- `make fmt` / `make check` / `make lint` clean on **Deno 2.9.0**.
- `deno task test:shared` green — includes the new `compose-config` guard test and `workspace.test.ts` (106 passed / 0 failed).
- `openspec validate --strict` passed pre-archive; archive applied spec deltas cleanly.
- Independent adversarial audit confirmed each requirement against the working tree with no over-reach.

## Notes

- **Stale local dev image:** the dev `app` image was still Deno **2.7.14** (built before d31's bump); its `deno fmt` reformatted unrelated `apps/web/*.html` files. Rebuilt the image to 2.9.0 (the `Dockerfile` already pinned it) and reverted those stray reformats — the diff is scoped to d32 only.
- **No behavior changes:** no application logic or DB schema changes; entrypoint, unstable flags, `denokv` sidecar, `release.yml`, and `.dockerignore` untouched.
- **Out of scope (deferred):** the d32 manual Docker cache-persistence smoke test and closing the superseded PR #54 / deleting `feat/workspace-management` (owned by d31 §14.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repeatable database seed flow to populate sample data and reference records more reliably.
  * Added a utility to generate app icons from the existing favicon source.

* **Bug Fixes**
  * Updated local development cache handling so Deno packages persist across restarts.
  * Pinned the preview web image version for more consistent builds.

* **Documentation**
  * Refreshed deployment and Docker guidance to match current runtime, install, and migration steps.
  * Added clearer notes for workspace setup and local development expectations.

* **Tests**
  * Added a check to guard key local-dev compose settings from accidental regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->