### PR TITLE
docs: correct Coolify auto-deploy webhook trigger (§12)

### DIFF
--- a/docs/deployment_coolify.md
+++ b/docs/deployment_coolify.md
@@ -345,12 +345,24 @@ Coolify keeps provisioning/serving the origin Let's Encrypt cert and routing.
 
 ---
 
-## 12. Step 10 — Auto-deploy webhook (optional)
+## 12. Step 10 — Auto-deploy via CI webhook
 
-1. Coolify → Settings → API → enable; create a **Deploy**-scoped token.
-2. API resource → Webhooks → copy deploy URL; same for the web resource.
-3. GitHub repo Secrets: `COOLIFY_API_TOKEN`, `COOLIFY_API_WEBHOOK`, `COOLIFY_WEB_WEBHOOK`.
-   `release.yml`'s `deploy` job then redeploys both on every `main` push.
+GitHub Actions builds/pushes the images; a final CI step pings Coolify's deploy
+endpoint, which pulls `:latest` and recreates each container — no server-side builds.
+
+1. Coolify → **Keys & Tokens → API Tokens** → create a token with the **Deploy** ability.
+2. Get each resource's **UUID** (last segment of its dashboard URL, or its General
+   settings) and build its deploy URL:
+   `https://<coolify-host>/api/v1/deploy?uuid=<resource-uuid>`
+   (Docker Image resources have no Git source, so the trigger is this API endpoint —
+   not the resource's "Webhooks" tab, which is for Git providers.)
+3. GitHub repo Secrets — `COOLIFY_API_TOKEN` (the Deploy token),
+   `COOLIFY_API_WEBHOOK` (API deploy URL), `COOLIFY_WEB_WEBHOOK` (web deploy URL).
+   `release.yml`'s `deploy` job redeploys both on every `main` push (it self-gates on
+   `COOLIFY_API_WEBHOOK` + `COOLIFY_API_TOKEN`).
+
+> If **Settings → Advanced → "Allowed IPs for API Access"** is set, leave it empty/`0.0.0.0`
+> — GitHub runner IPs rotate and can't be allowlisted; the bearer token is the protection.
 
 ---
 


### PR DESCRIPTION
## What

Corrects §12 of `docs/deployment_coolify.md` to match how auto-deploy actually works (verified live against the running Coolify instance).

## Why

The previous text said *"API resource → Webhooks → copy deploy URL."* For **Docker Image** resources that's wrong — they have no Git source, so the deploy trigger is the API endpoint built from the resource UUID:

```
https://<coolify-host>/api/v1/deploy?uuid=<resource-uuid>
```

(authenticated with a Deploy-ability bearer token). This was confirmed by pinging both resources' deploy URLs and getting `200 … deployment queued`.

## Changes

- Rewrite step 2 to construct the deploy URL from the resource UUID and clarify the "Webhooks" tab is Git-only.
- Fix the token menu path → **Keys & Tokens → API Tokens**.
- Note the `deploy` job self-gates on `COOLIFY_API_WEBHOOK` + `COOLIFY_API_TOKEN`.
- Add the **Allowed IPs for API Access** caveat (leave empty/`0.0.0.0`; GitHub runner IPs rotate).

Docs-only; no code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the deployment guide with a new auto-deploy setup using CI webhooks.
  * Clarified which repository secrets are needed for deploy automation.
  * Added guidance for using the API token-based deploy endpoint and handling API access IP restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->