### PR TITLE
feat(web): runtime-configurable API URL for the Docker image

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -39,15 +39,19 @@ RUN deno task --cwd apps/web build
 
 # --- Stage 3: Runtime (Caddy) ---
 # Minimal static web server — serves the compiled SPA with try_files fallback.
-# No runtime env: the VITE_* values are already baked into the bundle above.
+# VITE_PUBLIC_APP_URL / VITE_LOG_LEVEL are baked into the bundle above. VITE_API_URL
+# has a build-time default baked in too, but the entrypoint can OVERRIDE it at
+# container start from the runtime $VITE_API_URL env var (it writes /config.js) — so a
+# prebuilt image can be retargeted to any API origin without a rebuild.
 #
 # Pinned to a specific Caddy patch for reproducible builds. To track the latest
 # 2.x patch automatically instead, swap the line below for: FROM caddy:2-alpine
 FROM caddy:2.11.4-alpine AS runner
 COPY --from=builder /app/apps/web/dist /usr/share/caddy
-# Production Caddyfile listening on :80 (not :8080 like the repo-root preview one).
-RUN printf ':80\nroot * /usr/share/caddy\nfile_server\ntry_files {path} /index.html\n' > /etc/caddy/Caddyfile
+# Production Caddyfile on :80 (the repo-root Caddyfile is the :8080 preview one).
+COPY apps/web/Caddyfile /etc/caddy/Caddyfile
+# Entrypoint regenerates /usr/share/caddy/config.js from $VITE_API_URL at start, then execs Caddy.
+COPY docker-web-entrypoint.sh /docker-web-entrypoint.sh
+RUN chmod +x /docker-web-entrypoint.sh
 EXPOSE 80
-# No CMD — the caddy:2-alpine base image's default CMD is
-# `caddy run --config /etc/caddy/Caddyfile --adapter caddyfile`, which reads the
-# Caddyfile written above.
+ENTRYPOINT ["/docker-web-entrypoint.sh"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -39,10 +39,10 @@ RUN deno task --cwd apps/web build
 
 # --- Stage 3: Runtime (Caddy) ---
 # Minimal static web server — serves the compiled SPA with try_files fallback.
-# VITE_PUBLIC_APP_URL / VITE_LOG_LEVEL are baked into the bundle above. VITE_API_URL
-# has a build-time default baked in too, but the entrypoint can OVERRIDE it at
-# container start from the runtime $VITE_API_URL env var (it writes /config.js) — so a
-# prebuilt image can be retargeted to any API origin without a rebuild.
+# VITE_PUBLIC_APP_URL is baked into the bundle above (build ARG). VITE_API_URL also has
+# a build-time default baked in, but the entrypoint can OVERRIDE it at container start
+# from the runtime $VITE_API_URL env var (it writes /config.js) — so a prebuilt image
+# can be retargeted to any API origin without a rebuild.
 #
 # Pinned to a specific Caddy patch for reproducible builds. To track the latest
 # 2.x patch automatically instead, swap the line below for: FROM caddy:2-alpine

--- a/README.md
+++ b/README.md
@@ -283,6 +283,17 @@ The API is versioned at `/api/v1/`. See [docs/api.md](docs/api.md) for the full 
 | [docs/docker.md](docs/docker.md)                       | Docker development environment, volume strategy, troubleshooting |
 | [docs/serena-mcp.md](docs/serena-mcp.md)               | Serena MCP setup, architecture, and troubleshooting        |
 
+## Container images
+
+The API and SPA publish to GHCR (`ghcr.io/ardakilic/brewform-api`, `ghcr.io/ardakilic/brewform-web`)
+on every push to `main` via `.github/workflows/release.yml`.
+
+The **web image's API URL is runtime-configurable**: set `VITE_API_URL` as a container
+environment variable to point a prebuilt image at any API origin **without rebuilding** — the
+entrypoint writes it into `/config.js` at startup, overriding the build-time default baked by
+Vite (resolution order: runtime `/config.js` → build-time `VITE_API_URL` → `/api/v1`). See
+[coolify_deployment_plan.md](coolify_deployment_plan.md) and [docs/deployment.md](docs/deployment.md).
+
 ## License
 
 See [LICENSE](LICENSE) for details.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -16,8 +16,11 @@
 #     (`VITE_API_URL=... VITE_PUBLIC_APP_URL=... make images`)
 #   - Runtime (web container): set VITE_API_URL as a normal env var to retarget a
 #     prebuilt image at deploy time (e.g. in Coolify) — overrides the baked default.
-#   - Fallback:       if unset, the build defaults to /api/v1 (relative) and
-#     http://localhost:8080 — useful for local testing only.
+#   - Fallbacks when unset (local testing only — production sets real values above):
+#       - plain `vite build` (defaults in vite.config.ts): VITE_API_URL=/api/v1,
+#         VITE_PUBLIC_APP_URL=http://localhost:5173
+#       - Docker image build (ARG defaults in Dockerfile.web): VITE_API_URL=/api/v1,
+#         VITE_PUBLIC_APP_URL=http://localhost:8080
 
 # === API URL ===  (build-time default; ALSO runtime-overridable on the container)
 # The absolute URL the SPA calls for API requests.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,32 +1,37 @@
 # ============================================================
 # BrewForm Web — Build-Time Environment (set as GitHub Secrets)
 # ============================================================
-# These are NOT runtime env vars. Vite inlines import.meta.env.* at BUILD
-# time, so these values are baked into the JS bundle and index.html meta
-# tags. The web container (Caddy serving static files) has NO runtime env.
+# Vite inlines import.meta.env.* at BUILD time, so these values are baked into the
+# JS bundle and index.html meta tags.
+#
+# EXCEPTION — VITE_API_URL is ALSO runtime-overridable: set it as an env var on the
+# web container and docker-web-entrypoint.sh writes it into /config.js at startup,
+# overriding the baked default with no rebuild. VITE_PUBLIC_APP_URL and VITE_LOG_LEVEL
+# remain build-time only (they affect index.html meta tags / the bundle).
 #
 # How to set them:
 #   - GitHub Actions: set as repository Secrets (VITE_API_URL, VITE_PUBLIC_APP_URL)
 #     → the release.yml workflow passes them as --build-arg to the Docker build.
 #   - Local build:    `make images` reads them from your shell environment
 #     (`VITE_API_URL=... VITE_PUBLIC_APP_URL=... make images`)
+#   - Runtime (web container): set VITE_API_URL as a normal env var to retarget a
+#     prebuilt image at deploy time (e.g. in Coolify) — overrides the baked default.
 #   - Fallback:       if unset, the build defaults to /api/v1 (relative) and
 #     http://localhost:8080 — useful for local testing only.
-#
-# Changing the API domain requires rebuilding and re-pushing the web image.
 
-# === API URL ===
+# === API URL ===  (build-time default; ALSO runtime-overridable on the container)
 # The absolute URL the SPA calls for API requests.
 # For subdomain routing: https://api.brewform.example.com/api/v1
 # For same-origin path routing: /api/v1 (relative — no rebuild needed if API moves)
+# Runtime override: set VITE_API_URL on the web container to retarget a prebuilt image.
 VITE_API_URL=https://api.brewform.example.com/api/v1
 
-# === Public App URL ===
+# === Public App URL ===  (build-time only)
 # The public web URL. Used by index.html for og:image / twitter:image meta tags
-# and by the robots.txt sitemap reference.
+# and by the robots.txt sitemap reference. Changing it requires a rebuild.
 VITE_PUBLIC_APP_URL=https://brewform.example.com
 
-# === Log Level (browser console) ===
+# === Log Level (browser console) ===  (build-time only)
 # Minimum log level for the browser console logger.
 # Levels: trace, debug, info, warn, error, fatal. Default: info.
 VITE_LOG_LEVEL=info

--- a/apps/web/Caddyfile
+++ b/apps/web/Caddyfile
@@ -1,0 +1,14 @@
+:80 {
+	root * /usr/share/caddy
+	encode gzip
+
+	# Never cache the runtime config. A redeployed container regenerates /config.js
+	# (see docker-web-entrypoint.sh) and its new API URL must take effect immediately.
+	# The hashed JS/CSS bundles are still cached normally by the browser.
+	@runtime-config path /config.js
+	header @runtime-config Cache-Control "no-store"
+
+	# SPA fallback: serve index.html for client-side (React Router) routes.
+	try_files {path} /index.html
+	file_server
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -14,6 +14,15 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
 
+    <!--
+      Runtime configuration. /config.js is regenerated at container start from the
+      $VITE_API_URL env var (see docker-web-entrypoint.sh), letting a prebuilt image be
+      retargeted without a rebuild. Loaded as a classic (blocking) script so
+      globalThis.__BREWFORM_CONFIG__ is set before the app module runs. In local dev / a
+      plain `vite build` it is an empty default and the build-time VITE_API_URL applies.
+    -->
+    <script src="/config.js"></script>
+
     <!-- Open Graph defaults -->
     <meta property="og:title" content="BrewForm" />
     <meta

--- a/apps/web/public/config.js
+++ b/apps/web/public/config.js
@@ -1,0 +1,8 @@
+// Runtime configuration for the BrewForm SPA.
+//
+// This file is OVERWRITTEN at container start by docker-web-entrypoint.sh, which
+// writes `globalThis.__BREWFORM_CONFIG__.apiUrl` from the container's $VITE_API_URL
+// env var. When that env var is unset (and in local dev / `vite build`), this empty
+// default is served and the app falls back to the build-time VITE_API_URL baked into
+// the bundle. Keep this in sync with the entrypoint's "no env" branch.
+globalThis.__BREWFORM_CONFIG__ = globalThis.__BREWFORM_CONFIG__ || {};

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -3,7 +3,15 @@ import { createLogger } from '@/utils/logger.ts';
 
 const log = createLogger('api-client');
 
-const API_BASE = import.meta.env.VITE_API_URL || '/api/v1';
+// API base URL resolution order:
+//   1. Runtime config — `globalThis.__BREWFORM_CONFIG__.apiUrl`, written into /config.js
+//      at container start by docker-web-entrypoint.sh from the $VITE_API_URL env var.
+//      Lets one prebuilt image be retargeted at deploy time with no rebuild.
+//   2. Build-time `import.meta.env.VITE_API_URL`, inlined into the bundle by Vite.
+//   3. Same-origin `/api/v1` fallback.
+const runtimeConfig =
+  (globalThis as { __BREWFORM_CONFIG__?: { apiUrl?: string } }).__BREWFORM_CONFIG__;
+const API_BASE = runtimeConfig?.apiUrl || import.meta.env.VITE_API_URL || '/api/v1';
 
 async function requestInternal(endpoint: string, options: RequestInit): Promise<unknown> {
   log.debug({ endpoint, method: options.method }, 'API request started');

--- a/coolify_deployment_plan.md
+++ b/coolify_deployment_plan.md
@@ -456,13 +456,17 @@ The `denokv` container runs the remote Deno KV server that the API uses for cach
 3. **Port exposes:** `80`
 4. **Assign to the same destination** as the API (so Caddy could proxy to the API if needed,
    though with subdomain routing the SPA talks to the API cross-origin via CORS).
-5. **Environment Variables:** **None.** The `VITE_API_URL` and `VITE_PUBLIC_APP_URL` are
-   baked into the image at build time (in the `release.yml` workflow via GitHub Secrets). The
-   web container has no runtime configuration.
+5. **Environment Variables:** **Optional.** `VITE_API_URL` and `VITE_PUBLIC_APP_URL` are
+   baked into the image at build time (in the `release.yml` workflow via GitHub Secrets), so
+   for this deployment you can leave the web resource's env **empty**. However, `VITE_API_URL`
+   is **runtime-overridable**: set it as an env var on the web resource and the image's
+   entrypoint writes it into `/config.js` at startup, overriding the baked default — handy for
+   pointing a prebuilt image at a different API origin without a rebuild.
 
-   > **If you need to change the API URL**, you must rebuild the web image with new
-   > `VITE_API_URL` / `VITE_PUBLIC_APP_URL` build-args and push a new `:latest`. There's no
-   > way to change it at runtime because Vite inlines `import.meta.env.*` at build time.
+   > **Changing the API URL:** set `VITE_API_URL` on the web resource and redeploy (no rebuild
+   > needed — the entrypoint regenerates `/config.js`). `VITE_PUBLIC_APP_URL` (og:image /
+   > sitemap meta) is still build-time only; changing it requires rebuilding and re-pushing the
+   > web image.
 
 6. **Deploy.** Verify it starts: `curl http://<coolify-assigned-domain>/` should return the
    SPA's `index.html`.
@@ -832,5 +836,6 @@ alongside `:latest`. To roll back:
 - **API domain:** Change the FQDN on the API resource in Coolify. Update
   `CORS_ALLOWED_ORIGINS` if the web domain changed. No image rebuild needed.
 - **Web domain:** Change the FQDN on the web resource in Coolify. If the **API** domain
-  changed, you must rebuild the web image with a new `VITE_API_URL` build-arg and push to
-  GHCR, then redeploy the web resource.
+  changed, set `VITE_API_URL` as a runtime env var on the web resource and redeploy — the
+  entrypoint regenerates `/config.js`, no rebuild needed. (Rebuilding with a new
+  `VITE_API_URL` build-arg also works and additionally updates the image's baked default.)

--- a/docker-web-entrypoint.sh
+++ b/docker-web-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+# Generate the SPA's runtime configuration from the container environment.
+#
+# When $VITE_API_URL is set it OVERRIDES the build-time value baked into the JS
+# bundle by Vite — so one prebuilt image can be retargeted at any deployment
+# (e.g. point it at a different API origin) without a rebuild. When unset, an
+# empty config is emitted and the app falls back to the build-time default.
+#
+# Mirror file: apps/web/public/config.js (the dev/build default).
+CONFIG_FILE=/usr/share/caddy/config.js
+
+if [ -n "${VITE_API_URL:-}" ]; then
+	printf 'globalThis.__BREWFORM_CONFIG__ = { apiUrl: "%s" };\n' "$VITE_API_URL" >"$CONFIG_FILE"
+	echo "[web-entrypoint] runtime VITE_API_URL applied: $VITE_API_URL"
+else
+	printf 'globalThis.__BREWFORM_CONFIG__ = globalThis.__BREWFORM_CONFIG__ || {};\n' >"$CONFIG_FILE"
+	echo "[web-entrypoint] no runtime VITE_API_URL set; using build-time default"
+fi
+
+exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile

--- a/docker-web-entrypoint.sh
+++ b/docker-web-entrypoint.sh
@@ -11,11 +11,25 @@ set -e
 # Mirror file: apps/web/public/config.js (the dev/build default).
 CONFIG_FILE=/usr/share/caddy/config.js
 
-if [ -n "${VITE_API_URL:-}" ]; then
-	printf 'globalThis.__BREWFORM_CONFIG__ = { apiUrl: "%s" };\n' "$VITE_API_URL" >"$CONFIG_FILE"
-	echo "[web-entrypoint] runtime VITE_API_URL applied: $VITE_API_URL"
-else
+write_default() {
 	printf 'globalThis.__BREWFORM_CONFIG__ = globalThis.__BREWFORM_CONFIG__ || {};\n' >"$CONFIG_FILE"
+}
+
+if [ -n "${VITE_API_URL:-}" ]; then
+	# Validate before embedding the value in the JS string literal below. Accept only an
+	# absolute http(s) URL or a root-relative path built from URL-safe characters; this
+	# allowlist excludes quotes, backslashes, whitespace and angle brackets, so the value
+	# cannot break out of the string or inject code into /config.js.
+	if printf '%s' "$VITE_API_URL" |
+		grep -Eq '^(https?://[A-Za-z0-9._~:/?#@%!$&()*+,;=-]+|/[A-Za-z0-9._~:/?#@%!$&()*+,;=-]*)$'; then
+		printf 'globalThis.__BREWFORM_CONFIG__ = { apiUrl: "%s" };\n' "$VITE_API_URL" >"$CONFIG_FILE"
+		echo "[web-entrypoint] runtime VITE_API_URL applied: $VITE_API_URL"
+	else
+		write_default
+		echo "[web-entrypoint] WARNING: VITE_API_URL is not a valid URL/path; ignoring it, using build-time default"
+	fi
+else
+	write_default
 	echo "[web-entrypoint] no runtime VITE_API_URL set; using build-time default"
 fi
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -81,6 +81,10 @@ Configured in `apps/web/deno.json`:
 - **`VITE_API_URL`** injected at build time via Vite's `define` config:
   - Production: `https://api.brewform.cc/api/v1`
   - Development: `/api/v1` (proxied by Vite dev server)
+  - **Runtime override (containerized / Coolify image only):** the Docker web image's
+    entrypoint (`docker-web-entrypoint.sh`) regenerates `/config.js` from a `VITE_API_URL`
+    env var at container start, overriding the baked default with no rebuild. The SPA reads
+    `window.__BREWFORM_CONFIG__.apiUrl` first, then the build-time value, then `/api/v1`.
 
 ## Deployment Process
 
@@ -146,6 +150,10 @@ TLS certificates are provisioned and auto-renewed via Let's Encrypt.
 | Variable | Description |
 |---|---|
 | `VITE_API_URL` | `https://api.brewform.cc/api/v1` |
+
+> `VITE_API_URL` can **also** be supplied at **runtime** to the containerized web image
+> (it overrides the build-time default via a regenerated `/config.js`); the other `VITE_*`
+> vars are build-time only.
 
 ## Deno Deploy Free Plan Capabilities
 


### PR DESCRIPTION
## Summary

Makes the web SPA's API URL **runtime-configurable** so a prebuilt
`ghcr.io/ardakilic/brewform-web` image can be pointed at any API origin **without a
rebuild**. Previously `VITE_API_URL` was inlined by Vite at build time, locking each
published image to a single origin (the reusability gap noted during the Coolify deploy).

## How it works

- The Caddy image's entrypoint (`docker-web-entrypoint.sh`) regenerates
  `/usr/share/caddy/config.js` from the container's `VITE_API_URL` env var at start.
- `index.html` loads `/config.js` (a classic, blocking script) before the app module.
- `apps/web/src/api/client.ts` resolves the API base in order:
  `globalThis.__BREWFORM_CONFIG__.apiUrl` → build-time `VITE_API_URL` → `/api/v1`.
- Caddy serves `/config.js` with `Cache-Control: no-store` so a redeploy's new URL takes
  effect immediately; hashed JS/CSS bundles cache normally.

**Backward compatible:** the build-time default is unchanged. With no runtime env set the
baked value wins, so the current `brewform.cc` deployment behaves identically.

## Usage

Set `VITE_API_URL` as a runtime env var on the web container (e.g. in Coolify) to retarget
a prebuilt image. No rebuild needed. `VITE_PUBLIC_APP_URL` (og:image / sitemap meta) stays
build-time only.

## Validation

- `deno fmt` / `deno lint` clean
- `deno task build:web` succeeds; `dist/config.js` present and `index.html` loads it
- `docker-web-entrypoint.sh` passes `sh -n`
- **814/814 web tests pass** (59 files)

## Docs updated

`README.md`, `coolify_deployment_plan.md` (Step 4 + maintenance), `docs/deployment.md`,
`apps/web/.env.example` (no longer claims the web container has no runtime env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web containers can now use a runtime API URL override without rebuilding the frontend image.
  * The app loads container-generated configuration before the main bundle, allowing deployed environments to switch API targets more easily.

* **Bug Fixes**
  * Runtime config updates are applied immediately on redeploy, with the config file served uncached.

* **Documentation**
  * Updated setup and deployment guidance to explain which environment variables are runtime-overridable versus build-time only.
  * Added clearer container image publishing and configuration notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->