### PR TITLE
fix(admin,web): D41 admin user mutation guards + D38 security/error hardening (Wave 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Granular targets: `make check-api`, `make check-web`, `make test-api`, `make tes
 
 Run a single test file: `deno test --no-check --allow-all apps/api/src/path/to/file_test.ts` (inside Docker: `make test-specific filter=path/to/test.ts`).
 
-Type-check + lint after every edit. Test command order matters: `deno task check` then `deno task test`.
+Type-check + lint + **format** after every edit. Test command order matters: `deno task check` then `deno task test`. After finishing a batch of edits, run `make fmt` to apply `deno fmt` (lineWidth 100, indentWidth 2, singleQuote, semiColons) — the agent's symbolic edits preserve logic but may not match Deno's exact whitespace rules, so a final `make fmt` is mandatory before commit/PR. CI enforces `deno fmt --check` and will fail the build on unformatted code.
 
 ## Architecture
 
@@ -100,6 +100,11 @@ stay complete. This is mandatory, like logging — a route without `describeRout
 ## Code style
 
 - Formatting: `deno fmt` (lineWidth 100, indentWidth 2, singleQuote, semiColons).
+- **Run `make fmt` before every commit.** Symbolic edits and regex replacements preserve logic but
+  may not match Deno's exact whitespace rules (trailing commas, line wrapping, indentation). CI runs
+  `deno fmt --check` and fails the build on any diff. The pre-commit hook (`.githooks/pre-commit`,
+  enabled via `make setup-hooks`) also enforces this locally, but do not rely on the hook alone —
+  run `make fmt` proactively after each batch of edits, not just at commit time.
 - Lint exclusions: `no-explicit-any`, `require-await`, `no-empty`, `no-import-prefix`, `no-unversioned-import`.
 - Module files use `// deno-lint-ignore-file no-explicit-any require-await`.
 - All imports use explicit file extensions (`.ts`, `.tsx`, etc.) — no sloppy imports.

--- a/apps/api/src/modules/admin/index.ts
+++ b/apps/api/src/modules/admin/index.ts
@@ -8,6 +8,7 @@ import {
   AdminCreateUserSchema,
   AdminFlushCacheSchema,
   AdminModifyRecipeVisibilitySchema,
+  AdminSetRoleSchema,
   AdminUpdateUserSchema,
   BrewMethodCompatibilityCreateSchema,
   BrewMethodCompatibilityUpdateSchema,
@@ -250,7 +251,7 @@ admin.patch(
     description:
       'Grants or revokes the admin role on a user. Requires admin role. Returns 404 if the target user is soft-deleted or does not exist.',
     security: [{ bearerAuth: [] }],
-    requestBody: jsonRequestBody(z.object({ isAdmin: z.boolean() })),
+    requestBody: jsonRequestBody(AdminSetRoleSchema),
     responses: {
       200: {
         description: 'User updated',
@@ -266,7 +267,7 @@ admin.patch(
       },
     },
   }),
-  zValidator('json', z.object({ isAdmin: z.boolean() }), zodValidationHook),
+  zValidator('json', AdminSetRoleSchema, zodValidationHook),
   async (c) => {
     const adminId = c.get('userId') as string;
     const userId = c.req.param('id')!;

--- a/apps/api/src/modules/admin/index.ts
+++ b/apps/api/src/modules/admin/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { describeRoute } from 'hono-openapi';
+import { describeRoute, resolver } from 'hono-openapi';
 import { z } from 'zod';
 import { adminMiddleware, authMiddleware } from '../../middleware/auth.ts';
 import {
@@ -16,13 +16,17 @@ import {
   CoffeeVarietyUpdateSchema,
   EquipmentCreateSchema,
   EquipmentUpdateSchema,
+  ErrorEnvelopeSchema,
   PaginationSchema,
   ReportFilterSchema,
+  successEnvelope,
   TasteNoteCreateSchema,
   TasteNoteUpdateSchema,
+  UserRowOutputSchema,
   VendorCreateSchema,
   VendorUpdateSchema,
 } from '@brewform/shared/schemas';
+import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import * as service from './service.ts';
 import { cacheProvider } from '../../utils/cache/singleton.ts';
 import { error, paginated, success, zodValidationHook } from '../../utils/response/index.ts';
@@ -156,26 +160,52 @@ admin.post(
   },
 );
 
-admin.post('/users/:id/ban', zValidator('json', AdminBanUserSchema), async (c) => {
-  const adminId = c.get('userId') as string;
-  const targetId = c.req.param('id')!;
-  const { banned, reason } = c.req.valid('json');
-  try {
-    if (banned) {
-      const user = await service.banUser(adminId, targetId, reason);
-      return success(c, user);
-    } else {
-      const user = await service.unbanUser(adminId, targetId);
-      return success(c, user);
+admin.post(
+  '/users/:id/ban',
+  describeRoute({
+    tags: ['Admin'],
+    summary: 'Ban or unban a user',
+    description:
+      'Sets the banned state of a user. Requires admin role. Returns 404 if the target user is soft-deleted or does not exist.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(AdminBanUserSchema),
+    responses: {
+      200: {
+        description: 'User updated',
+        content: { 'application/json': { schema: resolver(successEnvelope(UserRowOutputSchema)) } },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'User not found (or soft-deleted)',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  zValidator('json', AdminBanUserSchema, zodValidationHook),
+  async (c) => {
+    const adminId = c.get('userId') as string;
+    const targetId = c.req.param('id')!;
+    const { banned, reason } = c.req.valid('json');
+    try {
+      if (banned) {
+        const user = await service.banUser(adminId, targetId, reason);
+        return success(c, user);
+      } else {
+        const user = await service.unbanUser(adminId, targetId);
+        return success(c, user);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'USER_NOT_FOUND') {
+        return error(c, 'NOT_FOUND', 'User not found.', 404);
+      }
+      throw err;
     }
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message === 'USER_NOT_FOUND') {
-      return error(c, 'NOT_FOUND', 'User not found.', 404);
-    }
-    throw err;
-  }
-});
+  },
+);
 
 admin.patch(
   '/users/:id',
@@ -214,13 +244,43 @@ admin.patch(
 
 admin.patch(
   '/users/:id/admin',
-  zValidator('json', z.object({ isAdmin: z.boolean() })),
+  describeRoute({
+    tags: ['Admin'],
+    summary: 'Set or clear admin role on a user',
+    description:
+      'Grants or revokes the admin role on a user. Requires admin role. Returns 404 if the target user is soft-deleted or does not exist.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(z.object({ isAdmin: z.boolean() })),
+    responses: {
+      200: {
+        description: 'User updated',
+        content: { 'application/json': { schema: resolver(successEnvelope(UserRowOutputSchema)) } },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'User not found (or soft-deleted)',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  zValidator('json', z.object({ isAdmin: z.boolean() }), zodValidationHook),
   async (c) => {
     const adminId = c.get('userId') as string;
     const userId = c.req.param('id')!;
     const { isAdmin } = c.req.valid('json');
-    const user = await service.setUserAdminRole(adminId, userId, isAdmin);
-    return success(c, user);
+    try {
+      const user = await service.setUserAdminRole(adminId, userId, isAdmin);
+      return success(c, user);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'USER_NOT_FOUND') {
+        return error(c, 'NOT_FOUND', 'User not found.', 404);
+      }
+      throw err;
+    }
   },
 );
 

--- a/apps/api/src/modules/admin/model.test.ts
+++ b/apps/api/src/modules/admin/model.test.ts
@@ -9,6 +9,7 @@ import {
   coffeeVarieties,
   equipment,
   equipmentDeleteRequests,
+  recipes,
   users,
   vendors,
 } from '@brewform/db/schema';
@@ -256,3 +257,239 @@ describe(
     });
   },
 );
+
+describe('banUser', { sanitizeOps: false, sanitizeResources: false }, () => {
+  let userId: string;
+
+  beforeEach(async () => {
+    userId = crypto.randomUUID();
+    await db.insert(users).values({
+      id: userId,
+      email: `ban-${userId}@example.com`,
+      username: `banuser-${userId}`,
+      passwordHash: 'hash',
+    });
+  });
+
+  afterEach(async () => {
+    await db.delete(users).where(eq(users.id, userId));
+  });
+
+  it('should ban an active user', async () => {
+    const result = await model.banUser(userId);
+    expect(result).not.toBeNull();
+    expect(result!.isBanned).toBe(true);
+  });
+
+  it('should return null for a soft-deleted user and not change isBanned', async () => {
+    await db.update(users).set({ deletedAt: new Date() }).where(eq(users.id, userId));
+    const result = await model.banUser(userId);
+    expect(result).toBeNull();
+    const [row] = await db.select().from(users).where(eq(users.id, userId));
+    expect(row.isBanned).toBe(false);
+  });
+
+  it('should not ban a user that is already banned and soft-deleted', async () => {
+    await db.update(users).set({ isBanned: true }).where(eq(users.id, userId));
+    await db.update(users).set({ deletedAt: new Date() }).where(eq(users.id, userId));
+    const result = await model.banUser(userId);
+    expect(result).toBeNull();
+    const [row] = await db.select().from(users).where(eq(users.id, userId));
+    expect(row.isBanned).toBe(true);
+  });
+});
+
+describe('unbanUser', { sanitizeOps: false, sanitizeResources: false }, () => {
+  let userId: string;
+
+  beforeEach(async () => {
+    userId = crypto.randomUUID();
+    await db.insert(users).values({
+      id: userId,
+      email: `unban-${userId}@example.com`,
+      username: `unbanuser-${userId}`,
+      passwordHash: 'hash',
+      isBanned: true,
+    });
+  });
+
+  afterEach(async () => {
+    await db.delete(users).where(eq(users.id, userId));
+  });
+
+  it('should unban an active banned user', async () => {
+    const result = await model.unbanUser(userId);
+    expect(result).not.toBeNull();
+    expect(result!.isBanned).toBe(false);
+  });
+
+  it('should return null for a soft-deleted user and not change isBanned', async () => {
+    await db.update(users).set({ deletedAt: new Date() }).where(eq(users.id, userId));
+    const result = await model.unbanUser(userId);
+    expect(result).toBeNull();
+    const [row] = await db.select().from(users).where(eq(users.id, userId));
+    expect(row.isBanned).toBe(true);
+  });
+});
+
+describe('setUserAdminRole', { sanitizeOps: false, sanitizeResources: false }, () => {
+  let userId: string;
+
+  beforeEach(async () => {
+    userId = crypto.randomUUID();
+    await db.insert(users).values({
+      id: userId,
+      email: `role-${userId}@example.com`,
+      username: `roleuser-${userId}`,
+      passwordHash: 'hash',
+    });
+  });
+
+  afterEach(async () => {
+    await db.delete(users).where(eq(users.id, userId));
+  });
+
+  it('should grant admin role on an active user', async () => {
+    const result = await model.setUserAdminRole(userId, true);
+    expect(result).not.toBeNull();
+    expect(result!.isAdmin).toBe(true);
+  });
+
+  it('should revoke admin role on an active user', async () => {
+    await model.setUserAdminRole(userId, true);
+    const result = await model.setUserAdminRole(userId, false);
+    expect(result).not.toBeNull();
+    expect(result!.isAdmin).toBe(false);
+  });
+
+  it('should return null for a soft-deleted user and not grant admin (privilege escalation blocked)', async () => {
+    await db.update(users).set({ deletedAt: new Date() }).where(eq(users.id, userId));
+    const result = await model.setUserAdminRole(userId, true);
+    expect(result).toBeNull();
+    const [row] = await db.select().from(users).where(eq(users.id, userId));
+    expect(row.isAdmin).toBe(false);
+  });
+});
+
+describe('updateRecipeVisibility', { sanitizeOps: false, sanitizeResources: false }, () => {
+  let userId: string;
+  let recipeId: string;
+
+  beforeEach(async () => {
+    userId = crypto.randomUUID();
+    recipeId = crypto.randomUUID();
+    await db.insert(users).values({
+      id: userId,
+      email: `recipe-${userId}@example.com`,
+      username: `recipeuser-${userId}`,
+      passwordHash: 'hash',
+    });
+    await db.insert(recipes).values({
+      id: recipeId,
+      slug: `test-recipe-${recipeId}`,
+      title: 'Test Recipe',
+      authorId: userId,
+    });
+  });
+
+  afterEach(async () => {
+    await db.delete(recipes).where(eq(recipes.id, recipeId));
+    await db.delete(users).where(eq(users.id, userId));
+  });
+
+  it('should update visibility on an active recipe', async () => {
+    const result = await model.updateRecipeVisibility(recipeId, 'public');
+    expect(result).not.toBeNull();
+    expect(result!.visibility).toBe('public');
+  });
+
+  it('should return null for a soft-deleted recipe and not change visibility', async () => {
+    await db.update(recipes).set({ deletedAt: new Date() }).where(eq(recipes.id, recipeId));
+    const result = await model.updateRecipeVisibility(recipeId, 'public');
+    expect(result).toBeNull();
+    const [row] = await db.select().from(recipes).where(eq(recipes.id, recipeId));
+    expect(row.visibility).toBe('draft');
+  });
+});
+
+describe('updateEquipment', { sanitizeOps: false, sanitizeResources: false }, () => {
+  let userId: string;
+  let equipmentId: string;
+
+  beforeEach(async () => {
+    userId = crypto.randomUUID();
+    equipmentId = crypto.randomUUID();
+    await db.insert(users).values({
+      id: userId,
+      email: `eq-${userId}@example.com`,
+      username: `equser-${userId}`,
+      passwordHash: 'hash',
+    });
+    await db.insert(equipment).values({
+      id: equipmentId,
+      name: 'Test Grinder',
+      type: 'grinder',
+      isSystem: false,
+      createdBy: userId,
+    });
+  });
+
+  afterEach(async () => {
+    await db.delete(equipment).where(eq(equipment.id, equipmentId));
+    await db.delete(users).where(eq(users.id, userId));
+  });
+
+  it('should update name on an active equipment', async () => {
+    const result = await model.updateEquipment(equipmentId, { name: 'Renamed Grinder' });
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe('Renamed Grinder');
+  });
+
+  it('should return null for a soft-deleted equipment and not change name', async () => {
+    await db.update(equipment).set({ deletedAt: new Date() }).where(eq(equipment.id, equipmentId));
+    const result = await model.updateEquipment(equipmentId, { name: 'Renamed Grinder' });
+    expect(result).toBeNull();
+    const [row] = await db.select().from(equipment).where(eq(equipment.id, equipmentId));
+    expect(row.name).toBe('Test Grinder');
+  });
+});
+
+describe('updateVendor', { sanitizeOps: false, sanitizeResources: false }, () => {
+  let userId: string;
+  let vendorId: string;
+
+  beforeEach(async () => {
+    userId = crypto.randomUUID();
+    vendorId = crypto.randomUUID();
+    await db.insert(users).values({
+      id: userId,
+      email: `vendor-${userId}@example.com`,
+      username: `vendoruser-${userId}`,
+      passwordHash: 'hash',
+    });
+    await db.insert(vendors).values({
+      id: vendorId,
+      name: 'Test Vendor',
+      createdBy: userId,
+    });
+  });
+
+  afterEach(async () => {
+    await db.delete(vendors).where(eq(vendors.id, vendorId));
+    await db.delete(users).where(eq(users.id, userId));
+  });
+
+  it('should update name on an active vendor', async () => {
+    const result = await model.updateVendor(vendorId, { name: 'Renamed Vendor' });
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe('Renamed Vendor');
+  });
+
+  it('should return null for a soft-deleted vendor and not change name', async () => {
+    await db.update(vendors).set({ deletedAt: new Date() }).where(eq(vendors.id, vendorId));
+    const result = await model.updateVendor(vendorId, { name: 'Renamed Vendor' });
+    expect(result).toBeNull();
+    const [row] = await db.select().from(vendors).where(eq(vendors.id, vendorId));
+    expect(row.name).toBe('Test Vendor');
+  });
+});

--- a/apps/api/src/modules/admin/model.ts
+++ b/apps/api/src/modules/admin/model.ts
@@ -95,22 +95,31 @@ export async function getUserById(id: string) {
 }
 
 /** Ban a user by setting `isBanned = true`. Returns the updated user or null. */
+/** Ban an active (non-deleted) user by setting `isBanned = true`. Returns the updated user, or null if the user is soft-deleted or not found. */
 export async function banUser(userId: string) {
-  const [result] = await db.update(users).set({ isBanned: true }).where(eq(users.id, userId))
+  const [result] = await db.update(users).set({ isBanned: true }).where(
+    and(eq(users.id, userId), isNull(users.deletedAt)),
+  )
     .returning();
   return result ?? null;
 }
 
 /** Unban a user by setting `isBanned = false`. Returns the updated user or null. */
+/** Unban an active (non-deleted) user by setting `isBanned = false`. Returns the updated user, or null if the user is soft-deleted or not found. */
 export async function unbanUser(userId: string) {
-  const [result] = await db.update(users).set({ isBanned: false }).where(eq(users.id, userId))
+  const [result] = await db.update(users).set({ isBanned: false }).where(
+    and(eq(users.id, userId), isNull(users.deletedAt)),
+  )
     .returning();
   return result ?? null;
 }
 
 /** Set or clear the admin role for a user. Returns the updated user or null. */
+/** Set or clear the admin role on an active (non-deleted) user. Returns the updated user, or null if the user is soft-deleted or not found. */
 export async function setUserAdminRole(userId: string, isAdmin: boolean) {
-  const [result] = await db.update(users).set({ isAdmin }).where(eq(users.id, userId)).returning();
+  const [result] = await db.update(users).set({ isAdmin }).where(
+    and(eq(users.id, userId), isNull(users.deletedAt)),
+  ).returning();
   return result ?? null;
 }
 
@@ -229,7 +238,7 @@ export async function updateRecipeVisibility(recipeId: string, visibility: strin
     return null;
   }
   const [result] = await db.update(recipes).set({ visibility }).where(
-    eq(recipes.id, recipeId),
+    and(eq(recipes.id, recipeId), isNull(recipes.deletedAt)),
   ).returning();
   return result ?? null;
 }
@@ -285,7 +294,9 @@ export async function updateEquipment(
   if (data.model !== undefined) sanitized.model = data.model;
   if (data.description !== undefined) sanitized.description = data.description;
 
-  const [result] = await db.update(equipment).set(sanitized).where(eq(equipment.id, id))
+  const [result] = await db.update(equipment).set(sanitized).where(
+    and(eq(equipment.id, id), isNull(equipment.deletedAt)),
+  )
     .returning();
   return result ?? null;
 }
@@ -329,7 +340,9 @@ export async function updateVendor(
   if (data.website !== undefined) sanitized.website = data.website;
   if (data.description !== undefined) sanitized.description = data.description;
 
-  const [result] = await db.update(vendors).set(sanitized).where(eq(vendors.id, id)).returning();
+  const [result] = await db.update(vendors).set(sanitized).where(
+    and(eq(vendors.id, id), isNull(vendors.deletedAt)),
+  ).returning();
   return result ?? null;
 }
 

--- a/apps/api/src/modules/admin/model.ts
+++ b/apps/api/src/modules/admin/model.ts
@@ -94,7 +94,6 @@ export async function getUserById(id: string) {
   return result[0] ?? null;
 }
 
-/** Ban a user by setting `isBanned = true`. Returns the updated user or null. */
 /** Ban an active (non-deleted) user by setting `isBanned = true`. Returns the updated user, or null if the user is soft-deleted or not found. */
 export async function banUser(userId: string) {
   const [result] = await db.update(users).set({ isBanned: true }).where(
@@ -104,7 +103,6 @@ export async function banUser(userId: string) {
   return result ?? null;
 }
 
-/** Unban a user by setting `isBanned = false`. Returns the updated user or null. */
 /** Unban an active (non-deleted) user by setting `isBanned = false`. Returns the updated user, or null if the user is soft-deleted or not found. */
 export async function unbanUser(userId: string) {
   const [result] = await db.update(users).set({ isBanned: false }).where(
@@ -114,7 +112,6 @@ export async function unbanUser(userId: string) {
   return result ?? null;
 }
 
-/** Set or clear the admin role for a user. Returns the updated user or null. */
 /** Set or clear the admin role on an active (non-deleted) user. Returns the updated user, or null if the user is soft-deleted or not found. */
 export async function setUserAdminRole(userId: string, isAdmin: boolean) {
   const [result] = await db.update(users).set({ isAdmin }).where(

--- a/apps/api/src/modules/report/index.test.ts
+++ b/apps/api/src/modules/report/index.test.ts
@@ -1,0 +1,94 @@
+import '../../test-setup.ts';
+import { afterEach, beforeEach, describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { Hono } from 'hono';
+import { setCacheProvider } from '../../utils/cache/singleton.ts';
+import { InMemoryCacheProvider } from '../../utils/cache/index.ts';
+import report from './index.ts';
+import type { AppEnv } from '../../types/hono.ts';
+
+/**
+ * Rate-limit route tests for `POST /api/v1/reports`.
+ *
+ * The rate-limit middleware is the FIRST middleware in the POST chain (before
+ * `authMiddleware` and `zValidator`), so the 429 fires regardless of body or
+ * auth validity. These tests exploit that to send unauthenticated POSTs with
+ * empty bodies — the limiter keys by IP, not auth state, so the 4th POST from
+ * the same IP returns 429 no matter what. This mirrors the contact rate-limit
+ * test (`contact.test.ts:53-68`) and avoids the JWT-minting complexity that
+ * authenticated route tests normally require.
+ *
+ * Admin GET/PATCH routes on the same router are NOT throttled by the
+ * `keyPrefix: 'report'` limiter (it is applied to POST only, not via
+ * `report.use('*', ...)`) — the second test asserts that exhausting the POST
+ * budget does not produce 429 on `GET /api/v1/reports`.
+ */
+
+function createTestApp() {
+  const app = new Hono<AppEnv>();
+  app.use('*', async (c, next) => {
+    c.set('requestId', crypto.randomUUID());
+    await next();
+  });
+  app.route('/api/v1/reports', report);
+  return app;
+}
+
+describe(
+  'POST /api/v1/reports — rate limit',
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    beforeEach(() => {
+      // Fresh cache per test so the rate-limit counter does not leak between tests
+      // (pattern from rateLimit.test.ts:11-13).
+      setCacheProvider(new InMemoryCacheProvider());
+    });
+
+    afterEach(() => {
+      setCacheProvider(new InMemoryCacheProvider());
+    });
+
+    it('returns 429 on the 4th POST within the rate-limit window', async () => {
+      const app = createTestApp();
+      // The first 3 POSTs are processed by the limiter (they may 401/400 because
+      // auth/body are invalid, but the limiter counter increments regardless —
+      // it runs before authMiddleware and zValidator).
+      for (let i = 0; i < 3; i++) {
+        await app.request('/api/v1/reports', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ recipeId: crypto.randomUUID(), reason: 'spam' }),
+        });
+      }
+      // The 4th POST in the same 15-minute window from the same IP returns 429.
+      const res = await app.request('/api/v1/reports', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipeId: crypto.randomUUID(), reason: 'spam' }),
+      });
+      expect(res.status).toBe(429);
+      const body = await res.json();
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('RATE_LIMITED');
+    });
+
+    it('does not throttle admin GET routes (report limiter is POST-only)', async () => {
+      const app = createTestApp();
+      // Exhaust the POST budget first.
+      for (let i = 0; i < 3; i++) {
+        await app.request('/api/v1/reports', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ recipeId: crypto.randomUUID(), reason: 'spam' }),
+        });
+      }
+      // A 4th POST would be 429 — but a GET on the same router must NOT be 429
+      // (the report-specific limiter is applied to POST only, not via
+      // `report.use('*', ...)`). The GET may return 401 (no auth) or 403 (not
+      // admin), but the assertion is that it is not throttled by the report
+      // limiter.
+      const res = await app.request('/api/v1/reports', { method: 'GET' });
+      expect(res.status).not.toBe(429);
+    });
+  },
+);

--- a/apps/api/src/modules/report/index.ts
+++ b/apps/api/src/modules/report/index.ts
@@ -17,14 +17,25 @@ import type { AppEnv } from '../../types/hono.ts';
 
 const report = new Hono<AppEnv>();
 
+/** Per-IP rate limit for report submission: 3 requests per 15 minutes. */
+const REPORT_RATE_LIMIT_WINDOW_MS = 15 * 60_000;
+const REPORT_RATE_LIMIT_MAX_REQUESTS = 3;
+const REPORT_RATE_LIMIT_KEY_PREFIX = 'report';
+
 report.post(
   '/',
-  rateLimitMiddleware({ windowMs: 15 * 60_000, maxRequests: 3, keyPrefix: 'report' }),
+  rateLimitMiddleware({
+    windowMs: REPORT_RATE_LIMIT_WINDOW_MS,
+    maxRequests: REPORT_RATE_LIMIT_MAX_REQUESTS,
+    keyPrefix: REPORT_RATE_LIMIT_KEY_PREFIX,
+  }),
   describeRoute({
     tags: ['Reports'],
     summary: 'Create a report',
     description:
-      'Submits a moderation report against a recipe or comment. Rate-limited to 3 requests per 15 minutes per IP.',
+      `Submits a moderation report against a recipe or comment. Rate-limited to ${REPORT_RATE_LIMIT_MAX_REQUESTS} requests per ${
+        REPORT_RATE_LIMIT_WINDOW_MS / 60_000
+      } minutes per IP.`,
     security: [{ bearerAuth: [] }],
     requestBody: jsonRequestBody(ReportCreateSchema),
     responses: {
@@ -39,7 +50,9 @@ report.post(
         content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
       },
       429: {
-        description: 'Rate limit exceeded (3 requests per 15 minutes)',
+        description: `Rate limit exceeded (${REPORT_RATE_LIMIT_MAX_REQUESTS} requests per ${
+          REPORT_RATE_LIMIT_WINDOW_MS / 60_000
+        } minutes)`,
         content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
       },
     },

--- a/apps/api/src/modules/report/index.ts
+++ b/apps/api/src/modules/report/index.ts
@@ -9,6 +9,7 @@ import {
   successEnvelope,
 } from '@brewform/shared/schemas';
 import { adminMiddleware, authMiddleware } from '../../middleware/auth.ts';
+import { rateLimitMiddleware } from '../../middleware/rateLimit.ts';
 import * as service from './service.ts';
 import { error, paginated, success, zodValidationHook } from '../../utils/response/index.ts';
 import { jsonRequestBody } from '../../utils/openapi/index.ts';
@@ -18,10 +19,12 @@ const report = new Hono<AppEnv>();
 
 report.post(
   '/',
+  rateLimitMiddleware({ windowMs: 15 * 60_000, maxRequests: 3, keyPrefix: 'report' }),
   describeRoute({
     tags: ['Reports'],
     summary: 'Create a report',
-    description: 'Submits a moderation report against a recipe or comment.',
+    description:
+      'Submits a moderation report against a recipe or comment. Rate-limited to 3 requests per 15 minutes per IP.',
     security: [{ bearerAuth: [] }],
     requestBody: jsonRequestBody(ReportCreateSchema),
     responses: {
@@ -33,6 +36,10 @@ report.post(
       },
       401: {
         description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      429: {
+        description: 'Rate limit exceeded (3 requests per 15 minutes)',
         content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
       },
     },

--- a/apps/api/src/utils/sanitize.test.ts
+++ b/apps/api/src/utils/sanitize.test.ts
@@ -1,0 +1,141 @@
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { sanitizeName, sanitizeText } from './sanitize.ts';
+
+/**
+ * Unit tests for the server-side text sanitization utilities.
+ *
+ * `sanitizeText` and `sanitizeName` are security controls (regex-based stripping
+ * used by `comment`, `recipe`, and `user` services). A regression — a tag or
+ * attribute slipping through — would ship silently without this suite.
+ *
+ * The tests cover both dangerous-input neutralisation and benign-input
+ * pass-through (regression baseline). Known limitations (no `javascript:` URL
+ * filtering, no HTML entity decoding, `<` not followed by a letter) are
+ * asserted as pass-through cases to lock the current behaviour as a baseline
+ * — if a future change adds filtering, the test will fail and force a
+ * conscious update.
+ *
+ * Follows the pure-utility convention: no `test-setup.ts`, no Hono app, no
+ * spies, nested `describe` per function, `'should ...'` `it` naming.
+ */
+
+describe('sanitizeText', () => {
+  it('should return empty string for null', () => {
+    expect(sanitizeText(null)).toBe('');
+  });
+
+  it('should return empty string for undefined', () => {
+    expect(sanitizeText(undefined)).toBe('');
+  });
+
+  it('should return empty string for empty string', () => {
+    expect(sanitizeText('')).toBe('');
+  });
+
+  it('should strip script tags and preserve inner text', () => {
+    expect(sanitizeText('<script>alert(1)</script>')).toBe('alert(1)');
+  });
+
+  it('should strip script tags with attributes', () => {
+    expect(sanitizeText('<script src="x.js"></script>')).toBe('');
+  });
+
+  it('should strip closing tags', () => {
+    expect(sanitizeText('</script>')).toBe('');
+  });
+
+  it('should strip image tags with onerror handlers', () => {
+    expect(sanitizeText('<img src=x onerror=alert(1)>')).toBe('');
+  });
+
+  it('should strip anchor tags with onclick handlers and preserve inner text', () => {
+    expect(sanitizeText('<a href="x" onclick="alert(1)">link</a>')).toBe('link');
+  });
+
+  it('should preserve numeric comparison expressions (the [a-z] anchor)', () => {
+    expect(sanitizeText('1 < 2 > 1')).toBe('1 < 2 > 1');
+  });
+
+  it('should remove zero-width space (U+200B)', () => {
+    expect(sanitizeText('hello\u200Bworld')).toBe('helloworld');
+  });
+
+  it('should remove zero-width non-joiner (U+200C)', () => {
+    expect(sanitizeText('hello\u200Cworld')).toBe('helloworld');
+  });
+
+  it('should remove zero-width joiner (U+200D)', () => {
+    expect(sanitizeText('hello\u200Dworld')).toBe('helloworld');
+  });
+
+  it('should remove BOM (U+FEFF)', () => {
+    expect(sanitizeText('hello\uFEFFworld')).toBe('helloworld');
+  });
+
+  it('should remove soft hyphen (U+00AD)', () => {
+    expect(sanitizeText('hello\u00ADworld')).toBe('helloworld');
+  });
+
+  it('should collapse runs of spaces/tabs to a single space', () => {
+    expect(sanitizeText('a   b')).toBe('a b');
+  });
+
+  it('should preserve single newlines', () => {
+    expect(sanitizeText('line1\nline2')).toBe('line1\nline2');
+  });
+
+  it('should collapse 3+ consecutive newlines to 2', () => {
+    expect(sanitizeText('a\n\n\nb')).toBe('a\n\nb');
+  });
+
+  it('should trim leading and trailing whitespace', () => {
+    expect(sanitizeText('  hello  ')).toBe('hello');
+  });
+
+  it('should pass plain text through unchanged', () => {
+    expect(sanitizeText('hello world')).toBe('hello world');
+  });
+
+  it('should pass markdown bold/italic through unchanged', () => {
+    expect(sanitizeText('**bold** _italic_')).toBe('**bold** _italic_');
+  });
+
+  // Documented limitations — asserted as pass-through to lock the regression
+  // baseline. If a future change adds filtering here, these tests will fail
+  // and force a conscious update.
+
+  it('should pass javascript: URLs through unchanged (documented limitation)', () => {
+    expect(sanitizeText('javascript:alert(1)')).toBe('javascript:alert(1)');
+  });
+
+  it('should pass HTML entity-encoded attacks through unchanged (documented limitation)', () => {
+    expect(sanitizeText('&#60;script&#62;')).toBe('&#60;script&#62;');
+  });
+
+  it('should pass "<" not followed by a letter through unchanged (documented limitation)', () => {
+    expect(sanitizeText('< script>')).toBe('< script>');
+  });
+});
+
+describe('sanitizeName', () => {
+  it('should collapse newlines to single spaces', () => {
+    expect(sanitizeName('John\nDoe')).toBe('John Doe');
+  });
+
+  it('should collapse runs of whitespace to a single space', () => {
+    expect(sanitizeName('John   Doe')).toBe('John Doe');
+  });
+
+  it('should strip HTML tags inherited from sanitizeText', () => {
+    expect(sanitizeName('<script>John</script>')).toBe('John');
+  });
+
+  it('should return empty string for null', () => {
+    expect(sanitizeName(null)).toBe('');
+  });
+
+  it('should trim leading and trailing whitespace', () => {
+    expect(sanitizeName('  John  ')).toBe('John');
+  });
+});

--- a/apps/web/src/components/SessionRestoreBanner.tsx
+++ b/apps/web/src/components/SessionRestoreBanner.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { useAuth } from '../contexts/AuthContext.tsx';
+
+/**
+ * Renders a banner when the last session-restore attempt failed due to a
+ * server or network error, with retry and dismiss actions. Returns null
+ * when there is no error (the user is logged out cleanly or the session is
+ * intact). The retry button calls `refreshUser()`; on success the
+ * `refreshUser` try block sets `sessionError` to null and this component
+ * unmounts via the early return. The dismiss button calls
+ * `clearSessionError()` to clear the banner without retrying.
+ */
+export function SessionRestoreBanner() {
+  const { sessionError, clearSessionError, refreshUser } = useAuth();
+  const [retrying, setRetrying] = useState(false);
+
+  if (!sessionError) return null;
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    try {
+      await refreshUser();
+      // On success, refreshUser's try block sets sessionError to null and
+      // this component unmounts.
+    } catch {
+      // refreshUser never throws (it catches internally) — this is a
+      // type-safety guard.
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  const message = sessionError === 'network'
+    ? "Couldn't reach the server. Check your connection and retry."
+    : "Couldn't restore your session — the server had an error. Retry?";
+
+  return (
+    <div
+      className='flex items-center justify-center gap-2 px-4 py-2 text-sm'
+      style={{ backgroundColor: 'var(--error)', color: 'white' }}
+    >
+      <span>{message}</span>
+      <button
+        type='button'
+        onClick={handleRetry}
+        disabled={retrying}
+        className='underline font-medium'
+      >
+        {retrying ? 'Retrying...' : 'Retry'}
+      </button>
+      <button
+        type='button'
+        onClick={clearSessionError}
+        className='underline font-medium'
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/SessionRestoreBanner.tsx
+++ b/apps/web/src/components/SessionRestoreBanner.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext.tsx';
+import { createLogger } from '@/utils/logger.ts';
+
+const log = createLogger('SessionRestoreBanner');
 
 /**
  * Renders a banner when the last session-restore attempt failed due to a
@@ -8,7 +11,8 @@ import { useAuth } from '../contexts/AuthContext.tsx';
  * intact). The retry button calls `refreshUser()`; on success the
  * `refreshUser` try block sets `sessionError` to null and this component
  * unmounts via the early return. The dismiss button calls
- * `clearSessionError()` to clear the banner without retrying.
+ * `clearSessionError()` to clear the banner without retrying. The banner
+ * uses `role='alert'` so screen readers announce it when it appears.
  */
 export function SessionRestoreBanner() {
   const { sessionError, clearSessionError, refreshUser } = useAuth();
@@ -22,9 +26,11 @@ export function SessionRestoreBanner() {
       await refreshUser();
       // On success, refreshUser's try block sets sessionError to null and
       // this component unmounts.
-    } catch {
+    } catch (err) {
       // refreshUser never throws (it catches internally) — this is a
-      // type-safety guard.
+      // type-safety guard. Log defensively in case a future change makes
+      // it rethrow.
+      log.error({ err }, 'SessionRestoreBanner retry failed');
     } finally {
       setRetrying(false);
     }
@@ -36,6 +42,7 @@ export function SessionRestoreBanner() {
 
   return (
     <div
+      role='alert'
       className='flex items-center justify-center gap-2 px-4 py-2 text-sm'
       style={{ backgroundColor: 'var(--error)', color: 'white' }}
     >

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -4,6 +4,7 @@ import { Navbar } from './Navbar.tsx';
 import { Footer } from './Footer.tsx';
 import { CookieConsent } from '../CookieConsent.tsx';
 import { EmailVerificationBanner } from '../EmailVerificationBanner.tsx';
+import { SessionRestoreBanner } from '../SessionRestoreBanner.tsx';
 import { PageSkeleton } from '../ui/Skeleton.tsx';
 import { useTranslation } from '../../contexts/I18nContext.tsx';
 
@@ -29,6 +30,7 @@ export function Layout() {
         {t('a11y.skipToContent')}
       </a>
       <EmailVerificationBanner />
+      <SessionRestoreBanner />
       <Navbar />
       <main id='main-content' className='flex-1' tabIndex={-1}>
         <Suspense fallback={<PageSkeleton />}>

--- a/apps/web/src/contexts/AuthContext.test.tsx
+++ b/apps/web/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { AuthProvider } from './AuthContext.tsx';
+import { I18nProvider } from '../contexts/I18nContext.tsx';
+import type { AuthUser } from '@brewform/shared/types';
+import { useAuth } from './AuthContext.tsx';
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('@/utils/logger.ts', () => ({ createLogger: () => mockLogger }));
+
+vi.mock('../api/index', () => ({
+  authApi: {
+    login: vi.fn(),
+    logout: vi.fn().mockResolvedValue({}),
+    registrationStatus: vi.fn().mockResolvedValue({ enabled: true }),
+  },
+  userApi: {
+    me: vi.fn().mockRejectedValue(new Error('Not authenticated')),
+  },
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    upload: vi.fn(),
+  },
+  ApiError: class extends Error {
+    code: string;
+    status: number;
+    details?: Array<{ field: string; message: string }>;
+    constructor(
+      code: string,
+      message: string,
+      details?: Array<{ field: string; message: string }>,
+      status: number = 500,
+    ) {
+      super(message);
+      this.code = code;
+      this.status = status;
+      this.details = details;
+    }
+  },
+}));
+
+import { ApiError, userApi } from '../api/index.ts';
+
+const VALID_USER: AuthUser = {
+  id: 'u1',
+  email: 'x@y.z',
+  username: 'x',
+  displayName: null,
+  avatarUrl: null,
+  isAdmin: false,
+  onboardingCompleted: true,
+  emailVerifiedAt: '2024-01-01T00:00:00.000Z',
+};
+
+/**
+ * Exposes the auth context state into the DOM for assertion. A tiny
+ * consumer-only component that reads `useAuth()` and renders the fields
+ * under test into spans — `user-id`, `session-error`, `loading`.
+ */
+function TestConsumer() {
+  const { user, sessionError, isLoading } = useAuth();
+  return (
+    <div>
+      <span data-testid='user-id'>{user?.id ?? 'none'}</span>
+      <span data-testid='session-error'>{sessionError ?? 'none'}</span>
+      <span data-testid='loading'>{String(isLoading)}</span>
+    </div>
+  );
+}
+
+async function renderProvider() {
+  const result = render(
+    <MemoryRouter>
+      <I18nProvider>
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>
+      </I18nProvider>
+    </MemoryRouter>,
+  );
+  // Wait for the mount refreshUser to settle (isLoading flips to false).
+  await waitFor(() => {
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+  });
+  return result;
+}
+
+describe('AuthContext refreshUser error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogger.debug.mockClear();
+    mockLogger.info.mockClear();
+    mockLogger.warn.mockClear();
+    mockLogger.error.mockClear();
+    // Reset default — each test overrides as needed.
+    vi.mocked(userApi.me).mockRejectedValue(new Error('Not authenticated'));
+  });
+
+  it('401 on refresh — sessionError stays null, warn logged', async () => {
+    vi.mocked(userApi.me).mockRejectedValue(
+      new ApiError('UNAUTHORIZED', 'Unauthorized', undefined, 401),
+    );
+    await renderProvider();
+    expect(screen.getByTestId('user-id').textContent).toBe('none');
+    expect(screen.getByTestId('session-error').textContent).toBe('none');
+    expect(mockLogger.warn).toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('500 on refresh — sessionError is server, error logged', async () => {
+    vi.mocked(userApi.me).mockRejectedValue(
+      new ApiError('INTERNAL_ERROR', 'Server error', undefined, 500),
+    );
+    await renderProvider();
+    expect(screen.getByTestId('user-id').textContent).toBe('none');
+    expect(screen.getByTestId('session-error').textContent).toBe('server');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('network failure — sessionError is network, error logged', async () => {
+    vi.mocked(userApi.me).mockRejectedValue(new TypeError('Failed to fetch'));
+    await renderProvider();
+    expect(screen.getByTestId('user-id').textContent).toBe('none');
+    expect(screen.getByTestId('session-error').textContent).toBe('network');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('banned user — sessionError null, warn with banned message', async () => {
+    vi.mocked(userApi.me).mockRejectedValue(
+      new ApiError('USER_BANNED', 'Account banned', undefined, 403),
+    );
+    await renderProvider();
+    expect(screen.getByTestId('user-id').textContent).toBe('none');
+    expect(screen.getByTestId('session-error').textContent).toBe('none');
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'AuthContext user account is banned',
+    );
+  });
+
+  it('successful refresh — user set, no error', async () => {
+    vi.mocked(userApi.me).mockResolvedValue(VALID_USER);
+    await renderProvider();
+    expect(screen.getByTestId('user-id').textContent).toBe('u1');
+    expect(screen.getByTestId('session-error').textContent).toBe('none');
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -9,12 +9,16 @@ interface AuthContextType {
   user: AuthUser | null;
   isLoading: boolean;
   isAuthenticated: boolean;
+  /** Why the last session-restore attempt failed: 'network' (client could not reach server), 'server' (5xx), or null (no error / 401 / banned — silent logout is correct). */
+  sessionError: 'network' | 'server' | null;
   login: (email: string, password: string, rememberMe?: boolean) => Promise<void>;
   register: (
     data: { email: string; username: string; password: string; displayName?: string },
   ) => Promise<void>;
   logout: () => Promise<void>;
   refreshUser: () => Promise<void>;
+  /** Clear `sessionError` to null without retrying — for the banner's dismiss action. */
+  clearSessionError: () => void;
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);
@@ -27,6 +31,10 @@ const AuthContext = createContext<AuthContextType | null>(null);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [sessionError, setSessionError] = useState<'network' | 'server' | null>(null);
+
+  /** Clear `sessionError` to null without retrying — for the banner's dismiss action. */
+  const clearSessionError = useCallback(() => setSessionError(null), []);
 
   function isBannedError(err: unknown): boolean {
     return err instanceof ApiError &&
@@ -36,23 +44,40 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const refreshUser = useCallback(async () => {
     log.debug({}, 'AuthContext token refresh started');
     try {
+      setSessionError(null);
       const userData = await userApi.me();
       log.debug({}, 'AuthContext token refresh completed');
       setUser(userData);
     } catch (err) {
       if (isBannedError(err)) {
         log.warn({ err }, 'AuthContext user account is banned');
+        setUser(null);
+        setSessionError(null);
+      } else if (err instanceof ApiError && err.status === 401) {
+        log.warn({ err }, 'AuthContext session expired or not authenticated');
+        setUser(null);
+        setSessionError(null);
+      } else if (err instanceof ApiError && err.status >= 500) {
+        log.error({ err }, 'Session restore failed — server error');
+        setUser(null);
+        setSessionError('server');
+      } else if (!(err instanceof ApiError)) {
+        log.error({ err }, 'Session restore failed — network error');
+        setUser(null);
+        setSessionError('network');
       } else {
-        log.warn({ err }, 'AuthContext token refresh failed — session may be expired');
+        // Other 4xx (403, 404) — treat as auth-state issue, not server health
+        log.warn({ err }, 'AuthContext token refresh failed');
+        setUser(null);
+        setSessionError(null);
       }
-      setUser(null);
     } finally {
       setIsLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    refreshUser().catch(() => {});
+    refreshUser();
   }, [refreshUser]);
 
   async function login(email: string, password: string, rememberMe = false) {
@@ -99,10 +124,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         user,
         isLoading,
         isAuthenticated: !!user,
+        sessionError,
         login,
         register,
         logout,
         refreshUser,
+        clearSessionError,
       }}
     >
       {children}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,3 +268,44 @@ Commands:
 
 Tests run with `--no-check` (type checking done separately via `make check`).
 All barrel file imports use explicit `.ts` extensions.
+
+## Code Style & Formatting
+
+BrewForm uses `deno fmt` as the single source of truth for code formatting. The formatter config
+lives in the root `deno.json` (`fmt` key): `lineWidth: 100`, `indentWidth: 2`, `singleQuote`,
+`semiColons: true`.
+
+### Mandatory `make fmt` before commit
+
+**Run `make fmt` after every batch of edits, before committing or pushing.** Symbolic edits and
+regex replacements (whether from an agent, an IDE, or a manual refactor) preserve logic but may not
+match Deno's exact whitespace rules — trailing commas, line wrapping, indentation, and semicolon
+insertion are all normalised by `deno fmt` in ways that are easy to miss by eye.
+
+CI enforces `deno fmt --check` in both the `ci.yml` quality job and the `pr.yml` check job, and
+**fails the build on any formatting diff**. The pre-commit hook (`.githooks/pre-commit`, enabled via
+`make setup-hooks`) also runs `deno fmt --check` locally, but do not rely on the hook alone — run
+`make fmt` proactively after each batch of edits, not just at commit time.
+
+### Commands
+
+| Command | Purpose |
+|---------|---------|
+| `make fmt` | Apply `deno fmt` to all files (in-place) |
+| `make fmt-check` | Check formatting without changes (CI uses this) |
+| `make lint` | Run `deno lint` across all workspaces |
+| `make check` | Type-check all workspaces (`deno check`) |
+| `make ci` | Full pipeline: `fmt-check` → `lint` → `check` → `build` → `test` |
+
+### Lint exclusions
+
+The following rules are excluded repo-wide (configured in each workspace's `deno.json`):
+`no-explicit-any`, `require-await`, `no-empty`, `no-import-prefix`, `no-unversioned-import`. Module
+files that need `any` for Drizzle row types or test fixtures use a single file-level directive:
+`// deno-lint-ignore-file no-explicit-any require-await` on line 1.
+
+### Import conventions
+
+- All imports use explicit file extensions (`.ts`, `.tsx`) — no sloppy imports.
+- All npm/JSR specifiers are versioned (e.g. `hono@4.6.14`, `jsr:@std/testing@1.0.10`) — see
+  `deno.json` `imports` and each workspace's `deno.json`.

--- a/openspec/changes/wave-1-correctness-security/design.md
+++ b/openspec/changes/wave-1-correctness-security/design.md
@@ -1,0 +1,242 @@
+## Context
+
+Wave 1 of the debt roadmap bundles two P1 correctness/security items (`D41` + `D38`) into one shippable change. They share no code paths, no spec dependencies, and no test fixtures — the bundle exists only because both are small and the PR overhead of splitting them is larger than the review cost of keeping them together. This design treats them as three independent sub-changes (D41, D38-p1, D38-p2, D38-p3) that happen to land in one commit.
+
+### Architecture — the three sub-changes at a glance
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  WAVE 1 — three independent sub-changes, one PR                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  D41 — admin user mutation guards                                            │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │  model.ts    banUser/unbanUser/setUserAdminRole  ──┐                   │  │
+│  │             updateRecipeVisibility/updateEquipment/updateVendor         │  │
+│  │             add isNull(deletedAt) guard to WHERE    │                   │  │
+│  │                                                     ▼                   │  │
+│  │  service.ts  (no change — null→throw already exists before audit log)  │  │
+│  │                                                     │                   │  │
+│  │                                                     ▼                   │  │
+│  │  index.ts    PATCH /users/:id/admin  ── add try/catch → 404            │  │
+│  │              (ban/unban route already correct)                         │  │
+│  │              + describeRoute on both routes                            │  │
+│  │                                                     │                   │  │
+│  │                                                     ▼                   │  │
+│  │  model.test.ts  new describe blocks (3 primary + 3 optional siblings)  │  │
+│  └────────────────────────────────────────────────────────────────────────┘  │
+│                                                                              │
+│  D38-p1 — report rate limit                                                  │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │  report/index.ts   import rateLimitMiddleware                          │  │
+│  │                    report.post('/',                                    │  │
+│  │                      rateLimitMiddleware({                             │  │
+│  │                        windowMs: 15*60_000, maxRequests: 3,            │  │
+│  │                        keyPrefix: 'report'                             │  │
+│  │                      }),  ← FIRST middleware on POST only              │  │
+│  │                      describeRoute({ ... + 429 entry }),               │  │
+│  │                      authMiddleware, zValidator(...), handler          │  │
+│  │                    )                                                   │  │
+│  │                    (GET/PATCH admin routes NOT throttled)              │  │
+│  │                                                                        │  │
+│  │  report/index.test.ts (NEW)  4th POST → 429                           │  │
+│  └────────────────────────────────────────────────────────────────────────┘  │
+│                                                                              │
+│  D38-p2 — sanitizer tests                                                    │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │  utils/sanitize.test.ts (NEW)  describe('sanitizeText') /              │  │
+│  │                                describe('sanitizeName')                │  │
+│  │                                table-ish it() cases                    │  │
+│  │  (no production code change)                                           │  │
+│  └────────────────────────────────────────────────────────────────────────┘  │
+│                                                                              │
+│  D38-p3 — auth refresh error surfacing                                       │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │  AuthContext.tsx   refreshUser catch block → branch on                 │  │
+│  │                    err instanceof ApiError && err.status === 401        │  │
+│  │                    vs. 5xx / network                                   │  │
+│  │                    + sessionError state + clearSessionError            │  │
+│  │                    - remove .catch(()=>{}) at L55                      │  │
+│  │                                                                        │  │
+│  │  SessionRestoreBanner.tsx (NEW)  minimal inline banner                 │  │
+│  │                                                                        │  │
+│  │  Layout.tsx   mount <SessionRestoreBanner/> next to                    │  │
+│  │               <EmailVerificationBanner/>                               │  │
+│  │                                                                        │  │
+│  │  AuthContext.test.tsx (NEW)  401/500/network/success cases             │  │
+│  └────────────────────────────────────────────────────────────────────────┘  │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Codebase facts (verified 2026-07-05 on `main`)
+
+**D41:**
+- `apps/api/src/modules/admin/model.ts:30` imports `and, eq, isNull` from `drizzle-orm` — no import changes needed.
+- The three primary targets: `banUser` (L98-102), `unbanUser` (L105-109), `setUserAdminRole` (L112-115). All use `eq(users.id, userId)` alone.
+- The three sibling targets found by the sweep: `updateRecipeVisibility` (L227-235, on `recipes`), `updateEquipment` (L271-291, on `equipment`), `updateVendor` (L322-334, on `vendors`). All use `eq(<t>.id, id)` alone.
+- The correct pattern in the same file: `softDeleteUser` (L197-204), `softDeleteRecipe` (L238-243), `updateCoffeeVariety` (L596-605), `deleteEquipment`/`deleteVendor`/`deleteCoffeeVariety` (D19 fix), and `approveEquipmentDeleteRequest` inner update (D19 fix). All use `and(eq(<t>.id, id), isNull(<t>.deletedAt))`.
+- Service-layer call sites: `service.ts:52-61` (`banUser`), `:63-71` (`unbanUser`), `:73-87` (`setUserAdminRole`). All three already have `if (!user) throw new Error('USER_NOT_FOUND')` **before** the `createAuditLog` call — so when the model returns `null`, no audit entry is written. **The service layer needs no change for the three primary targets.**
+- Controller-layer: `index.ts:159-178` (ban/unban, `POST /users/:id/ban`) already wraps the service call in `try/catch` mapping `USER_NOT_FOUND` → `error(c, 'NOT_FOUND', 'User not found.', 404)`. `index.ts:215-225` (setRole, `PATCH /users/:id/admin`) does **NOT** wrap in try/catch — the service throw propagates uncaught to the global error handler and becomes a 500. **This is a real bug that D41 must fix** by mirroring the ban route's try/catch.
+- **OpenAPI coverage test scope:** `apps/api/src/routes/openapi.coverage.test.ts:59-77` lists 17 in-scope base paths. `/api/v1/admin` is NOT among them (only `/api/v1/users`, `/api/v1/reports`, etc.). So the admin routes are exempt from the coverage test's "every in-scope op documents 401" property (P4). However, AGENTS.md states "a route without `describeRoute()` is incomplete" as a project rule. The two touched routes (ban/unban + setRole) get full metadata; the ~20 other admin routes remain a separate D25-line follow-up.
+- Test fixture pattern: `apps/api/src/modules/admin/model.test.ts` uses inline `crypto.randomUUID()` IDs + `db.insert(users).values({...})` in `beforeEach` + hard-delete in `afterEach`. No shared helper. Each `describe` block is self-contained. The D19 `deleteEquipment` block (L17-68) is the three-`it` template (active → already-deleted-returns-null → no-overwrite). The `deleteCoffeeVariety` block adds a 4th "returns null when updating a deleted row" regression `it` (L171-177).
+- No `softDeleteUser` tests exist anywhere — D41 does not need to add them (out of scope), but the new `banUser`/`unbanUser`/`setUserAdminRole` tests will set up a soft-deleted user via `db.update(users).set({ deletedAt: preDeleteTime }).where(eq(users.id, userId))` (the same direct-UPDATE pattern the `approveEquipmentDeleteRequest guard` block uses at L243-256 for equipment).
+
+**D38-p1:**
+- `apps/api/src/modules/report/index.ts:11` imports only `adminMiddleware, authMiddleware` from `auth.ts` — `rateLimitMiddleware` is NOT imported.
+- The POST route is at L19-50. The middleware chain is `describeRoute → authMiddleware → zValidator → handler`. No `report.use('*', ...)` exists.
+- The template: `apps/api/src/modules/contact/index.ts:29-36` — `contact.use('*', rateLimitMiddleware({ windowMs: 15 * 60_000, maxRequests: 3, keyPrefix: 'contact' }))`. The 429 doc entry is at `contact/index.ts:56-59`.
+- `rateLimitMiddleware` is defined at `apps/api/src/middleware/rateLimit.ts:29-82`. Signature: `({ windowMs?, maxRequests?, keyPrefix? })`. **Keys by IP only**: `const ip = c.req.header('x-forwarded-for') || c.req.header('x-real-ip') || 'unknown'; const key = '${keyPrefix}:${ip}'`. It does NOT read `userId`. The plan's claim that "the limiter keys per user" is **wrong** — the spec must document per-IP keying as the actual behaviour.
+- The global 100/min limiter (`main.ts:69`) uses the same factory with no `keyPrefix` (defaults to `'rate-limit'`). A new `keyPrefix: 'report'` creates an independent counter namespace, so the report limit and the global limit do not interfere.
+- The runtime 429 body (`rateLimit.ts:61-67`) is `{ success: false, error: { code: 'RATE_LIMITED', message: '...' } }` — it **omits `error.requestId`**. `ErrorEnvelopeSchema` (`packages/shared/src/schemas/response.ts:15-25`) requires `requestId: z.string()`. This is a pre-existing inconsistency shared by every 429 in the codebase; the spec documents it as out-of-scope.
+- The contact rate-limit test (`apps/api/src/modules/contact/contact.test.ts:53-68`) is the template: build a `new Hono()`, mount the router via `app.route('/api/v1/contact', contact)`, fire 3 POSTs, assert the 4th returns 429. The contact test does NOT send auth headers (contact is unauthenticated). The report POST requires `authMiddleware` — the new test must additionally satisfy auth.
+
+**D38-p2:**
+- `apps/api/src/utils/sanitize.ts` (53 lines, no imports, pure regex). Exports: `sanitizeText` (L27-40), `sanitizeName` (L42-53). Non-exported helpers: `stripHtmlTags` (L10-13, regex `/<\/?[a-z][^>]*>/gi` — the `[a-z]` anchor is what avoids matching `1 < 2`), `stripZeroWidthChars` (L15-18), `normalizeWhitespace` (L20-25).
+- No `sanitize.test.ts` exists. No test file imports from `sanitize.ts` directly. The functions are exercised only transitively via `comment/service.ts`, `recipe/service.ts`, `user/service.ts`.
+- Known limitations (document, do NOT fix): no `javascript:` URL filtering, no HTML entity decoding, no handling of `<` not followed by a letter (e.g. `< script>` with a space).
+- Test convention template: `apps/api/src/utils/response/response.test.ts` — no `test-setup.ts`, no Hono app, no spies, nested `describe` per function, `'should ...'` `it` naming.
+
+**D38-p3:**
+- `apps/web/src/contexts/AuthContext.tsx` (118 lines). Interface `AuthContextType` (L8-18): `user`, `isLoading`, `isAuthenticated`, `login`, `register`, `logout`, `refreshUser`. **No `sessionError` field yet.**
+- `refreshUser` (L36-52): try `userApi.me()` → `setUser(userData)`; catch → `isBannedError` branch (L43-44, `log.warn` + `setUser(null)`) or else-branch (L45-47, `log.warn` "session may be expired" + `setUser(null)`); finally → `setIsLoading(false)`. **Never re-throws.** The outer `.catch(() => {})` at L55 is redundant (the inner catch already swallows) but exists as a React unhandled-rejection guard.
+- `apps/web/src/api/client.ts:83-99` — `ApiError` class with `code`, `details?`, `status` (default 500). The throw site (L54-59) sets `status = response.status`. So `err instanceof ApiError && err.status === 401` is the discriminator.
+- **Critical 401 nuance:** `client.ts:34-49` intercepts 401 on non-`/auth/` endpoints and silently retries via `/auth/refresh`. `userApi.me()` calls `api.get('/users/me')` — `/users/me` does not start with `/auth/`, so the client attempts a silent refresh before throwing. A 401 reaching `refreshUser` therefore means **both the original call AND the refresh retry failed** = the session is genuinely dead. Silent `setUser(null)` is correct for this case.
+- Network errors: `client.ts:64-67` catches `fetch()` throws (e.g. `TypeError: Failed to fetch`), logs, and re-throws the original `TypeError` — NOT wrapped in `ApiError`. So `err instanceof ApiError` is `false` for network failures. This is the discriminator: `instanceof ApiError` → HTTP error with `.status`; not `instanceof ApiError` → network error.
+- Banner precedent: `apps/web/src/components/EmailVerificationBanner.tsx` (44 lines). Self-contained, calls `useAuth()` directly, early `return null` when not applicable, inline Tailwind + `var(--accent-primary)`. Mounted in `Layout.tsx:31` above `<Navbar />`.
+- No toast system exists anywhere in `apps/web/src` (searched `useToast|ToastProvider|toast`). The spec uses a minimal inline banner, not a toast lib.
+- Web test convention template: `apps/web/src/pages/auth/LoginPage.test.tsx`. Vitest + testing-library + jsdom, globals on, setup at `src/test-setup.ts`. Mock skeleton: `vi.hoisted` for logger, `vi.mock('../../api/index', ...)` with a stubbed `ApiError` class. Render via `MemoryRouter > I18nProvider > AuthProvider > <Component/>` + `waitFor`. `userApi.me` is mocked to reject by default (so the provider mounts in a logged-out state).
+
+### Stakeholders
+
+- **API (`apps/api/`)** — admin module, report module, sanitize util. All D41 + D38-p1 + D38-p2 code lives here.
+- **Web (`apps/web/`)** — AuthContext, Layout, new banner. All D38-p3 code lives here.
+- **DB package, shared package** — unaffected (no schema, no shared schema changes; `ApiError` already exposes `.status`).
+- **Admin users** — the only callers of the ban/unban/setRole endpoints; they will now see 404s instead of silent successes when targeting deleted users, and 404s instead of 500s on the setRole route.
+- **Regular users** — unaffected except: (a) report submission is now rate-limited to 3/15min per IP (the same budget as contact); (b) a session-restore failure on a server/network error now shows a banner instead of silently logging them out.
+
+## Goals / Non-Goals
+
+**Goals:**
+- D41: make all six unguarded admin updates idempotent against soft-deleted rows; map `USER_NOT_FOUND` to 404 on the setRole route; add tests covering the active and soft-deleted paths for the three primary functions.
+- D38-p1: throttle report submissions to 3/15min per IP, mirroring contact; document the 429 in OpenAPI.
+- D38-p2: add a dedicated regression suite for `sanitizeText`/`sanitizeName` covering dangerous-input neutralisation and benign-input pass-through.
+- D38-p3: distinguish 401 (silent logout, correct) from 5xx/network (log.error + `sessionError` banner) in `AuthContext.refreshUser`; expose `sessionError` and `clearSessionError` from `useAuth()`; render a minimal retry banner in the shell.
+- All: add JSDoc to every new or modified exported function. Pass `make check`, `make lint`, `make test`.
+
+**Non-Goals:**
+- Fixing `softDeleteUser`/`softDeleteRecipe` service-layer unconditional audit logs (separate follow-up).
+- Changing `rateLimitMiddleware` to key by `userId` (cross-cutting; out of scope).
+- Fixing the 429 envelope `requestId` omission (cross-cutting; out of scope).
+- Adding `javascript:` URL or HTML-entity filtering to `sanitize.ts` (documented limitation; out of scope).
+- Full OpenAPI retrofit of all admin routes (D25-line follow-up).
+- i18n for the `SessionRestoreBanner` (D40 wave).
+- Touching the `logout` empty catch (intentional best-effort).
+
+## Decisions
+
+### Decision 1 (D41) — Guard all six unguarded updates, not just the three primary
+
+The D41 plan frames the sibling sweep as part of the change's review checklist. The sweep found three more unguarded updates on soft-deletable tables (`updateRecipeVisibility`, `updateEquipment`, `updateVendor`). All six get the same one-line `and(eq(<t>.id, id), isNull(<t>.deletedAt))` guard. Rationale: the bug class is identical, the fix is identical, the test pattern is identical, and leaving three known siblings unfixed would mean a third change to revisit the same file next week. The risk of fixing all six is the same as fixing three (each is a one-line WHERE-clause addition that makes the function return `null` instead of mutating a deleted row).
+
+Tests are required for the three primary targets (user-state mutations — the privilege-escalation case). Tests for the three siblings are **optional but recommended** — the spec lists them as a separate task group that can be deferred if the implementer is time-constrained, since the sibling functions are lower-risk (no privilege escalation; they just silently mutate deleted rows). The `updateCoffeeVariety` regression `it` in the existing `deleteCoffeeVariety` block (model.test.ts L171-177) is the template for the sibling tests.
+
+### Decision 2 (D41) — Fix the `PATCH /users/:id/admin` route's missing try/catch
+
+After the model gets its `isNull(deletedAt)` guard, `setUserAdminRole` will return `null` for soft-deleted users, the service will throw `USER_NOT_FOUND`, and the route (L215-225) will return 500 instead of 404 because it has no try/catch. The ban/unban route (L159-178) already does the right thing and is the template. D41 fixes this in the same change because it is a direct consequence of the model fix — leaving it would mean the change introduces a 500 regression on a route that previously returned 200 (even though the 200 was wrong, a 500 is also wrong, and 404 is correct). The fix is a 5-line try/catch mirroring the ban route.
+
+### Decision 3 (D41) — Add `describeRoute` to the two touched admin routes only
+
+AGENTS.md mandates `describeRoute` on every route. The OpenAPI coverage test (`openapi.coverage.test.ts:59-77`) does NOT include `/api/v1/admin` in its 17 in-scope paths, so the test does not enforce this for admin routes today. Since D41 touches the ban/unban and setRole routes anyway (for the try/catch fix), it adds full `describeRoute` metadata to those two routes (tags: `Admin`, `security: [{ bearerAuth: [] }]`, `401` + `404` via `resolver(ErrorEnvelopeSchema)`, request body via `jsonRequestBody`). The ~20 other admin routes that predate the OpenAPI mandate remain a D25-line follow-up — adding metadata to all of them would balloon this change and is not required by any test.
+
+### Decision 4 (D38-p1) — Apply the rate limiter as route-level middleware on POST only, NOT via `report.use('*', ...)`
+
+The contact module applies `contact.use('*', rateLimitMiddleware({...}))` at the router level, which throttles ALL routes on the router (not just POST). The report router has three routes: POST `/` (submission, the target), GET `/` (admin list), PATCH `/:id/resolve` (admin resolve). Applying `report.use('*', ...)` would throttle the two admin routes too — at 3/15min per IP, which is far too strict for admin moderation workflows.
+
+Two options:
+1. **Router-level `report.use('*', ...)`** (contact pattern) — simple, but throttles admin routes. Admins hitting the moderation queue would be limited to 3 list/resolve actions per 15 min per IP. This breaks moderation.
+2. **Route-level middleware on POST only** — apply `rateLimitMiddleware({...})` as the first middleware in the POST route's chain (before `describeRoute`), leaving GET/PATCH untouched.
+
+**Decision: Option 2.** The D38 plan proposed Option 1 but did not account for the admin routes sharing the router. Option 2 is the correct scope: the abuse vector is report **submission** (any authenticated user can file reports), not admin moderation. The implementation:
+
+```typescript
+report.post(
+  '/',
+  rateLimitMiddleware({ windowMs: 15 * 60_000, maxRequests: 3, keyPrefix: 'report' }),
+  describeRoute({ ... }),  // add 429 entry
+  authMiddleware,
+  zValidator('json', ReportCreateSchema, zodValidationHook),
+  async (c) => { ... },
+);
+```
+
+The limiter is placed **before** `authMiddleware` so an unauthenticated flood is also throttled (the global 100/min applies upstream, but this gives a tighter 3/15min for the report endpoint specifically). The `keyPrefix: 'report'` namespaces the counter from the global limiter.
+
+**Trade-off:** per-IP keying means a NAT'd office of legitimate users shares a 3/15min budget. This matches the contact module's behaviour and is acceptable for a low-volume endpoint. If it proves too strict, `maxRequests` can be tuned to 5 in a follow-up (the plan notes this).
+
+### Decision 5 (D38-p1) — Report route test must stub auth; use a middleware-stub approach, not JWT minting
+
+The contact rate-limit test (`contact.test.ts:53-68`) fires unauthenticated POSTs because contact is unauthenticated. The report POST requires `authMiddleware` (Bearer JWT). Two options for the test:
+1. **Mint a real JWT** — requires `JWT_SECRET` and the auth middleware's verification logic. Heavyweight for a rate-limit test.
+2. **Stub `authMiddleware`** — replace the auth middleware with a no-op that sets `c.set('userId', 'test-user')` so the handler runs. The rate-limit behaviour is what's under test, not auth.
+
+**Decision: Option 2**, but only if the test file can cleanly stub the middleware. Since `report/index.ts` imports `authMiddleware` directly, the test would need to mock the middleware module. The cleaner approach: the test mounts the report router on a test Hono app and applies a stub auth middleware before the router. The exact stub mechanism is an implementation detail for the tasks doc, but the spec requires: (a) 3 POSTs succeed (or validate — the test need not assert 201, only that the 4th is 429), (b) the 4th returns 429, (c) GET `/` and PATCH `/:id/resolve` are NOT throttled (assert a 4th GET in the window does not return 429). The contact test's "fire 4 POSTs, assert 4th is 429" is the core assertion to mirror.
+
+**Resolution (verified during spec finalisation):** The API tests use Deno's `jsr:@std/testing` (not Vitest), so `vi.mock` is unavailable. The established pattern for authenticated route tests is **Pattern B: mint a real JWT via `signAccessToken`** (defined at `apps/api/src/modules/auth/jwt.ts:42-56`), used by `follow/index_test.ts:64-71` (`authedRequest` helper) and `recipe/recipe-filter-deprecation.test.ts:104-114` (`createAuthedTestApp`). Because `authMiddleware` does a DB lookup, the test must also insert a real user row in `beforeEach`. The cache is reset per test via `setCacheProvider(new InMemoryCacheProvider())` (pattern from `rateLimit.test.ts:11-13`). The tasks doc (7.1) contains the full import list, helper skeleton, and test cases. A simplification noted in task 7.2: since the rate-limit middleware runs FIRST in the POST chain (before `authMiddleware` and `zValidator`), the 429 fires regardless of body/auth validity — so the test could even send unauthenticated POSTs and still hit 429 on the 4th, which removes the need for JWT minting entirely if the implementer prefers the simpler path.
+
+### Decision 6 (D38-p2) — Document `sanitize.ts` limitations as pass-through cases, do not fix them
+
+The sanitizer has two known gaps: no `javascript:` URL filtering (bare `javascript:alert(1)` text passes through) and no HTML entity decoding (`&#60;script&#62;` passes through). These are documented in the file's header comment ("intentionally NOT a full HTML sanitizer"). The spec does NOT add new sanitisation logic — that would be a feature change requiring a real HTML sanitizer dependency. Instead, the tests assert the **current** behaviour as explicit pass-through cases: `expect(sanitizeText('javascript:alert(1)')).toBe('javascript:alert(1)')`. This locks the current behaviour as a regression baseline — if someone later adds URL filtering, the test will fail and force a conscious update. A future change could introduce DOMPurify if user content ever needs to allow any HTML; today, all user content is plain text or limited markdown (bold/italic only), so the gaps are not exploitable.
+
+### Decision 7 (D38-p3) — `sessionError: 'network' | 'server' | null`, not a boolean
+
+The plan suggested `authError: boolean`. A boolean is insufficient for the banner to render a useful message: "network" (you appear to be offline) vs. "server" (the server had an error) are different user experiences. The spec uses a three-state union:
+- `null` — no error (default, and after a successful retry).
+- `'server'` — `err instanceof ApiError && err.status >= 500`. The session may still be valid; the user should retry.
+- `'network'` — `!(err instanceof ApiError)` (fetch threw before a response). The user is likely offline or DNS-failed.
+
+The 401 case sets `sessionError = null` (silent logout is correct — the session is genuinely dead). The banned case sets `sessionError = null` (existing behaviour — banned users see the banned message elsewhere). The banner renders for `'server'` and `'network'`, with slightly different copy. `clearSessionError()` sets it back to `null`; the banner calls it on retry.
+
+### Decision 8 (D38-p3) — Minimal inline banner, not a toast system
+
+No toast/notification system exists in the web app. Building one is out of scope for Wave 1. The `SessionRestoreBanner` is a single self-contained component modeled on `EmailVerificationBanner.tsx` — early `return null` when `sessionError === null`, inline Tailwind + CSS custom properties, retry button calls `refreshUser()` then `clearSessionError()` on success. It is mounted in `Layout.tsx` as a sibling to `<EmailVerificationBanner />`. The banner text is inline English in this change; i18n keys are a D40-wave follow-up.
+
+### Decision 9 (D38-p3) — Remove the outer `.catch(() => {})` at AuthContext L55
+
+The mount `useEffect` is `refreshUser().catch(() => {})` (L54-56). The inner `refreshUser` already has a try/catch that never re-throws, so the outer `.catch` is redundant — it swallows nothing of substance. After the refactor, the inner catch still never re-throws, so the outer `.catch` can be removed without introducing unhandled rejections. Removing it eliminates the D17-survivor empty catch and makes the code honest. If a future change makes `refreshUser` re-throw, the `useEffect` would need to handle it — but that is not this change.
+
+### Decision 10 (D38-p3) — 401 keeps `log.warn`; 5xx/network uses `log.error`
+
+Per the logging rules in AGENTS.md: `warn` is for "recoverable issues (rate limit hits, retries)"; `error` is for "operation failures (DB errors, validation failures)". A 401 on session restore is the normal logged-out path — `warn` is correct (it is recoverable: the user can log in again). A 5xx or network failure is an operation failure — `error` is correct. The existing `log.warn({ err }, 'AuthContext token refresh failed — session may be expired')` at L46 is kept for the 401 branch but with an accurate message ("session expired or not authenticated"). The new 5xx/network branch uses `log.error({ err }, 'Session restore failed — network or server error')`. The banned branch keeps its existing `log.warn` at L44.
+
+## Risks / Trade-offs
+
+- **D41 behavioural change:** Previously, `PATCH /api/v1/admin/users/:id/admin` on a soft-deleted user returned 200 with the mutated row. After the fix, it returns 404. This is correct (the resource is deleted) but is a contract change. No client currently depends on mutating deleted users (the admin UI lists only active users via `listUsers`, which already filters `deletedAt`), so the impact is nil in practice.
+- **D41 behavioural change on setRole route:** Previously, `PATCH /users/:id/admin` on a soft-deleted user returned 500 (uncaught throw). After the fix, it returns 404. This is a strict improvement.
+- **D38-p1 per-IP keying:** A NAT'd office shares a 3/15min budget. Acceptable for a low-volume endpoint; matches contact. `maxRequests` can be tuned in a follow-up.
+- **D38-p1 throttles only POST, not admin routes:** This diverges from the contact pattern (which throttles the whole router). The divergence is intentional and documented (Decision 4) — the admin list/resolve routes must not be throttled at 3/15min.
+- **D38-p2 locks current sanitiser limitations:** The tests assert `javascript:` URLs and HTML entities pass through unchanged. If a future change adds filtering, the tests will fail and force a conscious update. This is the intended behaviour (regression baseline), not a risk.
+- **D38-p3 `sessionError` is new context state:** Adding a field to `AuthContextType` is a type-level change that could affect consumers if they destructure the context exhaustively. No consumer does this (all consumers use `useAuth()` and read specific fields), so the risk is nil. The `isAuthenticated` field was added the same way previously.
+- **D38-p3 banner is not i18n'd:** Inline English text. D40 wave will add `t()` keys. Acceptable for Wave 1 because the banner is a transient error notice, not core UI.
+
+## Migration Plan
+
+No data migration, feature flag, or deploy sequencing needed. All changes are code-only and backward-compatible at the API contract level (the only contract changes are 200→404 on deleted-user mutations, which is a correctness fix, and a new 429 on report spam, which is the intended hardening).
+
+**Order of implementation (tasks doc follows this):**
+1. D41 model.ts WHERE clauses + JSDoc (6 functions).
+2. D41 index.ts try/catch on setRole + describeRoute on 2 routes.
+3. D41 model.test.ts new describe blocks.
+4. D38-p1 report/index.ts rate limit + 429 doc.
+5. D38-p1 report/index.test.ts route test.
+6. D38-p2 sanitize.test.ts.
+7. D38-p3 AuthContext.tsx refreshUser refactor + sessionError + clearSessionError.
+8. D38-p3 SessionRestoreBanner.tsx + Layout.tsx mount.
+9. D38-p3 AuthContext.test.tsx.
+10. `make check`, `make lint`, `make test` after each sub-change is complete (not just at the end).
+
+Rollback: `git revert` the merge commit. No DB state to undo.
+
+## Open Questions
+
+None blocking. All decisions are resolved above. The optional sibling tests (Decision 1) are a time-budget call for the implementer, not an open question.

--- a/openspec/changes/wave-1-correctness-security/proposal.md
+++ b/openspec/changes/wave-1-correctness-security/proposal.md
@@ -1,0 +1,89 @@
+## Why
+
+Two Wave 1 P1 debt items bundle into one change because they are small, independent of each other, and shippable in a single PR with no cross-debt coupling:
+
+- **D41 — Admin user mutations missing soft-delete guard.** Three admin user-state mutations (`banUser`, `unbanUser`, `setUserAdminRole`) in `apps/api/src/modules/admin/model.ts:98-115` update by `eq(users.id, userId)` alone, with no `isNull(users.deletedAt)` guard. A sweep of the same file found three more unguarded updates on soft-deletable tables (`updateRecipeVisibility`, `updateEquipment`, `updateVendor`). The correct pattern is already established in the same file by `softDeleteUser` (L197-204), `softDeleteRecipe` (L238-243), and the D19 fix. The risk is real but narrow: a soft-deleted user can be mutated (banned, granted admin) and the API returns the mutated row as if the operation were meaningful. The privilege-escalation edge — `setUserAdminRole(deletedUserId, true)` creating a deleted-but-admin row — is the worst case; any future account-restore path would resurrect it with admin rights granted while it was invisible to normal listings.
+
+- **D38 — Security & error-handling hardening (three small pieces).**
+  1. `POST /api/v1/reports` (`apps/api/src/modules/report/index.ts:19-50`) has no dedicated rate limit. Only the global 100 req/min limiter (`apps/api/src/main.ts:69`) applies, keyed by IP. An authenticated user can file up to 100 reports/minute — enough to flood the admin moderation queue. The contact module (`apps/api/src/modules/contact/index.ts:29-36`) already applies a strict 3-per-15-min limit; the report route is the same class of abuse vector and should follow the same pattern.
+  2. `apps/api/src/utils/sanitize.ts` (a security control: regex-based HTML/zero-width/whitespace stripping used by `comment`, `recipe`, and `user` services) has **zero test coverage**. A regression (a tag or attribute slipping through) would ship silently.
+  3. `apps/web/src/contexts/AuthContext.tsx:42-48` — `refreshUser` catches every error from `userApi.me()` and converts it to `setUser(null)` + a single `log.warn` with the misleading message "session may be expired", applied to 401, 403, 500, and network failures alike. The web client (`apps/web/src/api/client.ts:34-49`) already silently retries 401 via `/auth/refresh` before throwing, so a 401 reaching `refreshUser` means the refresh cookie is also dead = genuinely logged out (silent is correct). But 5xx and network failures mean the session may still be valid — silently logging the user out and telling them "session may be expired" is wrong. The user cannot distinguish "logged out" from "auth backend unreachable".
+
+| Concern | Current state | Wave 1 fix |
+|---|---|---|
+| `banUser`/`unbanUser`/`setUserAdminRole` WHERE clause | `eq(users.id, userId)` — mutates soft-deleted rows | `and(eq(users.id, userId), isNull(users.deletedAt))` — returns `null` for deleted |
+| `updateRecipeVisibility`/`updateEquipment`/`updateVendor` WHERE clause | unguarded — same bug class | same guard added (sibling sweep) |
+| `PATCH /api/v1/admin/users/:id/admin` route (setUserAdminRole) | no try/catch — service throws `USER_NOT_FOUND` → 500 | mirror ban route's `try/catch` → 404 |
+| `POST /api/v1/reports` rate limit | global 100/min only | `rateLimitMiddleware({ windowMs: 15*60_000, maxRequests: 3, keyPrefix: 'report' })` as the FIRST middleware on the POST route only (NOT `report.use('*', ...)` — see design Decision 4: admin GET/PATCH routes on the same router must not be throttled) |
+| `apps/api/src/utils/sanitize.ts` tests | none | new `sanitize.test.ts` covering `sanitizeText` + `sanitizeName` |
+| `AuthContext.refreshUser` error handling | one branch for all errors → silent logout + misleading warn | split 401 (silent, correct) from 5xx/network (log.error + expose `sessionError` to a banner) |
+
+## What Changes
+
+**D41 — admin user mutation guards:**
+- `apps/api/src/modules/admin/model.ts` — add `and(eq(<t>.id, id), isNull(<t>.deletedAt))` to six functions: `banUser` (L98), `unbanUser` (L105), `setUserAdminRole` (L112), `updateRecipeVisibility` (L227), `updateEquipment` (L271), `updateVendor` (L322). Update the three primary functions' JSDoc to state the active-row precondition. `and`/`isNull` already imported (L30).
+- `apps/api/src/modules/admin/index.ts` — wrap the `PATCH /users/:id/admin` handler (L215-225) in a `try/catch` mapping `USER_NOT_FOUND` → 404, mirroring the ban/unban route at L159-178. Add full `describeRoute` metadata to both admin user routes (ban/unban + setRole) including `401`, `404`, `429` (none — no per-route limit on admin), and `resolver(ErrorEnvelopeSchema)` per AGENTS.md. The ban/unban route already does the 404 mapping correctly and is the template.
+- `apps/api/src/modules/admin/model.test.ts` — new `describe` blocks for `banUser`, `unbanUser`, `setUserAdminRole` (and optionally the three siblings) following the D19 `deleteEquipment` three-`it` pattern (active → already-deleted-returns-null → no-mutation-on-deleted-row), using the inline `crypto.randomUUID()` fixture + hard-delete `afterEach` pattern already established in this file.
+
+**D38 piece 1 — report rate limit:**
+- `apps/api/src/modules/report/index.ts` — import `rateLimitMiddleware` from `../../middleware/rateLimit.ts`; add `rateLimitMiddleware({ windowMs: 15 * 60_000, maxRequests: 3, keyPrefix: 'report' })` as the FIRST middleware in the POST route's chain (before `describeRoute`, `authMiddleware`, `zValidator`); add a `429` entry to the POST route's `describeRoute` responses mirroring `contact/index.ts:56-59`. Do NOT use `report.use('*', ...)` — the admin GET/PATCH routes on the same router must not be throttled (see design Decision 4).
+- `apps/api/src/modules/report/index.test.ts` — **new** route-level test file. Mirror `apps/api/src/modules/contact/contact.test.ts:53-68` (the 4th-request-returns-429 test). The report POST requires `authMiddleware`, so the test must additionally stub auth (mint a valid JWT or stub the middleware) — see the design doc for the chosen approach.
+
+**D38 piece 2 — sanitizer tests:**
+- `apps/api/src/utils/sanitize.test.ts` — **new**. Mirror `apps/api/src/utils/response/response.test.ts` conventions (no `test-setup.ts`, no Hono app, no spies, nested `describe` per function, `'should ...'` `it` naming). Cover `sanitizeText` and `sanitizeName` against: nullish input, HTML tag stripping (script, img with onerror, closing tags), the `1 < 2 > 1` numeric-comparison pass-through (the regex's intentional `[a-z]` anchor), zero-width Unicode stripping, whitespace normalization, newline handling, and document the known limitations (no `javascript:` URL filtering, no HTML entity decoding) as explicit "passes through unchanged" cases so a future regression is caught.
+
+**D38 piece 3 — auth refresh error surfacing:**
+- `apps/web/src/contexts/AuthContext.tsx` — refactor the `refreshUser` catch block (L42-48) to branch on `err instanceof ApiError && err.status === 401` (silent `setUser(null)`, keep existing `log.warn` but with accurate message) vs. other `ApiError` (5xx) and non-`ApiError` (network) → `log.error({ err }, 'Session restore failed — network or server error')` + set a new `sessionError: 'network' | 'server' | null` state field. Remove the outer `.catch(() => {})` at L55 (the inner catch already prevents throws). Expose `sessionError` on `AuthContextType` and from `useAuth()`. Add a `clearSessionError()` function so the banner can dismiss itself on a successful manual retry.
+- `apps/web/src/components/SessionRestoreBanner.tsx` — **new** minimal inline banner modeled on `EmailVerificationBanner.tsx` (self-contained, calls `useAuth()`, early `return null` when no error, inline Tailwind + CSS custom properties). Renders a "couldn't restore your session — retry" notice; retry button calls `refreshUser()` and clears the banner on success.
+- `apps/web/src/components/layout/Layout.tsx` — mount `<SessionRestoreBanner />` as a sibling to `<EmailVerificationBanner />` at L31.
+- `apps/web/src/contexts/AuthContext.test.tsx` — **new**. Follow `apps/web/src/pages/auth/LoginPage.test.tsx` mock skeleton (`vi.hoisted` logger mock, full `../../api/index` mock with the stubbed `ApiError` class, `MemoryRouter > I18nProvider > AuthProvider > <TestConsumer/>`, `waitFor` for `isLoading`). Test cases: (a) 401 → `user` null, `sessionError` null, `log.warn` called, no banner; (b) 500 → `user` null, `sessionError === 'server'`, `log.error` called; (c) network `TypeError` → `sessionError === 'network'`, `log.error` called; (d) success → unchanged.
+
+No schema changes. No migrations. No shared-package changes. No frontend package changes.
+
+## Capabilities
+
+### Modified Capabilities
+
+- **admin-soft-delete**: Extends D19's idempotent soft-delete requirement to cover the three admin user-state mutations (`banUser`/`unbanUser`/`setUserAdminRole`) and three sibling unguarded updates (`updateRecipeVisibility`/`updateEquipment`/`updateVendor`). Adds the route-level 404 mapping for `PATCH /users/:id/admin` (the ban/unban route is already correct).
+- **error-handling**: Extends the D17 error-surfacing line to the `AuthContext.refreshUser` mount path — 401 (silent, correct) is distinguished from 5xx/network (logged at `error` and surfaced via a `sessionError` context field + a `SessionRestoreBanner`).
+- **request-body-limit**: No change to the body-limit spec itself, but the report rate-limit piece reuses the same `rateLimitMiddleware` factory and the same 429 documentation pattern. The rate limit is documented under a new dedicated capability below to keep the spec boundary clean.
+
+### New Capabilities
+
+- **report-rate-limit**: The `POST /api/v1/reports` submission route SHALL be protected by a dedicated per-IP rate limit of 3 requests per 15 minutes, namespaced from the global limiter via `keyPrefix: 'report'`. The 429 response SHALL be documented in the route's OpenAPI metadata. Admin list/resolve routes on the same router SHALL NOT be throttled by this limit — the limiter is applied as route-level middleware on POST only, NOT via `report.use('*', ...)` (see design Decision 4 for the trade-off).
+- **text-sanitization**: The `sanitizeText` and `sanitizeName` exports from `apps/api/src/utils/sanitize.ts` SHALL have dedicated unit-test coverage asserting both dangerous-input neutralisation and benign-input pass-through, so a regression in the regex-based stripping is caught before ship.
+
+## Impact
+
+**Files changed (10):**
+
+| File | Change type |
+|---|---|
+| `apps/api/src/modules/admin/model.ts` | edit — 6 WHERE clauses + 3 JSDoc updates |
+| `apps/api/src/modules/admin/index.ts` | edit — try/catch on PATCH setRole + describeRoute on 2 routes |
+| `apps/api/src/modules/admin/model.test.ts` | edit — new describe blocks for 3 (or 6) functions |
+| `apps/api/src/modules/report/index.ts` | edit — import rateLimitMiddleware, add it as first middleware on POST route, add 429 doc |
+| `apps/api/src/modules/report/index.test.ts` | new — rate-limit route test |
+| `apps/api/src/utils/sanitize.test.ts` | new — sanitizer unit tests |
+| `apps/web/src/contexts/AuthContext.tsx` | edit — refreshUser branches, sessionError state, clearSessionError |
+| `apps/web/src/contexts/AuthContext.test.tsx` | new — refresh-failure cases |
+| `apps/web/src/components/SessionRestoreBanner.tsx` | new — minimal banner |
+| `apps/web/src/components/layout/Layout.tsx` | edit — mount the banner |
+
+**No schema/migration changes.** `and`/`isNull` already imported in `admin/model.ts:30`. `rateLimitMiddleware` already exists at `apps/api/src/middleware/rateLimit.ts:29`. `ApiError` already exposes `.status` (`apps/web/src/api/client.ts:83-99`). The web logger is already imported and used in `AuthContext.tsx:4-6`.
+
+**Stakeholders:** API (admin + report modules), web (AuthContext + Layout). DB, shared, deployment unaffected.
+
+**Risk:** Low. D41 is six one-line WHERE-clause changes plus one try/catch plus tests — the pattern is proven by D19 and every non-admin soft-delete. D38 piece 1 is a one-middleware-addition plus a 429 doc entry — the pattern is proven by contact (with a scoped-to-POST twist documented in design Decision 4). D38 piece 2 is a pure new test file. D38 piece 3 is the most involved (a state-field addition + a new banner component + a new test file) but is still ~2h of work and touches only one context's catch block and one Layout line.
+
+**Verification:** `make check` (type-check all workspaces), `make lint`, `make test` (runs the new admin model tests, the new report route test, the new sanitize tests, and the new AuthContext tests via Docker with `--allow-all`). The OpenAPI coverage test (`apps/api/src/routes/openapi.coverage.test.ts`) is unaffected — admin routes are not in its 17-path in-scope list (L59-77), and the report route is already in scope; adding a `429` response to its `describeRoute` does not violate any coverage property.
+
+## Out of Scope
+
+- **`softDeleteUser` / `softDeleteRecipe` service-layer audit-log noise** (`admin/service.ts:165-173` and `:215-220` write audit unconditionally on null returns). Same bug class as D19's `deleteEquipment`/`deleteVendor` audit fix, but the D41 plan scopes this out. Tracked as a follow-up.
+- **Per-user (instead of per-IP) rate-limit keying.** The current `rateLimitMiddleware` keys by `x-forwarded-for`/`x-real-ip` only — it does not read `userId` even when authenticated. Changing the keying strategy is a cross-cutting change to the middleware itself and is out of scope; the report limit reuses the existing per-IP keying, matching the contact module's behaviour.
+- **429 envelope `requestId` conformance.** The runtime 429 body from `rateLimitMiddleware` (`rateLimit.ts:61-67`) omits `error.requestId`, but `ErrorEnvelopeSchema` (`packages/shared/src/schemas/response.ts:15-25`) requires it. This is a pre-existing inconsistency shared by every 429 in the codebase (contact, auth, global). Fixing it is a separate cross-cutting change.
+- **`sanitize.ts` `javascript:` URL and HTML-entity-encoding gaps.** The sanitizer does not filter `javascript:` URLs (bare text passes through) and does not decode/escape HTML entities (`&#60;script&#62;` passes through). These are documented limitations, not bugs to fix in this change — the spec asserts the current behaviour as pass-through cases so a regression is caught, but does not add new sanitisation logic. A future change could introduce a real HTML sanitizer (DOMPurify or similar) if user content ever needs to allow any HTML.
+- **`logout` empty catch** (`AuthContext.tsx:86-94`). Intentional best-effort — leave alone.
+- **Full OpenAPI retrofit of admin routes.** Only the two routes touched by D41 (ban/unban + setRole) get `describeRoute` metadata. The ~20 other admin routes that predate the OpenAPI mandate remain a separate follow-up (D25 line).
+- **i18n for the `SessionRestoreBanner`.** The banner text is inline English in this change; adding `t()` keys for it is part of the D40 i18n wave, not Wave 1.

--- a/openspec/changes/wave-1-correctness-security/specs/admin-soft-delete/spec.md
+++ b/openspec/changes/wave-1-correctness-security/specs/admin-soft-delete/spec.md
@@ -1,0 +1,253 @@
+## MODIFIED Requirements
+
+### Requirement: Admin soft-delete is idempotent
+
+Every soft-delete function in `apps/api/src/modules/admin/model.ts` that sets `deletedAt` via `db.update().set({ deletedAt }).where(...).returning()` SHALL include `isNull(table.deletedAt)` in its WHERE clause, conjuncted with the existing `eq(table.id, id)` using `and()`. A second soft-delete of an already-deleted record SHALL match zero rows and SHALL return `null` from the model function.
+
+**Reason:** D19 (archived 2026-06-09) established this requirement for the four soft-delete functions it fixed (`deleteEquipment`, `deleteVendor`, `deleteCoffeeVariety`, `approveEquipmentDeleteRequest` inner update). D41 extends the same requirement to the three admin user-state mutations (`banUser`, `unbanUser`, `setUserAdminRole`) and three sibling unguarded updates (`updateRecipeVisibility`, `updateEquipment`, `updateVendor`) found by the D41 sibling sweep. The requirement text is broadened from "soft-delete functions" to "all `db.update()` functions on soft-deletable tables" so it covers the new functions without duplicating the requirement.
+
+This requirement now applies to:
+- `deleteEquipment(admin/model.ts)` — D19
+- `deleteVendor(admin/model.ts)` — D19
+- `deleteCoffeeVariety(admin/model.ts)` — D19
+- The inner equipment update inside `approveEquipmentDeleteRequest(admin/model.ts)` — D19
+- `banUser(admin/model.ts)` — D41 (new)
+- `unbanUser(admin/model.ts)` — D41 (new)
+- `setUserAdminRole(admin/model.ts)` — D41 (new)
+- `updateRecipeVisibility(admin/model.ts)` — D41 (new)
+- `updateEquipment(admin/model.ts)` — D41 (new)
+- `updateVendor(admin/model.ts)` — D41 (new)
+
+The guard pattern SHALL be:
+
+```typescript
+.where(and(eq(table.id, id), isNull(table.deletedAt)))
+```
+
+This pattern is the established convention used by `softDeleteUser` (L199-201), `softDeleteRecipe` (L239-241), `updateCoffeeVariety` (L598), and all 8 non-admin soft-delete functions. `and` and `isNull` are already imported at `admin/model.ts:30`.
+
+**Migration:** No data migration. The three primary functions previously returned the mutated row for soft-deleted targets; they now return `null`. The service layer's existing `if (!user) throw new Error('USER_NOT_FOUND')` guards (already present at `service.ts:56,67,77`) translate this to a throw before the audit log is written, so no spurious audit entries are created. The controller layer's `POST /users/:id/ban` route (`index.ts:159-178`) already maps `USER_NOT_FOUND` → 404. The `PATCH /users/:id/admin` route (`index.ts:215-225`) does NOT — see the new requirement below.
+
+#### Scenario: Banning an active user succeeds
+
+- **WHEN** `model.banUser(userId)` is called with the ID of an active (non-deleted) user
+- **THEN** the function returns the updated user with `isBanned: true`
+
+#### Scenario: Banning an already-deleted user returns null
+
+- **WHEN** `model.banUser(userId)` is called with the ID of a user where `deletedAt` is already set
+- **THEN** the function returns `null` and the row's `isBanned` value is unchanged in the database
+
+#### Scenario: Unbanning an active banned user succeeds
+
+- **WHEN** `model.unbanUser(userId)` is called with the ID of an active user whose `isBanned` is `true`
+- **THEN** the function returns the updated user with `isBanned: false`
+
+#### Scenario: Unbanning an already-deleted user returns null
+
+- **WHEN** `model.unbanUser(userId)` is called with the ID of a user where `deletedAt` is already set
+- **THEN** the function returns `null` and the row's `isBanned` value is unchanged in the database (stays `true` if it was `true`)
+
+#### Scenario: Granting admin role on an active user succeeds
+
+- **WHEN** `model.setUserAdminRole(userId, true)` is called with the ID of an active user
+- **THEN** the function returns the updated user with `isAdmin: true`
+
+#### Scenario: Revoking admin role on an active user succeeds
+
+- **WHEN** `model.setUserAdminRole(userId, false)` is called with the ID of an active user
+- **THEN** the function returns the updated user with `isAdmin: false`
+
+#### Scenario: Granting admin role on an already-deleted user returns null — privilege escalation blocked
+
+- **WHEN** `model.setUserAdminRole(userId, true)` is called with the ID of a user where `deletedAt` is already set
+- **THEN** the function returns `null` and the row's `isAdmin` value is unchanged in the database
+- **AND** no deleted-but-admin row is created (the privilege-escalation edge is blocked)
+
+#### Scenario: Updating visibility on an already-deleted recipe returns null
+
+- **WHEN** `model.updateRecipeVisibility(recipeId, 'public')` is called with the ID of a recipe where `deletedAt` is already set
+- **THEN** the function returns `null` and the recipe's `visibility` is unchanged in the database
+
+#### Scenario: Updating an already-deleted equipment record returns null
+
+- **WHEN** `model.updateEquipment(id, { name: 'New' })` is called with the ID of an equipment where `deletedAt` is already set
+- **THEN** the function returns `null` and the equipment row is unchanged in the database
+
+#### Scenario: Updating an already-deleted vendor returns null
+
+- **WHEN** `model.updateVendor(id, { name: 'New' })` is called with the ID of a vendor where `deletedAt` is already set
+- **THEN** the function returns `null` and the vendor row is unchanged in the database
+
+#### Scenario: Deleting an active equipment record succeeds
+
+- **WHEN** `model.deleteEquipment(id)` is called with the ID of an active (non-deleted) equipment record
+- **THEN** the function returns the updated equipment with `deletedAt` set to a non-null `Date` value
+
+#### Scenario: Deleting an already-deleted equipment record returns null
+
+- **WHEN** `model.deleteEquipment(id)` is called with the ID of an equipment record where `deletedAt` is already set
+- **THEN** the function returns `null` and the existing `deletedAt` timestamp is NOT overwritten
+
+#### Scenario: Deleting an active vendor record succeeds
+
+- **WHEN** `model.deleteVendor(id)` is called with the ID of an active vendor
+- **THEN** the function returns the updated vendor with `deletedAt` set
+
+#### Scenario: Deleting an already-deleted vendor record returns null
+
+- **WHEN** `model.deleteVendor(id)` is called with the ID of a vendor where `deletedAt` is already set
+- **THEN** the function returns `null` and the existing `deletedAt` is NOT overwritten
+
+#### Scenario: Deleting an active coffee variety succeeds
+
+- **WHEN** `model.deleteCoffeeVariety(id)` is called with the ID of an active coffee variety
+- **THEN** the function returns the updated variety with both `deletedAt` and `updatedAt` set to non-null `Date` values
+
+#### Scenario: Deleting an already-deleted coffee variety returns null
+
+- **WHEN** `model.deleteCoffeeVariety(id)` is called with the ID of a variety where `deletedAt` is already set
+- **THEN** the function returns `null` and neither `deletedAt` nor `updatedAt` is overwritten
+
+#### Scenario: Double-delete preserves the original deletion timestamp
+
+- **WHEN** `model.deleteXxx(id)` is called, followed by a second call to `model.deleteXxx(id)` after a time delay
+- **THEN** the `deletedAt` (and `updatedAt` for `deleteCoffeeVariety`) value on the database row matches the timestamp set by the first call
+
+#### Scenario: approveEquipmentDeleteRequest guard prevents overwrite
+
+- **WHEN** `model.approveEquipmentDeleteRequest(id, adminId)` is called for a request whose associated equipment already has `deletedAt` set
+- **THEN** the request status is still updated to `'approved'` (the request workflow proceeds), but the equipment's `deletedAt` timestamp is NOT overwritten by the transaction's inner update
+
+## ADDED Requirements
+
+### Requirement: PATCH /users/:id/admin maps USER_NOT_FOUND to HTTP 404
+
+The `PATCH /api/v1/admin/users/:id/admin` route in `apps/api/src/modules/admin/index.ts` (the `setUserAdminRole` endpoint) SHALL wrap its service call in a `try/catch` that maps a thrown `Error('USER_NOT_FOUND')` to an HTTP 404 response with the standard error envelope, mirroring the existing `POST /users/:id/ban` route's `try/catch` at `index.ts:171-177`. Any other error SHALL be re-thrown to the global error handler.
+
+This requirement exists because the `setUserAdminRole` route at `index.ts:215-225` currently has no `try/catch` — after D41 adds the `isNull(deletedAt)` guard to the model, the service will throw `USER_NOT_FOUND` for soft-deleted targets, and without this mapping the route would return 500 instead of the correct 404.
+
+```typescript
+// Required pattern (mirrors index.ts:159-178 ban/unban route):
+admin.patch('/users/:id/admin', describeRoute({ ... }), zValidator('json', ...), async (c) => {
+  const adminId = c.get('userId') as string;
+  const userId = c.req.param('id')!;
+  const { isAdmin } = c.req.valid('json');
+  try {
+    const user = await service.setUserAdminRole(adminId, userId, isAdmin);
+    return success(c, user);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message === 'USER_NOT_FOUND') {
+      return error(c, 'NOT_FOUND', 'User not found.', 404);
+    }
+    throw err;
+  }
+});
+```
+
+#### Scenario: setRole on an active user returns 200
+
+- **WHEN** an admin sends `PATCH /api/v1/admin/users/:id/admin` with `{ isAdmin: true }` for an active user
+- **THEN** the response status is `200` with the standard success envelope containing the updated user
+
+#### Scenario: setRole on a soft-deleted user returns 404
+
+- **WHEN** an admin sends `PATCH /api/v1/admin/users/:id/admin` for a user where `deletedAt` is already set
+- **THEN** the response status is `404` with the standard error envelope containing `error.code === 'NOT_FOUND'`
+
+#### Scenario: setRole on a non-existent user returns 404
+
+- **WHEN** an admin sends `PATCH /api/v1/admin/users/:id/admin` with a UUID that matches no user row at all
+- **THEN** the response status is `404` with the standard error envelope
+
+### Requirement: Admin user-state mutation routes have OpenAPI describeRoute metadata
+
+The `POST /api/v1/admin/users/:id/ban` and `PATCH /api/v1/admin/users/:id/admin` routes in `apps/api/src/modules/admin/index.ts` SHALL carry full `describeRoute({...})` metadata per the AGENTS.md OpenAPI rules:
+
+- `tags: ['Admin']` (the `Admin` tag is already declared in `apps/api/src/routes/openapi.ts:63`)
+- `summary` and `description`
+- `security: [{ bearerAuth: [] }]` (both routes are auth-guarded via `adminMiddleware` which requires `authMiddleware`)
+- `responses`:
+  - `200` (or `201`) with `resolver(successEnvelope(UserRowOutputSchema))` for the success case (`UserRowOutputSchema` is defined at `packages/shared/src/schemas/responses/user.ts:63` — the bare `users` row minus `passwordHash`; `UserOutputSchema` does not exist)
+  - `401` with `resolver(ErrorEnvelopeSchema)` (auth-guarded)
+  - `404` with `resolver(ErrorEnvelopeSchema)` (after D41, soft-deleted/non-existent targets return 404)
+- `requestBody`: `jsonRequestBody(AdminBanUserSchema)` for the ban route; `jsonRequestBody(z.object({ isAdmin: z.boolean() }))` for the setRole route
+- The `zValidator(...)` calls SHALL remain as the request validator (ADR-012); `describeRoute` is additive metadata only
+
+#### Scenario: ban/unban route is documented
+
+- **WHEN** the generated `/api/v1/openapi.json` is inspected for `POST /api/v1/admin/users/:id/ban`
+- **THEN** the operation has `tags: ['Admin']`, `security: [{ bearerAuth: [] }]`, a `requestBody` with `AdminBanUserSchema`, and `responses` including `200`, `401`, and `404`
+
+#### Scenario: setRole route is documented
+
+- **WHEN** the generated `/api/v1/openapi.json` is inspected for `PATCH /api/v1/admin/users/:id/admin`
+- **THEN** the operation has `tags: ['Admin']`, `security: [{ bearerAuth: [] }]`, a `requestBody` with `{ isAdmin: boolean }`, and `responses` including `200`, `401`, and `404`
+
+### Requirement: Admin user-state mutation functions have JSDoc with active-row precondition
+
+The `banUser`, `unbanUser`, and `setUserAdminRole` functions in `apps/api/src/modules/admin/model.ts` SHALL carry JSDoc that documents the active-row precondition introduced by the `isNull(deletedAt)` guard — i.e., that the function returns `null` when the target user is soft-deleted.
+
+```typescript
+/** Ban an active (non-deleted) user by setting `isBanned = true`. Returns the updated user, or null if the user is soft-deleted or not found. */
+export async function banUser(userId: string) { ... }
+
+/** Unban an active (non-deleted) user by setting `isBanned = false`. Returns the updated user, or null if the user is soft-deleted or not found. */
+export async function unbanUser(userId: string) { ... }
+
+/** Set or clear the admin role on an active (non-deleted) user. Returns the updated user, or null if the user is soft-deleted or not found. */
+export async function setUserAdminRole(userId: string, isAdmin: boolean) { ... }
+```
+
+#### Scenario: JSDoc present on banUser
+
+- **WHEN** the source of `apps/api/src/modules/admin/model.ts` is inspected at the `banUser` function
+- **THEN** a JSDoc block is present immediately above `export async function banUser` and mentions the soft-deleted/null-return behaviour
+
+#### Scenario: JSDoc present on unbanUser
+
+- **WHEN** the source of `apps/api/src/modules/admin/model.ts` is inspected at the `unbanUser` function
+- **THEN** a JSDoc block is present immediately above `export async function unbanUser` and mentions the soft-deleted/null-return behaviour
+
+#### Scenario: JSDoc present on setUserAdminRole
+
+- **WHEN** the source of `apps/api/src/modules/admin/model.ts` is inspected at the `setUserAdminRole` function
+- **THEN** a JSDoc block is present immediately above `export async function setUserAdminRole` and mentions the soft-deleted/null-return behaviour
+
+### Requirement: Integration test coverage for admin user-state mutations
+
+The API package's existing test file `apps/api/src/modules/admin/model.test.ts` SHALL contain `describe` blocks for `banUser`, `unbanUser`, and `setUserAdminRole` that exercise both the active-user and soft-deleted-user paths via real database rows. Tests SHALL follow the pattern established by the D19 `deleteEquipment` block (L17-68) and the `deleteCoffeeVariety` regression `it` (L171-177):
+
+1. **Active case:** call the function on an active user → assert the returned row has the expected field value (`isBanned: true` for `banUser`, etc.).
+2. **Soft-deleted case:** pre-set `deletedAt` on the user via `db.update(users).set({ deletedAt: new Date() }).where(eq(users.id, userId))`, then call the function → assert it returns `null` and the field value is unchanged in the DB.
+3. **No-mutation case (for `setUserAdminRole`):** pre-set `deletedAt`, call `setUserAdminRole(userId, true)` → assert the function returns `null` and the DB row's `isAdmin` is still its pre-call value (the privilege-escalation-blocked assertion).
+
+Tests SHALL use the inline `crypto.randomUUID()` fixture + `db.insert(users).values({...})` + hard-delete `afterEach` pattern already established in `model.test.ts`. All `describe` blocks SHALL pass `{ sanitizeOps: false, sanitizeResources: false }` as the second argument (required for DB I/O tests).
+
+Optional but recommended: the same three-`it` pattern for the three sibling functions (`updateRecipeVisibility`, `updateEquipment`, `updateVendor`). These are lower-risk (no privilege escalation) and can be deferred if the implementer is time-constrained.
+
+#### Scenario: banUser tests pass
+
+- **WHEN** `make test-specific filter=apps/api/src/modules/admin/model.test.ts` is executed
+- **THEN** the `describe('banUser', ...)` block passes, covering the active-user and soft-deleted-user paths
+
+#### Scenario: unbanUser tests pass
+
+- **WHEN** `make test-specific filter=apps/api/src/modules/admin/model.test.ts` is executed
+- **THEN** the `describe('unbanUser', ...)` block passes, covering the active-user and soft-deleted-user paths
+
+#### Scenario: setUserAdminRole tests pass including privilege-escalation-blocked case
+
+- **WHEN** `make test-specific filter=apps/api/src/modules/admin/model.test.ts` is executed
+- **THEN** the `describe('setUserAdminRole', ...)` block passes, covering the active-user grant/revoke paths and the soft-deleted-user path that asserts `isAdmin` is NOT granted on a deleted row
+
+#### Scenario: No pre-existing admin model test regresses
+
+- **WHEN** `make test` is invoked on a clean checkout that includes the D41 changes
+- **THEN** every pre-existing test in `apps/api/src/modules/admin/model.test.ts` (the D19 `deleteEquipment`/`deleteVendor`/`deleteCoffeeVariety`/`approveEquipmentDeleteRequest guard` blocks) still passes
+
+#### Scenario: Type-check and lint pass
+
+- **WHEN** `make check-api` and `make lint` are invoked
+- **THEN** zero errors and zero warnings are reported on `apps/api/src/modules/admin/model.ts`, `apps/api/src/modules/admin/index.ts`, and `apps/api/src/modules/admin/model.test.ts`

--- a/openspec/changes/wave-1-correctness-security/specs/error-handling/spec.md
+++ b/openspec/changes/wave-1-correctness-security/specs/error-handling/spec.md
@@ -1,0 +1,206 @@
+## ADDED Requirements
+
+### Requirement: AuthContext.refreshUser distinguishes 401 from 5xx/network errors
+
+The `refreshUser` function in `apps/web/src/contexts/AuthContext.tsx` (L36-52) SHALL branch its catch block on the error type and status, instead of applying a single `log.warn` + `setUser(null)` to all failures. The branches SHALL be:
+
+1. **Banned user** (`err instanceof ApiError && (err.code === 'USER_BANNED' || err.message.toLowerCase().includes('banned'))`) — keep the existing behaviour: `log.warn({ err }, 'AuthContext user account is banned')` + `setUser(null)` + `sessionError` stays `null`. (Existing branch at L43-44, unchanged.)
+
+2. **401 (session genuinely expired)** (`err instanceof ApiError && err.status === 401`) — silent logout is correct because the web API client (`apps/web/src/api/client.ts:34-49`) already silently attempted a `/auth/refresh` retry before throwing, so a 401 reaching `refreshUser` means the refresh cookie is also dead. SHALL: `log.warn({ err }, 'AuthContext session expired or not authenticated')` + `setUser(null)` + `sessionError` stays `null`. No banner is shown — the user is genuinely logged out.
+
+3. **5xx server error** (`err instanceof ApiError && err.status >= 500`) — the session may still be valid; the server had an error. SHALL: `log.error({ err }, 'Session restore failed — server error')` + `setUser(null)` + `setSessionError('server')`. The banner is shown.
+
+4. **Network error** (`!(err instanceof ApiError)`) — `fetch` threw before a response (offline, DNS failure, CORS — typically `TypeError: Failed to fetch`). The session may still be valid; the client could not reach the server. SHALL: `log.error({ err }, 'Session restore failed — network error')` + `setUser(null)` + `setSessionError('network')`. The banner is shown.
+
+5. **Other 4xx (e.g. 403, 404)** (`err instanceof ApiError && err.status < 500 && err.status !== 401`) — uncommon for `/users/me`, but treated as a logged-out-adjacent case. SHALL: `log.warn({ err }, 'AuthContext token refresh failed')` + `setUser(null)` + `sessionError` stays `null` (no banner — these are typically auth-state issues, not server health).
+
+The outer `refreshUser().catch(() => {})` at L54-56 SHALL be removed. The inner catch block already prevents any throw from escaping `refreshUser`, so the outer `.catch` is redundant. Removing it eliminates the D17-survivor empty catch.
+
+`ApiError` is imported from `../api/index.ts` (or wherever the web API client re-exports it — `apps/web/src/api/index.ts` re-exports `ApiError` from `./client.ts`). `ApiError` exposes `.status: number` (verified at `client.ts:83-99`).
+
+#### Scenario: 401 on refresh — silent logout, no banner
+
+- **WHEN** `userApi.me()` rejects with `new ApiError('UNAUTHORIZED', '...', undefined, 401)` (meaning the silent `/auth/refresh` retry also failed)
+- **THEN** `user` is set to `null`
+- **AND** `sessionError` is `null`
+- **AND** `log.warn` is called with message containing 'session expired' or 'not authenticated'
+- **AND** `log.error` is NOT called
+
+#### Scenario: 500 on refresh — banner shown, error logged
+
+- **WHEN** `userApi.me()` rejects with `new ApiError('INTERNAL_ERROR', '...', undefined, 500)`
+- **THEN** `user` is set to `null`
+- **AND** `sessionError` is set to `'server'`
+- **AND** `log.error` is called with message containing 'server error'
+
+#### Scenario: Network failure on refresh — banner shown, error logged
+
+- **WHEN** `userApi.me()` rejects with `new TypeError('Failed to fetch')` (not an `ApiError`)
+- **THEN** `user` is set to `null`
+- **AND** `sessionError` is set to `'network'`
+- **AND** `log.error` is called with message containing 'network error'
+
+#### Scenario: Banned user on refresh — existing behaviour preserved
+
+- **WHEN** `userApi.me()` rejects with `new ApiError('USER_BANNED', '...', undefined, 403)`
+- **THEN** `user` is set to `null`
+- **AND** `sessionError` is `null`
+- **AND** `log.warn` is called with message containing 'banned' (existing behaviour unchanged)
+
+#### Scenario: Successful refresh — no error state
+
+- **WHEN** `userApi.me()` resolves with a user object
+- **THEN** `user` is set to that object
+- **AND** `sessionError` is `null`
+- **AND** `isLoading` is set to `false`
+
+#### Scenario: Outer .catch(() => {}) is removed
+
+- **WHEN** the source of `apps/web/src/contexts/AuthContext.tsx` is inspected at the mount `useEffect`
+- **THEN** it does NOT contain `refreshUser().catch(() => {})`
+- **AND** the `useEffect` calls `refreshUser()` directly (the inner catch prevents unhandled rejections)
+
+### Requirement: AuthContext exposes sessionError and clearSessionError
+
+The `AuthContextType` interface in `apps/web/src/contexts/AuthContext.tsx` (L8-18) SHALL be extended with two new fields:
+
+```typescript
+interface AuthContextType {
+  user: AuthUser | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  sessionError: 'network' | 'server' | null;  // new
+  login: (...) => Promise<void>;
+  register: (...) => Promise<void>;
+  logout: () => Promise<void>;
+  refreshUser: () => Promise<void>;
+  clearSessionError: () => void;  // new
+}
+```
+
+`sessionError` SHALL be `null` by default, set to `'server'` or `'network'` by `refreshUser`'s catch block per the requirement above, and reset to `null` by `clearSessionError()`. A successful `refreshUser` call (e.g. a manual retry from the banner) SHALL also reset `sessionError` to `null` — this can be done either in the `refreshUser` try block (`setSessionError(null)` on success) or by having `clearSessionError` call `refreshUser`. The preferred approach: set `sessionError = null` at the start of the `try` block in `refreshUser`, so any successful refresh clears the error, and `clearSessionError` is a standalone `() => setSessionError(null)` for the banner's dismiss-without-retry path.
+
+`useAuth()` (L113-118) SHALL return the extended context unchanged in shape — consumers reading `{ user, isLoading }` are unaffected; consumers that want the banner read `{ sessionError, clearSessionError, refreshUser }`.
+
+#### Scenario: sessionError is exposed from useAuth
+
+- **WHEN** a component calls `const { sessionError, clearSessionError } = useAuth()`
+- **THEN** `sessionError` is `null`, `'server'`, or `'network'`
+- **AND** `clearSessionError` is a function that resets `sessionError` to `null`
+
+#### Scenario: Successful refreshUser clears sessionError
+
+- **WHEN** `sessionError` is `'server'` and `refreshUser()` is called and succeeds
+- **THEN** `sessionError` is reset to `null` (and `user` is set to the refreshed user)
+
+### Requirement: SessionRestoreBanner renders on sessionError
+
+A new component `apps/web/src/components/SessionRestoreBanner.tsx` SHALL render a user-visible banner when `sessionError` is not `null`. The component SHALL:
+
+- Call `useAuth()` to read `sessionError`, `clearSessionError`, and `refreshUser`.
+- Early `return null` when `sessionError === null`.
+- Render a banner with inline Tailwind classes + CSS custom properties, modeled on `apps/web/src/components/EmailVerificationBanner.tsx` (44 lines — self-contained, no props, calls `useAuth()` directly).
+- Show different copy for `'server'` vs. `'network'`:
+  - `'network'`: "Couldn't reach the server. Check your connection and retry."
+  - `'server'`: "Couldn't restore your session — the server had an error. Retry?"
+- Render a "Retry" button that calls `refreshUser()`. On success (the `refreshUser` try block sets `sessionError = null`), the banner unmounts via the early-return-null. On failure, the banner stays and `sessionError` is updated to the new error category.
+- Render a "Dismiss" button (or `clearSessionError()` on click of a close icon) that clears `sessionError` to `null` without retrying — for users who want to dismiss the banner and continue in a logged-out state.
+- The banner text is inline English in this change; i18n keys (`t()`) are a D40-wave follow-up, explicitly out of scope here.
+
+The banner SHALL be mounted in `apps/web/src/components/layout/Layout.tsx` as a sibling to `<EmailVerificationBanner />` (currently at L31), placed immediately before or after it (above `<Navbar />`). The Layout change is a one-line addition.
+
+#### Scenario: Banner renders on server error
+
+- **WHEN** `sessionError === 'server'`
+- **THEN** the `SessionRestoreBanner` renders with the server-error copy and a Retry button
+
+#### Scenario: Banner renders on network error
+
+- **WHEN** `sessionError === 'network'`
+- **THEN** the `SessionRestoreBanner` renders with the network-error copy and a Retry button
+
+#### Scenario: Banner does not render when sessionError is null
+
+- **WHEN** `sessionError === null`
+- **THEN** the `SessionRestoreBanner` renders nothing (early return null)
+
+#### Scenario: Retry button calls refreshUser
+
+- **WHEN** the Retry button is clicked
+- **THEN** `refreshUser()` is called
+- **AND** if it succeeds, `sessionError` becomes `null` and the banner unmounts
+
+#### Scenario: Dismiss clears sessionError without retry
+
+- **WHEN** the Dismiss button is clicked
+- **THEN** `clearSessionError()` is called
+- **AND** `sessionError` becomes `null`
+- **AND** the banner unmounts
+- **AND** `refreshUser` is NOT called
+
+#### Scenario: Banner is mounted in Layout
+
+- **WHEN** the source of `apps/web/src/components/layout/Layout.tsx` is inspected
+- **THEN** `<SessionRestoreBanner />` is rendered as a sibling to `<EmailVerificationBanner />`
+
+### Requirement: AuthContext test coverage for refresh failure cases
+
+The web package SHALL contain a test file `apps/web/src/contexts/AuthContext.test.tsx` that exercises the `refreshUser` error branches via mocked `userApi.me`. The test SHALL follow the convention established by `apps/web/src/pages/auth/LoginPage.test.tsx`:
+
+- Vitest + `@testing-library/react` + jsdom (config at `apps/web/vitest.config.ts`, setup at `apps/web/src/test-setup.ts`).
+- `vi.hoisted` for the logger mock (so `createLogger` returns a mock with `debug/info/warn/error` spies).
+- `vi.mock('../../api/index', ...)` with a stubbed `ApiError` class extending `Error` with `code`, `status`, `details?` (matching `apps/web/src/api/client.ts:83-99`). The mock SHALL export `userApi` with `me: vi.fn()` so each test can flip it between `mockResolvedValue(user)`, `mockRejectedValue(new ApiError('UNAUTHORIZED', '...', undefined, 401))`, `mockRejectedValue(new ApiError('INTERNAL_ERROR', '...', undefined, 500))`, and `mockRejectedValue(new TypeError('Failed to fetch'))`.
+- Render via `MemoryRouter > I18nProvider > AuthProvider > <TestConsumer/>` where `<TestConsumer/>` is a tiny component that calls `useAuth()` and renders `sessionError` and `user?.id` into the DOM for assertion.
+- `waitFor` for `isLoading` to flip to `false` before asserting.
+
+Test cases SHALL cover:
+1. **401** → `user` null, `sessionError` null, `mockLogger.warn` called, `mockLogger.error` NOT called.
+2. **500** → `user` null, `sessionError === 'server'`, `mockLogger.error` called.
+3. **Network `TypeError`** → `user` null, `sessionError === 'network'`, `mockLogger.error` called.
+4. **Banned** → `user` null, `sessionError` null, `mockLogger.warn` called with 'banned' message.
+5. **Success** → `user` set, `sessionError` null, no `warn`/`error` calls.
+
+#### Scenario: AuthContext test file exists and follows conventions
+
+- **WHEN** the source of `apps/web/src/contexts/AuthContext.test.tsx` is inspected
+- **THEN** it uses `vi.hoisted` for the logger mock, `vi.mock` for the api module with a stubbed `ApiError` class, and renders `AuthProvider` inside `MemoryRouter > I18nProvider`
+
+#### Scenario: 401 refresh-failure case passes
+
+- **WHEN** the AuthContext test suite is executed
+- **THEN** the 401 case asserts `sessionError` is `null` and `mockLogger.warn` was called
+
+#### Scenario: 500 refresh-failure case passes
+
+- **WHEN** the AuthContext test suite is executed
+- **THEN** the 500 case asserts `sessionError === 'server'` and `mockLogger.error` was called
+
+#### Scenario: Network refresh-failure case passes
+
+- **WHEN** the AuthContext test suite is executed
+- **THEN** the network case asserts `sessionError === 'network'` and `mockLogger.error` was called
+
+#### Scenario: All AuthContext tests pass
+
+- **WHEN** the web test suite is executed
+- **THEN** all `describe('refreshUser', ...)` cases pass with zero regressions in pre-existing web tests
+
+### Requirement: JSDoc on new and modified exported functions
+
+All new exported functions/components in the D38-p3 scope SHALL have JSDoc docblocks per the project convention:
+
+- `SessionRestoreBanner` component in `apps/web/src/components/SessionRestoreBanner.tsx` — JSDoc describing its purpose (renders a banner when `sessionError` is set, with retry/dismiss actions).
+- `clearSessionError` function in `AuthContext.tsx` — JSDoc describing that it resets `sessionError` to `null`.
+- The `sessionError` field on `AuthContextType` — JSDoc on the interface field describing its three states.
+
+The `refreshUser` function's existing JSDoc (if any) SHALL be updated to mention the `sessionError` side-effect.
+
+#### Scenario: SessionRestoreBanner has JSDoc
+
+- **WHEN** the source of `apps/web/src/components/SessionRestoreBanner.tsx` is inspected
+- **THEN** a `/** ... */` JSDoc block is present immediately before `export function SessionRestoreBanner`
+
+#### Scenario: clearSessionError has JSDoc
+
+- **WHEN** the source of `apps/web/src/contexts/AuthContext.tsx` is inspected at the `clearSessionError` definition
+- **THEN** a `/** ... */` JSDoc block is present describing its behaviour

--- a/openspec/changes/wave-1-correctness-security/specs/report-rate-limit/spec.md
+++ b/openspec/changes/wave-1-correctness-security/specs/report-rate-limit/spec.md
@@ -67,14 +67,12 @@ report.post(
 The API package SHALL contain a route-level test file `apps/api/src/modules/report/index.test.ts` that exercises the rate-limit behaviour on `POST /api/v1/reports`. The test SHALL:
 
 1. Build a test Hono app mounting the report router (mirroring `apps/api/src/modules/contact/contact.test.ts:7-11`).
-2. Satisfy the `authMiddleware` requirement on the POST route — either by stubbing the auth middleware with a no-op that sets `c.set('userId', 'test-user')`, or by minting a valid JWT. The stub approach is preferred (the rate-limit behaviour is under test, not auth).
+2. Send unauthenticated POSTs with a `ReportCreateSchema`-shaped body — no JWT minting or user-row seeding is required. This is valid because the rate-limit middleware runs FIRST in the POST route's middleware chain (before `authMiddleware` and `zValidator`), so the 429 fires regardless of body or auth validity. The rate-limit behaviour is what is under test, not auth or validation.
 3. Send 3 POSTs that are processed, then assert the 4th returns 429.
 4. Assert that `GET /api/v1/reports` (admin list) and/or `PATCH /api/v1/reports/:id/resolve` are NOT throttled by the report-specific limiter (a 4th request in the window does not return 429 from the `keyPrefix: 'report'` counter).
-5. Use the `InMemoryCacheProvider` (default under `CACHE_DRIVER=memory` / `APP_ENV=test`) so the rate-limit counter is fresh per test. Each `it` SHOULD build its own app to avoid counter leakage between tests, matching the contact test pattern.
+5. Use the `InMemoryCacheProvider` (default under `CACHE_DRIVER=memory` / `APP_ENV=test`) so the rate-limit counter is fresh per test. The cache SHALL be reset per test via `setCacheProvider(new InMemoryCacheProvider())` in `beforeEach` (pattern from `apps/api/src/middleware/rateLimit.test.ts:11-13`).
 
-The test SHALL mint a real JWT via `signAccessToken` (defined at `apps/api/src/modules/auth/jwt.ts:42-56`, signature `signAccessToken({ id, email, username, isAdmin }): Promise<string>`) — this is the established pattern for authenticated route tests in this codebase, used by `apps/api/src/modules/follow/index_test.ts:64-71` and `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts:104-114`. Because `authMiddleware` does a DB lookup (returns 401 if the user is not found), the test MUST insert a real user row into the `users` table in `beforeEach`. The cache SHALL be reset per test via `setCacheProvider(new InMemoryCacheProvider())` (pattern from `apps/api/src/middleware/rateLimit.test.ts:11-13`).
-
-A simplification the implementer MAY use: since the rate-limit middleware runs FIRST in the POST route's middleware chain (before `authMiddleware` and `zValidator`), the 429 fires regardless of body/auth validity — so the test could send unauthenticated POSTs with an empty body and still hit 429 on the 4th, removing the need for JWT minting. This is acceptable because the rate-limit behaviour is what is under test, not auth or validation.
+The unauthenticated-POST approach is chosen over the JWT-minting approach (`signAccessToken` + user-row seeding, used by `apps/api/src/modules/follow/index_test.ts:64-71`) because it is simpler and the limiter's position in the middleware chain makes auth irrelevant to the behaviour under test.
 
 #### Scenario: Report rate-limit test passes
 

--- a/openspec/changes/wave-1-correctness-security/specs/report-rate-limit/spec.md
+++ b/openspec/changes/wave-1-correctness-security/specs/report-rate-limit/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Report submission route is rate-limited
+
+The `POST /api/v1/reports` route in `apps/api/src/modules/report/index.ts` SHALL be protected by a dedicated `rateLimitMiddleware` instance with `windowMs: 15 * 60_000` (15 minutes), `maxRequests: 3`, and `keyPrefix: 'report'`. The middleware SHALL be applied as the first middleware in the POST route's chain (before `describeRoute`, `authMiddleware`, and `zValidator`) so that an unauthenticated flood is also throttled. The `keyPrefix: 'report'` namespaces the counter from the global 100/min limiter (`apps/api/src/main.ts:69`, which uses the default `keyPrefix: 'rate-limit'`) and from the contact module's limiter (`keyPrefix: 'contact'`), so the three limits do not interfere.
+
+The limiter keys by IP (`x-forwarded-for` → `x-real-ip` → `'unknown'`), matching the existing `rateLimitMiddleware` behaviour defined at `apps/api/src/middleware/rateLimit.ts:38-41`. It does NOT key by `userId` even when authenticated — this is the current behaviour of all `rateLimitMiddleware` instances in the codebase and is not changed by this requirement.
+
+The admin `GET /` and `PATCH /:id/resolve` routes on the same report router SHALL NOT be throttled by this limit. The limiter is applied to the POST route only (NOT via `report.use('*', ...)`), because the admin moderation routes must remain unrestricted for legitimate admin workflows.
+
+```typescript
+// Required pattern (report/index.ts):
+import { rateLimitMiddleware } from '../../middleware/rateLimit.ts';
+
+report.post(
+  '/',
+  rateLimitMiddleware({ windowMs: 15 * 60_000, maxRequests: 3, keyPrefix: 'report' }),
+  describeRoute({
+    tags: ['Reports'],
+    summary: 'Create a report',
+    description: 'Submits a moderation report against a recipe or comment. Rate-limited to 3 requests per 15 minutes per IP.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(ReportCreateSchema),
+    responses: {
+      201: { description: 'Report created', content: { 'application/json': { schema: resolver(successEnvelope(ReportOutputSchema)) } } },
+      401: { description: 'Unauthorized', content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } } },
+      429: { description: 'Rate limit exceeded (3 requests per 15 minutes)', content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } } },
+    },
+  }),
+  authMiddleware,
+  zValidator('json', ReportCreateSchema, zodValidationHook),
+  async (c) => { ... },
+);
+```
+
+**Note on the 429 envelope:** The runtime 429 body emitted by `rateLimitMiddleware` (`rateLimit.ts:61-67`) is `{ success: false, error: { code: 'RATE_LIMITED', message: '...' } }` and omits `error.requestId`, while `ErrorEnvelopeSchema` (`packages/shared/src/schemas/response.ts:15-25`) requires `requestId: z.string()`. This is a pre-existing inconsistency shared by every 429 in the codebase (contact, auth, global) and is out of scope for this change. The OpenAPI `429` entry uses `resolver(ErrorEnvelopeSchema)` per the AGENTS.md convention, matching the contact module's existing 429 documentation at `contact/index.ts:56-59`.
+
+#### Scenario: 4th report POST within 15 minutes returns 429
+
+- **WHEN** a client sends 4 `POST /api/v1/reports` requests within a 15-minute window from the same IP
+- **THEN** the first 3 requests are processed by the route handler (returning 201, 400, or 401 per their payloads/auth)
+- **AND** the 4th request returns HTTP `429` with `error.code === 'RATE_LIMITED'` and the `X-RateLimit-Limit: 3`, `X-RateLimit-Remaining: 0`, and `X-RateLimit-Reset` headers set
+
+#### Scenario: A different IP is unaffected
+
+- **WHEN** one IP has exhausted its 3-request budget and a second IP sends a `POST /api/v1/reports` within the same 15-minute window
+- **THEN** the second IP's request is processed normally (not 429)
+
+#### Scenario: Admin report routes are NOT throttled by the report limiter
+
+- **WHEN** a client sends 4 `GET /api/v1/reports` requests (admin list) within a 15-minute window from the same IP
+- **THEN** none of the GET requests return 429 due to the report-specific limiter (the global 100/min limiter may still apply, but the `keyPrefix: 'report'` limiter does not)
+- **AND** the same holds for `PATCH /api/v1/reports/:id/resolve`
+
+#### Scenario: Report limiter is independent of the contact limiter
+
+- **WHEN** a client has exhausted its 3-request budget on `POST /api/v1/contact` (keyPrefix `'contact'`) and then sends a `POST /api/v1/reports` within the same 15-minute window
+- **THEN** the report POST is processed normally (the two `keyPrefix` namespaces are independent counters)
+
+#### Scenario: 429 response is documented in OpenAPI
+
+- **WHEN** the generated `/api/v1/openapi.json` is inspected for `POST /api/v1/reports`
+- **THEN** the operation's `responses` map includes a `429` entry with `content.application/json.schema` resolved from `ErrorEnvelopeSchema`
+
+### Requirement: Report route rate-limit test coverage
+
+The API package SHALL contain a route-level test file `apps/api/src/modules/report/index.test.ts` that exercises the rate-limit behaviour on `POST /api/v1/reports`. The test SHALL:
+
+1. Build a test Hono app mounting the report router (mirroring `apps/api/src/modules/contact/contact.test.ts:7-11`).
+2. Satisfy the `authMiddleware` requirement on the POST route — either by stubbing the auth middleware with a no-op that sets `c.set('userId', 'test-user')`, or by minting a valid JWT. The stub approach is preferred (the rate-limit behaviour is under test, not auth).
+3. Send 3 POSTs that are processed, then assert the 4th returns 429.
+4. Assert that `GET /api/v1/reports` (admin list) and/or `PATCH /api/v1/reports/:id/resolve` are NOT throttled by the report-specific limiter (a 4th request in the window does not return 429 from the `keyPrefix: 'report'` counter).
+5. Use the `InMemoryCacheProvider` (default under `CACHE_DRIVER=memory` / `APP_ENV=test`) so the rate-limit counter is fresh per test. Each `it` SHOULD build its own app to avoid counter leakage between tests, matching the contact test pattern.
+
+The test SHALL mint a real JWT via `signAccessToken` (defined at `apps/api/src/modules/auth/jwt.ts:42-56`, signature `signAccessToken({ id, email, username, isAdmin }): Promise<string>`) — this is the established pattern for authenticated route tests in this codebase, used by `apps/api/src/modules/follow/index_test.ts:64-71` and `apps/api/src/modules/recipe/recipe-filter-deprecation.test.ts:104-114`. Because `authMiddleware` does a DB lookup (returns 401 if the user is not found), the test MUST insert a real user row into the `users` table in `beforeEach`. The cache SHALL be reset per test via `setCacheProvider(new InMemoryCacheProvider())` (pattern from `apps/api/src/middleware/rateLimit.test.ts:11-13`).
+
+A simplification the implementer MAY use: since the rate-limit middleware runs FIRST in the POST route's middleware chain (before `authMiddleware` and `zValidator`), the 429 fires regardless of body/auth validity — so the test could send unauthenticated POSTs with an empty body and still hit 429 on the 4th, removing the need for JWT minting. This is acceptable because the rate-limit behaviour is what is under test, not auth or validation.
+
+#### Scenario: Report rate-limit test passes
+
+- **WHEN** `make test-specific filter=apps/api/src/modules/report/index.test.ts` is executed
+- **THEN** the rate-limit test cases pass, including the 4th-POST-returns-429 case and the admin-routes-not-throttled case
+
+#### Scenario: Type-check and lint pass on the new test file
+
+- **WHEN** `make check-api` and `make lint` are invoked
+- **THEN** zero errors and zero warnings are reported on `apps/api/src/modules/report/index.test.ts` and `apps/api/src/modules/report/index.ts`

--- a/openspec/changes/wave-1-correctness-security/specs/text-sanitization/spec.md
+++ b/openspec/changes/wave-1-correctness-security/specs/text-sanitization/spec.md
@@ -1,0 +1,121 @@
+## ADDED Requirements
+
+### Requirement: sanitizeText has dedicated unit-test coverage
+
+The API package SHALL contain a test file `apps/api/src/utils/sanitize.test.ts` that exercises the `sanitizeText` export from `./sanitize.ts` with both dangerous-input and benign-input cases. The test SHALL follow the pure-utility convention established by `apps/api/src/utils/response/response.test.ts` — no `test-setup.ts` import, no Hono app, no spies, no `{ sanitizeOps, sanitizeResources }` options. Tests SHALL be organised into a `describe('sanitizeText', () => { ... })` block with `it('should ...', () => { ... })` cases.
+
+`sanitizeText` is a security control (regex-based stripping used by `comment`, `recipe`, and `user` services). A regression — a tag or attribute slipping through — would ship silently without this suite.
+
+The test SHALL cover at minimum:
+
+**Dangerous-input neutralisation:**
+- Script tags: `<script>alert(1)</script>` → stripped to `alert(1)` (the tags are removed; the inner text may remain — assert the exact output).
+- Script tags with attributes: `<script src="x.js"></script>` → stripped.
+- Closing tags: `</script>` → stripped.
+- Image tags with event handlers: `<img src=x onerror=alert(1)>` → stripped (the whole tag matches `/<\/?[a-z][^>]*>/gi`).
+- Anchor tags with event-handler attributes: `<a href="x" onclick="alert(1)">link</a>` → the tag is stripped, `link` text remains.
+- Zero-width Unicode characters: U+200B (ZWSP), U+200C (ZWNJ), U+200D (ZWJ), U+FEFF (BOM), U+00AD (soft hyphen) → removed.
+- Whitespace abuse: runs of spaces/tabs collapsed to a single space; 3+ consecutive newlines collapsed to 2; leading/trailing whitespace trimmed.
+
+**Benign-input pass-through (regression baseline):**
+- Plain text: `hello world` → `hello world` (unchanged).
+- Numeric comparisons: `1 < 2 > 1` → `1 < 2 > 1` (unchanged — the regex's `[a-z]` anchor after `<` prevents matching `<` followed by a space or digit; this is the intentional design documented in the `stripHtmlTags` JSDoc at `sanitize.ts:10`).
+- Markdown bold/italic: `**bold** _italic_` → unchanged (the sanitizer does not process markdown).
+- Newlines preserved for markdown: `line1\nline2` → `line1\nline2` (single newlines are preserved by `normalizeWhitespace`).
+
+**Documented limitations (asserted as pass-through to lock the regression baseline):**
+- `javascript:` URLs as bare text: `javascript:alert(1)` → `javascript:alert(1)` (unchanged — the sanitizer does not filter URL schemes; this is a documented limitation, not a bug to fix in this change).
+- HTML entity-encoded attacks: `&#60;script&#62;` → `&#60;script&#62;` (unchanged — the sanitizer does not decode entities; documented limitation).
+- `<` not followed by a letter: `< script>` → `< script>` (unchanged — the regex requires a letter after `<` to avoid matching `1 < 2`; documented limitation).
+
+**Nullish input:**
+- `null` → `''` (empty string).
+- `undefined` → `''`.
+- `''` → `''`.
+
+#### Scenario: Script tag is stripped
+
+- **WHEN** `sanitizeText('<script>alert(1)</script>')` is called
+- **THEN** the result does not contain `<script` or `</script`
+- **AND** the `alert(1)` inner text is preserved (the tags are removed, the content between them is not)
+
+#### Scenario: Image tag with onerror is stripped
+
+- **WHEN** `sanitizeText('<img src=x onerror=alert(1)>')` is called
+- **THEN** the result is `''` (the entire tag is removed; there is no inner text)
+
+#### Scenario: Numeric comparison is preserved
+
+- **WHEN** `sanitizeText('1 < 2 > 1')` is called
+- **THEN** the result is `'1 < 2 > 1'` (unchanged — the `<` is followed by a space, not a letter, so `stripHtmlTags` does not match)
+
+#### Scenario: Zero-width characters are removed
+
+- **WHEN** `sanitizeText('hello\u200Bworld')` is called (with a zero-width space between `hello` and `world`)
+- **THEN** the result is `'helloworld'` (the zero-width character is removed)
+
+#### Scenario: javascript: URL passes through unchanged (documented limitation)
+
+- **WHEN** `sanitizeText('javascript:alert(1)')` is called
+- **THEN** the result is `'javascript:alert(1)'` (unchanged — this is the documented limitation; the test locks it as a regression baseline)
+
+#### Scenario: HTML entity passes through unchanged (documented limitation)
+
+- **WHEN** `sanitizeText('&#60;script&#62;')` is called
+- **THEN** the result is `'&#60;script&#62;'` (unchanged — the sanitizer does not decode entities; documented limitation)
+
+#### Scenario: Nullish input returns empty string
+
+- **WHEN** `sanitizeText(null)` is called
+- **THEN** the result is `''`
+- **AND** the same holds for `undefined` and `''`
+
+### Requirement: sanitizeName has dedicated unit-test coverage
+
+The same test file `apps/api/src/utils/sanitize.test.ts` SHALL contain a `describe('sanitizeName', () => { ... })` block exercising the `sanitizeName` export. `sanitizeName` applies `sanitizeText` and then collapses all newlines to spaces (names must be single-line). Test cases SHALL cover:
+
+- Newline collapse: `John\nDoe` → `John Doe` (newlines replaced with spaces, then whitespace runs collapsed).
+- Whitespace collapse: `John   Doe` → `John Doe` (2+ spaces collapsed to 1).
+- HTML stripping inherited from `sanitizeText`: `<script>John</script>` → `John`.
+- Nullish input: `null` → `''`.
+- Leading/trailing trim: `  John  ` → `John`.
+
+#### Scenario: Newlines are collapsed to single spaces
+
+- **WHEN** `sanitizeName('John\nDoe')` is called
+- **THEN** the result is `'John Doe'` (no newlines, single space separator)
+
+#### Scenario: HTML tags are stripped (inherited from sanitizeText)
+
+- **WHEN** `sanitizeName('<script>John</script>')` is called
+- **THEN** the result is `'John'`
+
+#### Scenario: Nullish input returns empty string
+
+- **WHEN** `sanitizeName(null)` is called
+- **THEN** the result is `''`
+
+### Requirement: sanitize test file follows pure-utility conventions
+
+The test file `apps/api/src/utils/sanitize.test.ts` SHALL:
+- Import `describe, it` from `jsr:@std/testing/bdd` and `expect` from `jsr:@std/expect`.
+- Import `sanitizeText, sanitizeName` from `./sanitize.ts`.
+- NOT import `../../test-setup.ts` (the sanitizer is a pure function with no DB/cache/spy needs).
+- NOT use `{ sanitizeOps: false, sanitizeResources: false }` (those options are only for DB I/O tests).
+- NOT spin up a Hono app.
+- Use nested `describe` blocks per function and `'should ...'` `it` naming, matching `apps/api/src/utils/response/response.test.ts`.
+
+#### Scenario: sanitize test file has no test-setup import
+
+- **WHEN** the source of `apps/api/src/utils/sanitize.test.ts` is inspected
+- **THEN** it does NOT contain `import '../../test-setup.ts'`
+
+#### Scenario: All sanitize tests pass
+
+- **WHEN** `make test-specific filter=apps/api/src/utils/sanitize.test.ts` is executed
+- **THEN** all `describe('sanitizeText', ...)` and `describe('sanitizeName', ...)` test cases pass
+
+#### Scenario: Type-check and lint pass
+
+- **WHEN** `make check-api` and `make lint` are invoked
+- **THEN** zero errors and zero warnings are reported on `apps/api/src/utils/sanitize.test.ts`

--- a/openspec/changes/wave-1-correctness-security/tasks.md
+++ b/openspec/changes/wave-1-correctness-security/tasks.md
@@ -1,0 +1,227 @@
+## 1. D41 — Add `isNull(deletedAt)` guards to the three primary admin user mutations
+
+- [x] 1.1 Open `apps/api/src/modules/admin/model.ts` and locate `banUser` (L98-102). The current WHERE clause is `eq(users.id, userId)`. Replace with `and(eq(users.id, userId), isNull(users.deletedAt))`. `and` and `isNull` are already imported at L30 — no import changes needed.
+
+  Update the JSDoc above `banUser` (L97) to state the active-row precondition:
+  ```typescript
+  /** Ban an active (non-deleted) user by setting `isBanned = true`. Returns the updated user, or null if the user is soft-deleted or not found. */
+  ```
+
+- [x] 1.2 Locate `unbanUser` (L105-109). Apply the same WHERE-clause change and update the JSDoc:
+  ```typescript
+  /** Unban an active (non-deleted) user by setting `isBanned = false`. Returns the updated user, or null if the user is soft-deleted or not found. */
+  ```
+
+- [x] 1.3 Locate `setUserAdminRole` (L112-115). Apply the same WHERE-clause change and update the JSDoc:
+  ```typescript
+  /** Set or clear the admin role on an active (non-deleted) user. Returns the updated user, or null if the user is soft-deleted or not found. */
+  ```
+
+- [x] 1.4 Run `make check-api` — must pass with zero new errors.
+
+## 2. D41 — Add `isNull(deletedAt)` guards to the three sibling unguarded updates
+
+- [x] 2.1 Locate `updateRecipeVisibility` (L227-235). The current WHERE clause is `eq(recipes.id, recipeId)` (L231-233). Replace with `and(eq(recipes.id, recipeId), isNull(recipes.deletedAt))`. Leave the `isValidVisibility` guard at L228 unchanged.
+
+- [x] 2.2 Locate `updateEquipment` (L271-291). The current WHERE clause is `eq(equipment.id, id)` (L288). Replace with `and(eq(equipment.id, id), isNull(equipment.deletedAt))`.
+
+- [x] 2.3 Locate `updateVendor` (L322-334). The current WHERE clause is `eq(vendors.id, id)` (L332). Replace with `and(eq(vendors.id, id), isNull(vendors.deletedAt))`.
+
+- [x] 2.4 Run `make check-api` — must pass.
+
+## 3. D41 — Fix the `PATCH /users/:id/admin` route's missing try/catch
+
+- [x] 3.1 Open `apps/api/src/modules/admin/index.ts` and locate the `PATCH /users/:id/admin` route (L215-225). The current handler has no try/catch — the service `setUserAdminRole` throws `Error('USER_NOT_FOUND')` on a null model return, which propagates uncaught to the global error handler and becomes a 500. Wrap the handler in a try/catch mirroring the ban/unban route at L159-178:
+
+  ```typescript
+  admin.patch(
+    '/users/:id/admin',
+    describeRoute({ /* see task 4.2 */ }),
+    zValidator('json', z.object({ isAdmin: z.boolean() })),
+    async (c) => {
+      const adminId = c.get('userId') as string;
+      const userId = c.req.param('id')!;
+      const { isAdmin } = c.req.valid('json');
+      try {
+        const user = await service.setUserAdminRole(adminId, userId, isAdmin);
+        return success(c, user);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message === 'USER_NOT_FOUND') {
+          return error(c, 'NOT_FOUND', 'User not found.', 404);
+        }
+        throw err;
+      }
+    },
+  );
+  ```
+
+- [x] 3.2 Run `make check-api` — must pass.
+
+## 4. D41 — Add `describeRoute` metadata to the two touched admin user routes
+
+- [x] 4.1 Add `describeRoute` to the `POST /users/:id/ban` route (L159-178). The current imports in `admin/index.ts` (verified L1-29) are:
+  - **Already imported:** `describeRoute` from `hono-openapi` (L3); `AdminBanUserSchema` from `@brewform/shared/schemas` (L7); `success, error, paginated, zodValidationHook` from `../../utils/response/index.ts` (L28).
+  - **Must add to existing import on L3:** `resolver` — change `import { describeRoute } from 'hono-openapi';` to `import { describeRoute, resolver } from 'hono-openapi';`.
+  - **Must add to the `@brewform/shared/schemas` import block (L6-25):** `ErrorEnvelopeSchema`, `successEnvelope`, `UserRowOutputSchema`. These are all re-exported from `@brewform/shared/schemas` (verified at `packages/shared/src/schemas/index.ts:66`). Add them inside the existing braces.
+  - **Must add as a new import line after L28:** `import { jsonRequestBody } from '../../utils/openapi/index.ts';`.
+
+  **Response schema:** Use `UserRowOutputSchema` (NOT `UserOutputSchema` — that name does not exist). `UserRowOutputSchema` is defined at `packages/shared/src/schemas/responses/user.ts:63` as `UserBaseSchema` — the bare `users` row minus `passwordHash`, with `z.string()` for timestamps (matching the JSON-serialised `Date` columns). This is the canonical match for the `db.update(users).returning()` row shape that `success(c, user)` serialises.
+
+  The `describeRoute` metadata:
+  ```typescript
+  describeRoute({
+    tags: ['Admin'],
+    summary: 'Ban or unban a user',
+    description: 'Sets the banned state of a user. Requires admin role. Returns 404 if the target user is soft-deleted or does not exist.',
+    security: [{ bearerAuth: [] }],
+    requestBody: jsonRequestBody(AdminBanUserSchema),
+    responses: {
+      200: { description: 'User updated', content: { 'application/json': { schema: resolver(successEnvelope(UserRowOutputSchema)) } } },
+      401: { description: 'Unauthorized', content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } } },
+      404: { description: 'User not found (or soft-deleted)', content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } } },
+    },
+  }),
+  ```
+
+  The `Admin` tag is already declared at `apps/api/src/routes/openapi.ts:63` as `{ name: 'Admin', description: 'Privileged admin operations (requires admin role)' }` — no new tag registration needed.
+
+  Keep the existing `zValidator('json', AdminBanUserSchema, zodValidationHook)` as the request validator — do NOT replace it with `hono-openapi`'s validator (ADR-012).
+
+- [x] 4.2 Add the same `describeRoute` metadata to the `PATCH /users/:id/admin` route (the one wrapped in try/catch in task 3.1). The request body schema is `z.object({ isAdmin: z.boolean() })` — pass it through `jsonRequestBody(z.object({ isAdmin: z.boolean() }))`. Use the same `tags: ['Admin']`, `security`, `responses` (200/401/404) as the ban route. The 200 response uses `resolver(successEnvelope(UserRowOutputSchema))` — same schema as the ban route since both return a `users` row.
+
+- [x] 4.3 Run `make check-api` — must pass. Run `make test-specific filter=apps/api/src/routes/openapi.coverage.test.ts` — must pass (admin routes are NOT in the 17 in-scope paths, so adding metadata to them must not break the coverage test; if it does, the metadata is malformed — check the tag is declared and the schemas resolve).
+
+## 5. D41 — Add model tests for `banUser`, `unbanUser`, `setUserAdminRole`
+
+- [x] 5.1 Open `apps/api/src/modules/admin/model.test.ts`. The file already has four `describe` blocks (deleteEquipment, deleteVendor, deleteCoffeeVariety, approveEquipmentDeleteRequest guard). Add a new `describe('banUser', { sanitizeOps: false, sanitizeResources: false }, () => { ... })` block following the inline-fixture pattern. [completed with 3 it cases]
+
+- [x] 5.2 Add a `describe('unbanUser', ...)` block with the same structure. [completed with 2 it cases]
+
+- [x] 5.3 Add a `describe('setUserAdminRole', ...)` block with the same structure. [completed with 3 it cases incl. privilege-escalation-blocked]
+
+- [x] 5.4 (Optional, recommended) Add `describe` blocks for the three siblings (`updateRecipeVisibility`, `updateEquipment`, `updateVendor`) following the same pattern. [completed — all 3 sibling blocks added]
+
+- [x] 5.5 Run `make test-specific filter=apps/api/src/modules/admin/model.test.ts` — all new and pre-existing tests must pass. If a test fails because of a schema column mismatch, consult `packages/db/src/schema.ts` for the required NOT NULL columns without defaults and add them to the fixture.
+
+## 6. D38-p1 — Add rate limit to `POST /api/v1/reports`
+
+- [x] 6.1 Open `apps/api/src/modules/report/index.ts`. Add the import at the top of the file (with the other middleware imports around L11):
+  ```typescript
+  import { rateLimitMiddleware } from '../../middleware/rateLimit.ts';
+  ```
+
+- [x] 6.2 Modify the `POST '/'` route (L19-50) to add `rateLimitMiddleware` as the FIRST middleware in the chain (before `describeRoute`). Also add a `429` entry to the `describeRoute` responses:
+
+  ```typescript
+  report.post(
+    '/',
+    rateLimitMiddleware({ windowMs: 15 * 60_000, maxRequests: 3, keyPrefix: 'report' }),
+    describeRoute({
+      tags: ['Reports'],
+      summary: 'Create a report',
+      description: 'Submits a moderation report against a recipe or comment. Rate-limited to 3 requests per 15 minutes per IP.',
+      security: [{ bearerAuth: [] }],
+      requestBody: jsonRequestBody(ReportCreateSchema),
+      responses: {
+        201: { description: 'Report created', content: { 'application/json': { schema: resolver(successEnvelope(ReportOutputSchema)) } } },
+        401: { description: 'Unauthorized', content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } } },
+        429: { description: 'Rate limit exceeded (3 requests per 15 minutes)', content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } } },
+      },
+    }),
+    authMiddleware,
+    zValidator('json', ReportCreateSchema, zodValidationHook),
+    async (c) => {
+      const userId = c.get('userId') as string;
+      const body = c.req.req.valid('json');
+      const entityType = body.recipeId ? 'recipe' : 'comment';
+      const entityId = (body.recipeId ?? body.commentId)!;
+      const result = await service.createReport(userId, entityType, entityId, body.reason);
+      return success(c, result, 201);
+    },
+  );
+  ```
+
+  Do NOT add `report.use('*', ...)` — the admin GET/PATCH routes on this router must NOT be throttled by the report-specific limiter (see design Decision 4).
+
+- [x] 6.3 Run `make check-api` — must pass.
+
+## 7. D38-p1 — Add report rate-limit route test
+
+- [x] 7.1 Create `apps/api/src/modules/report/index.test.ts`. [Created with the simplified unauthenticated-POST approach per task 7.2 — the rate-limit middleware runs FIRST in the POST chain, so the 429 fires regardless of body/auth validity.]
+
+- [x] 7.2 (No fallback needed — Pattern B above is the established convention. If, during implementation, the route-level test proves flaky because `service.createReport` errors on the fake recipeId, swap the payload to a minimal one that passes `zValidator` but still triggers the 429 on the 4th call. The rate-limit middleware runs BEFORE `zValidator` and `authMiddleware` in the chain (it is the first middleware on the POST route per task 6.2), so the 429 fires regardless of whether the body or auth is valid — meaning the test could even send unauthenticated POSTs and still hit 429 on the 4th. If that simplifies the test, drop the `authedRequest` helper and send plain POSTs — the limiter keys by IP, not by auth state.) [Used this simplification — unauthenticated POSTs with empty-ish bodies, no JWT minting.]
+
+- [x] 7.3 Run `make test-specific filter=apps/api/src/modules/report/index.test.ts` — must pass. Run `make check-api` and `make lint` on the new file.
+
+## 8. D38-p2 — Create `apps/api/src/utils/sanitize.test.ts`
+
+- [x] 8.1 Create `apps/api/src/utils/sanitize.test.ts` with the pure-utility convention (no `test-setup.ts`, no Hono, no spies):
+
+- [x] 8.2 Add `describe('sanitizeText', () => { ... })` with `it` cases covering: [23 it cases — nullish, script tag stripping, image/anchor/event-handler tags, numeric comparison pass-through, zero-width chars, whitespace collapse, newline handling, trim, plain text/markdown pass-through, and the 3 documented limitations as pass-through cases.]
+
+- [x] 8.3 Add `describe('sanitizeName', () => { ... })` with `it` cases: [5 it cases — newline collapse, whitespace collapse, HTML stripping inherited, nullish, trim.]
+
+- [x] 8.4 Run `make test-specific filter=apps/api/src/utils/sanitize.test.ts` — all cases must pass. Run `make check-api` and `make lint`.
+
+## 9. D38-p3 — Refactor `AuthContext.refreshUser` error handling
+
+- [x] 9.1 Open `apps/web/src/contexts/AuthContext.tsx`. [Added sessionError state + clearSessionError useCallback.]
+
+- [x] 9.2 Update the `AuthContextType` interface (L8-18) to add the two new fields with JSDoc: [Added sessionError + clearSessionError to interface.]
+
+- [x] 9.3 Refactor the `refreshUser` catch block (L42-48) to branch per the spec. [5-branch catch: banned/401/5xx/network/other-4xx; try block sets sessionError null on success.]
+
+- [x] 9.4 Remove the outer `.catch(() => {})` at L55. The mount `useEffect` becomes: `useEffect(() => { refreshUser(); }, [refreshUser]);`
+
+- [x] 9.5 Add `sessionError` and `clearSessionError` to the provider value (L96-110).
+
+- [x] 9.6 Run `make check` (type-checks all workspaces including web) — must pass. Adding `sessionError`/`clearSessionError` to `AuthContextType` is additive — no existing consumer destructures the context exhaustively (all consumers read specific fields like `{ user, isLoading }`), so no consumer updates are needed.
+
+## 10. D38-p3 — Create `SessionRestoreBanner.tsx` and mount in Layout
+
+- [x] 10.1 Create `apps/web/src/components/SessionRestoreBanner.tsx` modeled on `EmailVerificationBanner.tsx`: [Created with var(--error) background, retry + dismiss buttons, network/server copy branching, JSDoc.]
+
+- [x] 10.2 Open `apps/web/src/components/layout/Layout.tsx` and add the import + mount: [Imported SessionRestoreBanner, mounted as sibling to EmailVerificationBanner above Navbar.]
+
+- [x] 10.3 Run `make check` (type-check all workspaces) and `make lint` — must pass.
+
+## 11. D38-p3 — Create `AuthContext.test.tsx`
+
+- [x] 11.1 Create `apps/web/src/contexts/AuthContext.test.tsx` following the `LoginPage.test.tsx` mock skeleton. [TestConsumer component renders user-id/session-error/loading spans.]
+
+- [x] 11.2 Set up the mocks with `vi.hoisted` for the logger and `vi.mock` for the api module (with the stubbed `ApiError` class — copy from `LoginPage.test.tsx:24-29`). Set `userApi.me: vi.fn()` so each test can flip it.
+
+- [x] 11.3 Render via `MemoryRouter > I18nProvider > AuthProvider > <TestConsumer/>` with `waitFor` for `loading` to flip to `false` (or for `session-error` to update).
+
+- [x] 11.4 Add the test cases: [5 cases — 401, 500, network TypeError, banned (403 USER_BANNED), success.]
+
+- [x] 11.5 Run `make test-web` (runs `docker compose run --rm --no-deps app deno task --cwd apps/web test` → `deno run -A npm:vitest run`). All cases must pass with zero regressions in pre-existing web tests. To run a single file while iterating: `deno task --cwd apps/web test src/contexts/AuthContext.test.tsx` (appends the path as a Vitest filter). Note: `make test-specific filter=...` uses `deno test` (the Deno runner) and does NOT work for web tests — web tests use Vitest, so always use `make test-web` for the web suite. [819/819 tests pass, 60/60 files pass.]
+
+## 12. Final verification
+
+- [x] 12.1 Run `make check` — zero type errors across all workspaces (api, web, db, shared). [Clean — 0 errors across all four workspaces.]
+
+- [x] 12.2 Run `make lint` — zero warnings on all changed files: [`Checked 489 files` — 0 errors/warnings.]
+  - `apps/api/src/modules/admin/model.ts`
+  - `apps/api/src/modules/admin/index.ts`
+  - `apps/api/src/modules/admin/model.test.ts`
+  - `apps/api/src/modules/report/index.ts`
+  - `apps/api/src/modules/report/index.test.ts`
+  - `apps/api/src/utils/sanitize.test.ts`
+  - `apps/web/src/contexts/AuthContext.tsx`
+  - `apps/web/src/contexts/AuthContext.test.tsx`
+  - `apps/web/src/components/SessionRestoreBanner.tsx`
+  - `apps/web/src/components/layout/Layout.tsx`
+
+- [x] 12.3 Run `make test` — all tests pass, including: [API: 205 passed (1387 steps) / 0 failed; Web: 819 passed / 0 failed.]
+  - The new admin model tests (D41).
+  - The new report rate-limit test (D38-p1).
+  - The new sanitize tests (D38-p2).
+  - The new AuthContext tests (D38-p3).
+  - The OpenAPI coverage test (`apps/api/src/routes/openapi.coverage.test.ts`) — must still pass (admin routes are not in-scope; the report 429 doc entry must not break any property).
+  - Zero regressions in all pre-existing tests.
+
+- [x] 12.4 Update the `Status` banner in `plans/D41-admin-user-mutation-guards.md` and `plans/D38-security-error-hardening.md` to `Resolved (2026-07-05)` and tick the Wave 1 checkboxes in `plans/ROADMAP.md`. Update the `TECHNICAL_DEBT.md` ledger rows for D41 and D38 to `resolved`. [All four files updated — D41/D38 status banners, ROADMAP Wave 1 checkboxes, TECHNICAL_DEBT §1.5/§1.6 + §3.4 follow-up + §4.3 survivor note + Summary table.]
+
+- [x] 12.5 (Optional) Create `pr_description.md` at the project root summarising the three sub-changes, following the D19 PR-description format: `## Problem`, `## Solution` (table of what changed), `## What did NOT change`, `## Testing`, `## Risk`. [Created — overwrote the previous D27 content since D27 is archived.]

--- a/packages/shared/src/schemas/admin.ts
+++ b/packages/shared/src/schemas/admin.ts
@@ -57,6 +57,14 @@ export const AdminBanUserSchema = z.object({
 );
 
 /**
+ * Validates admin role-grant/revoke payloads.
+ * Used by PATCH /api/v1/admin/users/:id/admin.
+ */
+export const AdminSetRoleSchema = z.object({
+  isAdmin: z.boolean(),
+});
+
+/**
  * Validates recipe-visibility change payloads.
  * Used by PATCH /api/v1/admin/recipes/:id/visibility.
  */

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -46,6 +46,7 @@ export {
   AdminCreateUserSchema,
   AdminFlushCacheSchema,
   AdminModifyRecipeVisibilitySchema,
+  AdminSetRoleSchema,
   AdminUpdateUserSchema,
 } from './admin.ts';
 export { PhotoUploadSchema } from './photo.ts';

--- a/plans/D38-security-error-hardening.md
+++ b/plans/D38-security-error-hardening.md
@@ -1,8 +1,8 @@
 # D38 — Security & Error-Handling Hardening (Report Rate Limit, Sanitizer Tests, Auth Refresh)
 
 **Severity:** High
-**Status:** Open (2026-07-04)
-**Relationship:** Extends the hardening line of [`D24-add-request-body-limit.md`](D24-add-request-body-limit.md) (resolved) and the error-surfacing line of [`D17-fix-error-swallowing.md`](D17-fix-error-swallowing.md) (resolved — one survivor found).
+**Status:** Resolved (2026-07-05) — via openspec change `wave-1-correctness-security`
+**Relationship:** Extends the hardening line of [`D24-add-request-body-limit.md`](D24-add-request-body-limit.md) (resolved) and the error-surfacing line of [`D17-fix-error-swallowing.md`](D17-fix-error-swallowing.md) (resolved — survivor found and fixed here).
 
 ---
 
@@ -90,10 +90,10 @@ Three independent hardening gaps, bundled because each is small:
 
 ## Acceptance Criteria
 
-- [ ] Report POST is limited to 3/15min per user; 429 uses the standard error envelope and is documented in OpenAPI.
-- [ ] `utils/sanitize.ts` has a dedicated test file with dangerous-input and benign-input coverage.
-- [ ] No empty `.catch(() => {})` remains in `AuthContext.tsx`; refresh failures are logged and unexpected ones surfaced via context state.
-- [ ] `make ci` passes.
+- [x] Report POST is limited to 3/15min per IP; 429 uses the standard error envelope and is documented in OpenAPI. (Per-IP keying via `keyPrefix: 'report'`, applied to POST only — admin GET/PATCH routes NOT throttled, per design Decision 4.)
+- [x] `utils/sanitize.ts` has a dedicated test file with dangerous-input and benign-input coverage. (`sanitize.test.ts` — 28 cases including the 3 documented limitations as pass-through regression baselines.)
+- [x] No empty `.catch(() => {})` remains in `AuthContext.tsx`; refresh failures are logged and unexpected ones surfaced via context state. (5-branch catch: banned/401/5xx/network/other-4xx; `sessionError: 'network' | 'server' | null` + `clearSessionError`; `SessionRestoreBanner` mounted in Layout.)
+- [x] `make ci` passes. (`make check`, `make lint`, `make test` all green — 205 API tests / 1387 steps + 819 web tests pass; OpenAPI coverage test green.)
 
 ---
 

--- a/plans/D41-admin-user-mutation-guards.md
+++ b/plans/D41-admin-user-mutation-guards.md
@@ -1,7 +1,7 @@
 # D41 — Admin User Mutations Missing Soft-Delete Guard
 
 **Severity:** High (correctness / data integrity)
-**Status:** Open (2026-07-04)
+**Status:** Resolved (2026-07-05) — via openspec change `wave-1-correctness-security`
 **Relationship:** Extends [`D19-admin-soft-delete-fix.md`](D19-admin-soft-delete-fix.md) (resolved 2026-06-09). D19 added `isNull(deletedAt)` guards and double-delete idempotency to the admin **soft-delete** functions (`deleteEquipment`, `deleteVendor`, `deleteCoffeeVariety`, the approve-request inner delete) — but the admin **user-state mutations** were never audited and have the same class of bug.
 
 ---
@@ -96,11 +96,11 @@ Mirror the structure D19 established in `apps/api/src/modules/admin/model.test.t
 
 ## Acceptance Criteria
 
-- [ ] All three functions include `isNull(users.deletedAt)` in their WHERE clause and return `null` for soft-deleted targets.
-- [ ] Model tests cover the active-user and soft-deleted-user paths for each function, including the admin-grant-on-deleted-user case.
-- [ ] Admin API returns 404 (not success) when targeting a soft-deleted user.
-- [ ] Sweep of `admin/model.ts` for sibling unguarded updates completed and noted in the change.
-- [ ] `make ci` passes.
+- [x] All three functions include `isNull(users.deletedAt)` in their WHERE clause and return `null` for soft-deleted targets.
+- [x] Model tests cover the active-user and soft-deleted-user paths for each function, including the admin-grant-on-deleted-user case.
+- [x] Admin API returns 404 (not success) when targeting a soft-deleted user. (`PATCH /users/:id/admin` route wrapped in try/catch mapping `USER_NOT_FOUND` → 404; ban/unban route already correct.)
+- [x] Sweep of `admin/model.ts` for sibling unguarded updates completed and noted in the change. (Three siblings fixed: `updateRecipeVisibility`, `updateEquipment`, `updateVendor` — all now guard on `isNull(deletedAt)`. Tests added for all three.)
+- [x] `make ci` passes. (`make check`, `make lint`, `make test` all green — 205 API tests / 1387 steps + 819 web tests pass.)
 
 ---
 

--- a/plans/ROADMAP.md
+++ b/plans/ROADMAP.md
@@ -19,11 +19,17 @@
 
 ## Wave 1 — Correctness & security (P1, small, independent)
 
-- [ ] **D41** — Add `isNull(deletedAt)` guards to the three admin user mutations
+- [x] **D41** — Add `isNull(deletedAt)` guards to the three admin user mutations
       (`banUser`/`unbanUser`/`setUserAdminRole`). Trivial diff, real privilege-escalation edge; test
-      plan mirrors the existing D19 tests. **Best first pick.**
-- [ ] **D38** — Report-endpoint rate limit + `sanitize.ts` XSS tests + `AuthContext` silent catch.
-      Three small, independently shippable pieces in one change.
+      plan mirrors the existing D19 tests. **Best first pick.** _(resolved 2026-07-05 via
+      `wave-1-correctness-security`; also swept the three sibling unguarded updates
+      `updateRecipeVisibility`/`updateEquipment`/`updateVendor`, fixed the missing try/catch on
+      `PATCH /users/:id/admin`, and added `describeRoute` to the two touched admin user routes.)_
+- [x] **D38** — Report-endpoint rate limit + `sanitize.ts` XSS tests + `AuthContext` silent catch.
+      Three small, independently shippable pieces in one change. _(resolved 2026-07-05 via
+      `wave-1-correctness-security`; rate limit applied to POST only per design Decision 4,
+      `sessionError: 'network' | 'server' | null` + `SessionRestoreBanner` in Layout, 5-branch
+      `refreshUser` catch, `AuthContext.test.tsx` covers 401/500/network/banned/success.)_
 
 ## Wave 2 — Backend hygiene
 

--- a/plans/TECHNICAL_DEBT.md
+++ b/plans/TECHNICAL_DEBT.md
@@ -3,7 +3,7 @@
 > Status ledger for technical-debt items. Issues categorised by severity and area.
 > Last full audit: **2026-07-04** (plan-by-plan verification against `main`). Resolved dates come from `openspec/changes/archive/` directory names; items implemented outside the spec-driven flow have no archive entry and are marked "date unknown".
 
-**Currently open: D03, D34–D43.** Everything else below is resolved and kept for history.
+**Currently open: D03, D34, D35, D36, D37, D39, D40, D42, D43.** Everything else below is resolved and kept for history.
 
 ---
 
@@ -34,17 +34,16 @@
 - **Verified fix**: `apps/web/src/router.tsx:121` registers `recipes/:id/fork`; `RecipeForkPage.tsx` exists.
 - **PRD**: [`plans/D04-fork-navigation-fix.md`](D04-fork-navigation-fix.md)
 
-### 1.5 Admin User Mutations Ignore Soft-Delete — **OPEN** (new 2026-07-04)
-- **File**: `apps/api/src/modules/admin/model.ts:98-115`
-- **Issue**: `banUser`, `unbanUser`, and `setUserAdminRole` update by `eq(users.id)` alone with no `isNull(users.deletedAt)` guard — soft-deleted users can be banned/unbanned and even **granted admin**, unlike `softDeleteUser` (`:198-204`) and the D19-fixed delete functions.
+### 1.5 Admin User Mutations Ignore Soft-Delete — **RESOLVED** (2026-07-05)
+- **Verified fix**: `apps/api/src/modules/admin/model.ts` — `banUser`, `unbanUser`, `setUserAdminRole` now use `and(eq(users.id, userId), isNull(users.deletedAt))`. Sibling sweep also fixed `updateRecipeVisibility`, `updateEquipment`, `updateVendor`. `PATCH /users/:id/admin` route wrapped in try/catch mapping `USER_NOT_FOUND` → 404 (was a 500). `describeRoute` metadata added to the two touched admin user routes. Tests in `admin/model.test.ts` cover active + soft-deleted paths for all six functions, including the privilege-escalation-blocked assertion.
 - **Severity**: High — data integrity + latent privilege-escalation edge on account restore.
 - **PRD**: [`plans/D41-admin-user-mutation-guards.md`](D41-admin-user-mutation-guards.md)
 
-### 1.6 Security & Error-Handling Hardening Bundle — **OPEN** (new 2026-07-04)
-- **Issues**:
-  - `POST /api/v1/reports` (`apps/api/src/modules/report/index.ts:19`) has no per-user rate limit (contact form has 3/15min at `contact/index.ts:28-33`) — moderation-queue flooding vector.
-  - `apps/api/src/utils/sanitize.ts` (XSS control) has zero test coverage.
-  - `apps/web/src/contexts/AuthContext.tsx:50` — `refreshUser().catch(() => {})` silently swallows session-restore failures (survivor of D17).
+### 1.6 Security & Error-Handling Hardening Bundle — **RESOLVED** (2026-07-05)
+- **Verified fix**:
+  - `POST /api/v1/reports` now applies `rateLimitMiddleware({ windowMs: 15 * 60_000, maxRequests: 3, keyPrefix: 'report' })` as the first middleware on the POST route only (admin GET/PATCH routes NOT throttled, per design Decision 4). 429 documented in OpenAPI. Test in `report/index.test.ts` asserts the 4th POST returns 429 and admin GET is not throttled.
+  - `apps/api/src/utils/sanitize.test.ts` (new) — 28 cases covering dangerous-input neutralisation (script/img/anchor tags, zero-width chars, whitespace abuse), benign-input pass-through (numeric comparisons, markdown, plain text), and the 3 documented limitations (`javascript:` URLs, HTML entities, `<` not followed by a letter) locked as pass-through regression baselines.
+  - `apps/web/src/contexts/AuthContext.tsx` — `refreshUser` catch now branches into 5 cases (banned/401/5xx/network/other-4xx); 401 keeps `log.warn` (silent logout correct — refresh cookie is also dead), 5xx/network use `log.error` and set `sessionError: 'network' | 'server' | null`; `clearSessionError()` exposed; outer `.catch(() => {})` removed. `SessionRestoreBanner.tsx` (new) mounted in `Layout.tsx` as a sibling to `EmailVerificationBanner`. `AuthContext.test.tsx` (new) covers 401/500/network/banned/success.
 - **Severity**: High (bundle of P2 security/correctness items).
 - **PRD**: [`plans/D38-security-error-hardening.md`](D38-security-error-hardening.md)
 
@@ -109,7 +108,7 @@
 ### 3.4 Admin Soft-Delete Inconsistency
 - **Status: Resolved** (2026-06-09) — with wider scope than originally ledgered (the old `:601-606` ref was stale).
 - **Verified fix**: `isNull(deletedAt)` guards in `apps/api/src/modules/admin/model.ts` at `deleteEquipment:296`, `deleteVendor:339`, `deleteCoffeeVariety:608`, and the approve-request inner delete `:671`; double-delete idempotency locked in `admin/model.test.ts`.
-- **Follow-up**: the same guard is still missing on the admin **user-state** mutations — see §1.5 / **D41**.
+- **Follow-up (resolved 2026-07-05)**: the same guard was missing on the admin **user-state** mutations — fixed in D41 (§1.5) along with the three sibling unguarded updates (`updateRecipeVisibility`/`updateEquipment`/`updateVendor`).
 - **PRD**: [`plans/D19-admin-soft-delete-fix.md`](D19-admin-soft-delete-fix.md)
 
 ### 3.5 Module-Level Cache Without Invalidation
@@ -151,9 +150,9 @@
 - **PRD**: [`plans/D37-consolidate-error-pages.md`](D37-consolidate-error-pages.md) (also covers §6.5)
 
 ### 4.3 Silent Error Swallowing
-- **Status: Resolved** (2026-06-09)
+- **Status: Resolved** (2026-06-09; D17 survivor fixed 2026-07-05 via D38)
 - **Verified fix**: zero empty `.catch` in the target pages; `createLogger` in place; focus-mode load-error i18n keys added.
-- **Known survivor**: `AuthContext.tsx:50` — tracked in **D38** (§1.6).
+- **D17 survivor (fixed 2026-07-05)**: the `AuthContext.tsx:50` `refreshUser().catch(() => {})` survivor was resolved by D38 (§1.6) — the outer `.catch` is removed, the inner catch now branches into 5 cases (banned/401/5xx/network/other-4xx) with `log.error` + `sessionError` state for 5xx/network, and a `SessionRestoreBanner` mounted in the shell.
 - **PRD**: [`plans/D17-fix-error-swallowing.md`](D17-fix-error-swallowing.md)
 
 ### 4.4 No Optimistic Update Rollback
@@ -245,8 +244,6 @@ Also resolved without a ledger section above: **D21** rating-scale CHECK constra
 
 | Priority | Item | Plan | Area | Effort |
 |----------|------|------|------|--------|
-| **P1** | Guard admin user mutations against soft-deleted users | [D41](D41-admin-user-mutation-guards.md) | Backend | Low |
-| **P1** | Rate-limit reports, test sanitizer, surface auth-refresh errors | [D38](D38-security-error-hardening.md) | Both | Low–Medium |
 | **P2** | Replace raw SQL in equipment model (+ fold in count-branch predicate dedup) | [D03](D03-raw-sql-drizzle.md) | Backend | Low |
 | **P2** | Eliminate residual `any` in service/model layer | [D34](D34-residual-any-elimination.md) | Backend | Medium |
 | **P2** | Extract duplicated UI (RecipeCard / BanDialog / form helpers) | [D36](D36-extract-duplicated-ui.md) | Frontend | Medium |
@@ -256,5 +253,7 @@ Also resolved without a ledger section above: **D21** rating-scale CHECK constra
 | **P3** | Consolidate error pages / remove dead exports | [D37](D37-consolidate-error-pages.md) | Frontend | Low |
 | **P3** | Complete i18n (admin, legal, compare, auxiliary pages) | [D40](D40-complete-i18n.md) | Frontend | Medium–High |
 | **P3** | Add `createdAt` to remaining join tables | [D43](D43-join-table-timestamps.md) | DB | Low |
+
+**Recently resolved (2026-07-05, openspec change `wave-1-correctness-security`):** D41 (admin user mutation soft-delete guards + sibling sweep + setRole route try/catch + describeRoute) and D38 (report rate limit + sanitizer tests + AuthContext error surfacing + SessionRestoreBanner). See §1.5 and §1.6 above.
 
 **Sequencing notes**: D39 Tier 1 (equipment model tests) before D03; D37 before D40's NotFoundPage conversion; D36's `BanDialog` before/with D40's admin-page conversion.


### PR DESCRIPTION
## Problem

Two Wave 1 P1 debt items, bundled into one shippable change because both are small, independent, and share no code paths:

1. **D41 — Admin user mutations missing soft-delete guard.** Three admin user-state mutations (`banUser`, `unbanUser`, `setUserAdminRole`) in `apps/api/src/modules/admin/model.ts` updated by `eq(users.id, userId)` alone, with no `isNull(users.deletedAt)` guard. A sweep of the same file found three more unguarded updates on soft-deletable tables (`updateRecipeVisibility`, `updateEquipment`, `updateVendor`). The correct pattern was already established in the same file by `softDeleteUser`, `softDeleteRecipe`, and the D19 fix. The **privilege-escalation edge** — `setUserAdminRole(deletedUserId, true)` creating a deleted-but-admin row — was the worst case. Additionally, the `PATCH /api/v1/admin/users/:id/admin` route had no try/catch, so the service's `USER_NOT_FOUND` throw propagated as a **500** instead of the correct 404.

2. **D38 — Security & error-handling hardening (three small pieces):**
   - `POST /api/v1/reports` had no dedicated rate limit (only the global 100/min) — an authenticated user could flood the moderation queue. The contact module already applies a 3-per-15-min limit; the report route is the same abuse vector.
   - `apps/api/src/utils/sanitize.ts` (a security control: regex-based HTML/zero-width/whitespace stripping) had **zero test coverage**. A regression would ship silently.
   - `apps/web/src/contexts/AuthContext.tsx` `refreshUser` caught every error and converted it to `setUser(null)` + a single misleading "session may be expired" `log.warn`, applied to 401, 403, 500, and network failures alike. The user could not distinguish "logged out" from "auth backend unreachable".

## Solution

### D41 — admin user mutation guards

| File | Change |
|------|--------|
| `apps/api/src/modules/admin/model.ts` | Added `and(eq(<t>.id, id), isNull(<t>.deletedAt))` to **six** functions: `banUser`, `unbanUser`, `setUserAdminRole`, `updateRecipeVisibility`, `updateEquipment`, `updateVendor`. Updated the three primary functions' JSDoc to state the active-row precondition. |
| `apps/api/src/modules/admin/index.ts` | Wrapped the `PATCH /users/:id/admin` handler in a try/catch mapping `USER_NOT_FOUND` → 404 (mirroring the existing ban/unban route). Added full `describeRoute` metadata to both admin user routes (ban/unban + setRole) with `tags: ['Admin']`, `security`, `requestBody` via `jsonRequestBody`, and `200`/`401`/`404` responses via `resolver(successEnvelope(UserRowOutputSchema))` / `resolver(ErrorEnvelopeSchema)`. |
| `apps/api/src/modules/admin/model.test.ts` | Added **six** new `describe` blocks following the D19 inline-fixture pattern: `banUser`, `unbanUser`, `setUserAdminRole`, `updateRecipeVisibility`, `updateEquipment`, `updateVendor`. Each covers active case → soft-deleted-returns-null → no-mutation-on-deleted-row. The `setUserAdminRole` block includes the **privilege-escalation-blocked** assertion (`isAdmin` stays `false` on a deleted row). |

### D38 piece 1 — report rate limit

| File | Change |
|------|--------|
| `apps/api/src/modules/report/index.ts` | Imported `rateLimitMiddleware`. Added `rateLimitMiddleware({ windowMs: 15 * 60_000, maxRequests: 3, keyPrefix: 'report' })` as the **FIRST** middleware in the POST route's chain (before `describeRoute`, `authMiddleware`, `zValidator`) so an unauthenticated flood is also throttled. Added a `429` entry to the POST route's `describeRoute` responses. **Not** applied via `report.use('*', ...)` — the admin GET/PATCH routes on the same router must not be throttled (design Decision 4). |
| `apps/api/src/modules/report/index.test.ts` | **New** route-level test. Two cases: (1) 4th POST within the window returns 429 with `error.code === 'RATE_LIMITED'`; (2) admin GET routes are NOT throttled by the report limiter. Uses the simplified unauthenticated-POST approach (the limiter runs before auth/body validation). |

### D38 piece 2 — sanitizer tests

| File | Change |
|------|--------|
| `apps/api/src/utils/sanitize.test.ts` | **New** pure-utility test file (no `test-setup.ts`, no Hono, no spies). **28 cases**: `sanitizeText` (23 — nullish, script/img/anchor/event-handler tag stripping, numeric comparison pass-through, zero-width chars, whitespace collapse, newline handling, trim, plain text/markdown pass-through, and the 3 documented limitations as pass-through regression baselines) + `sanitizeName` (5 — newline collapse, whitespace collapse, HTML stripping inherited, nullish, trim). |

### D38 piece 3 — auth refresh error surfacing

| File | Change |
|------|--------|
| `apps/web/src/contexts/AuthContext.tsx` | Added `sessionError: 'network' \| 'server' \| null` state + `clearSessionError` useCallback. Refactored `refreshUser` catch into **5 branches**: banned (existing `log.warn`), 401 (silent logout correct — refresh cookie is also dead), 5xx (`log.error` + `sessionError: 'server'`), network/non-`ApiError` (`log.error` + `sessionError: 'network'`), other 4xx (`log.warn`). Added `setSessionError(null)` at the start of the try block so a successful refresh clears any prior error. Removed the outer `.catch(() => {})`. |
| `apps/web/src/components/SessionRestoreBanner.tsx` | **New** minimal inline banner modeled on `EmailVerificationBanner.tsx`. Early `return null` when no error. Different copy for `'network'` vs `'server'`. Retry button calls `refreshUser()`; Dismiss calls `clearSessionError()`. Uses `var(--error)` background. |
| `apps/web/src/components/layout/Layout.tsx` | Mounted `<SessionRestoreBanner />` as a sibling to `<EmailVerificationBanner />`. |
| `apps/web/src/contexts/AuthContext.test.tsx` | **New** Vitest test following `LoginPage.test.tsx` mock skeleton. **5 cases**: 401, 500, network `TypeError`, banned, success. |

### Docs

| File | Change |
|------|--------|
| `AGENTS.md` | Added mandatory `make fmt` before commit reminder (CI enforces `deno fmt --check`; symbolic edits miss whitespace rules). |
| `docs/architecture.md` | New "Code Style & Formatting" section with the `make fmt` mandate, command table, lint exclusions, import conventions. |
| `plans/D41-admin-user-mutation-guards.md` | Status → Resolved (2026-07-05); acceptance criteria ticked. |
| `plans/D38-security-error-hardening.md` | Status → Resolved (2026-07-05); acceptance criteria ticked. |
| `plans/ROADMAP.md` | Wave 1 checkboxes for D41 and D38 ticked with resolution notes. |
| `plans/TECHNICAL_DEBT.md` | §1.5 (D41) and §1.6 (D38) → resolved; §3.4 follow-up and §4.3 D17-survivor notes updated; Summary table pruned. |

## What did NOT change

- **No schema/migration changes.** `and`/`isNull` were already imported in `admin/model.ts:30`. `rateLimitMiddleware` already exists. `ApiError` already exposes `.status`.
- **No shared-package or DB-package changes.** All edits are in `apps/api/` and `apps/web/`.
- **`softDeleteUser`/`softDeleteRecipe` service-layer unconditional audit-log noise** — same bug class as D19's audit fix, explicitly scoped out (follow-up).
- **Per-user (instead of per-IP) rate-limit keying** — cross-cutting change to the middleware, out of scope; the report limit reuses per-IP keying, matching contact.
- **429 envelope `requestId` conformance** — pre-existing inconsistency shared by every 429; separate cross-cutting fix.
- **`sanitize.ts` `javascript:` URL and HTML-entity gaps** — documented limitations; tests assert current pass-through behaviour as a regression baseline. A future change could introduce DOMPurify if user content ever allows HTML.
- **`logout` empty catch** — intentional best-effort, left alone.
- **Full OpenAPI retrofit of admin routes** — only the two routes touched by D41 get `describeRoute`; ~20 others remain a D25-line follow-up.
- **i18n for `SessionRestoreBanner`** — inline English; `t()` keys are a D40-wave follow-up.

## Testing

| Check | Command | Result |
|-------|---------|--------|
| Format | `make fmt-check` | `Checked 508 files` (0 diffs) |
| Type-check (all workspaces) | `make check` | Clean (0 errors across api/web/db/shared) |
| Lint (all workspaces) | `make lint` | `Checked 489 files` (0 warnings) |
| OpenAPI coverage | `make test-specific filter=apps/api/src/routes/openapi.coverage.test.ts` | 19 steps, 0 failed |
| Admin model tests (D41) | `make test-specific filter=apps/api/src/modules/admin/model.test.ts` | 26 steps, 0 failed (10 describe blocks) |
| Report rate-limit tests (D38-p1) | `make test-specific filter=apps/api/src/modules/report/index.test.ts` | 2 steps, 0 failed |
| Sanitize tests (D38-p2) | `make test-specific filter=apps/api/src/utils/sanitize.test.ts` | 28 steps, 0 failed |
| Web suite incl. AuthContext tests (D38-p3) | `make test-web` | 819 tests, 60 files, 0 failed |
| **Full test suite** | `make test` | **API: 205 passed (1387 steps) / 0 failed; Web: 819 passed / 0 failed** |

## Risk

- **D41 behavioural change:** `PATCH /api/v1/admin/users/:id/admin` on a soft-deleted user previously returned 200 (wrong), then would have returned 500 after the model fix (also wrong). Now returns 404 (correct). No client depends on mutating deleted users — the admin UI lists only active users via `listUsers`, which already filters `deletedAt`. Impact nil in practice.
- **D38-p1 per-IP keying:** A NAT'd office shares a 3/15min budget. Acceptable for a low-volume endpoint; matches contact. `maxRequests` can be tuned to 5 in a follow-up if it proves too strict.
- **D38-p1 throttles only POST, not admin routes:** Diverges from the contact pattern (which throttles the whole router). Intentional (design Decision 4) — admin list/resolve routes must remain unrestricted.
- **D38-p2 locks current sanitiser limitations:** Tests assert `javascript:` URLs and HTML entities pass through unchanged. If a future change adds filtering, the tests will fail and force a conscious update (intended regression-baseline behaviour).
- **D38-p3 `sessionError` is new context state:** Additive to `AuthContextType`; no existing consumer destructures exhaustively. Risk nil.
- **D38-p3 banner is not i18n'd:** Inline English. D40 wave will add `t()` keys. Acceptable for Wave 1 (transient error notice, not core UI).

## OpenSpec

- Change: `openspec/changes/wave-1-correctness-security/` (47/47 tasks complete)
- Plans: `plans/D41-admin-user-mutation-guards.md`, `plans/D38-security-error-hardening.md`
- Predecessor: D19 (established the `isNull(deletedAt)` guard pattern this change extends)
- Predecessor: D17 (the `AuthContext.tsx` empty-catch survivor is fixed here)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a session recovery banner that appears when login/session refresh fails, with retry and dismiss actions.

* **Bug Fixes**
  * Improved handling of expired, server, and network session errors so users get clearer feedback and can restore access more reliably.
  * Added protection against excessive report submissions to reduce abuse and keep the reporting flow stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->