### PR TITLE
feat(f09): version diff — endpoint, service, shared schema, frontend page

### DIFF
--- a/apps/api/src/modules/recipe/diff.route.test.ts
+++ b/apps/api/src/modules/recipe/diff.route.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Route-level integration tests for GET /api/v1/recipes/:slug/versions/diff.
+ *
+ * Exercises the full HTTP stack (Zod query validation, optionalAuthGuard,
+ * visibility checks, service dispatch, envelope shaping) against the
+ * PostgreSQL test database.
+ */
+
+import '../../test-setup.ts';
+import { afterAll, beforeAll, describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { Hono } from 'hono';
+import type { Context, Next } from 'hono';
+import type { AppEnv } from '../../types/hono.ts';
+import { db } from '@brewform/db';
+import {
+  recipeEquipment,
+  recipes,
+  recipeTasteNotes,
+  recipeVersions,
+  userBadges,
+  users,
+} from '@brewform/db/schema';
+import { eq, inArray } from 'drizzle-orm';
+import recipeRouter, { deps } from './index.ts';
+
+async function createUser(prefix: string, isAdmin = false) {
+  const id = crypto.randomUUID();
+  const [user] = await db.insert(users).values({
+    id,
+    email: `${prefix}-${id}@example.com`,
+    username: `${prefix}-${id.slice(0, 8)}`,
+    passwordHash: 'hash',
+    isAdmin,
+  }).returning();
+  return user;
+}
+
+const stubOptionalAuth = async (_c: Context, next: Next) => {
+  await next();
+};
+const originalOptionalAuth = deps.optionalAuthMiddleware;
+
+function createAnonymousApp() {
+  deps.optionalAuthMiddleware = stubOptionalAuth;
+  const app = new Hono<AppEnv>();
+  app.use('*', async (c, next) => {
+    c.set('requestId', crypto.randomUUID());
+    await next();
+  });
+  app.route('/api/v1/recipes', recipeRouter);
+  return app;
+}
+
+function createAuthApp(userId: string, isAdmin = false) {
+  deps.optionalAuthMiddleware = stubOptionalAuth;
+  const app = new Hono<AppEnv>();
+  app.use('*', async (c, next) => {
+    c.set('requestId', crypto.randomUUID());
+    c.set('userId', userId);
+    c.set('user', {
+      id: userId,
+      isAdmin,
+      emailVerifiedAt: new Date(),
+      // deno-lint-ignore no-explicit-any -- test mock request body
+    } as any);
+    await next();
+  });
+  app.route('/api/v1/recipes', recipeRouter);
+  return app;
+}
+
+describe(
+  { name: 'GET /api/v1/recipes/:slug/versions/diff', sanitizeResources: false, sanitizeOps: false },
+  () => {
+    let author: typeof users.$inferSelect;
+    let outsider: typeof users.$inferSelect;
+    let admin: typeof users.$inferSelect;
+    let publicRecipeId: string;
+    let privateRecipeId: string;
+    let otherRecipeId: string;
+    let v1Id: string;
+    let v2Id: string;
+    let privateV1Id: string;
+    let privateV2Id: string;
+    let otherVersionId: string;
+
+    beforeAll(async () => {
+      author = await createUser('diff-route-author');
+      outsider = await createUser('diff-route-outsider');
+      admin = await createUser('diff-route-admin', true);
+
+      publicRecipeId = crypto.randomUUID();
+      privateRecipeId = crypto.randomUUID();
+      otherRecipeId = crypto.randomUUID();
+      v1Id = crypto.randomUUID();
+      v2Id = crypto.randomUUID();
+      privateV1Id = crypto.randomUUID();
+      privateV2Id = crypto.randomUUID();
+      otherVersionId = crypto.randomUUID();
+
+      await db.insert(recipes).values([
+        {
+          id: publicRecipeId,
+          slug: `diff-pub-${publicRecipeId.slice(0, 8)}`,
+          title: 'Public Diff Recipe',
+          authorId: author.id,
+          visibility: 'public',
+        },
+        {
+          id: privateRecipeId,
+          slug: `diff-priv-${privateRecipeId.slice(0, 8)}`,
+          title: 'Private Diff Recipe',
+          authorId: author.id,
+          visibility: 'private',
+        },
+        {
+          id: otherRecipeId,
+          slug: `diff-other-${otherRecipeId.slice(0, 8)}`,
+          title: 'Other Recipe',
+          authorId: author.id,
+          visibility: 'public',
+        },
+      ]);
+
+      await db.insert(recipeVersions).values([
+        {
+          id: v1Id,
+          recipeId: publicRecipeId,
+          versionNumber: 1,
+          brewMethod: 'v60',
+          drinkType: 'pour_over',
+          grindSize: 'medium',
+          groundWeightGrams: 18,
+          preparationNotes: 'Bloom 30s',
+          brewDate: new Date('2025-01-01'),
+          isFavourite: false,
+        },
+        {
+          id: v2Id,
+          recipeId: publicRecipeId,
+          versionNumber: 2,
+          brewMethod: 'espresso_machine',
+          drinkType: 'pour_over',
+          grindSize: 'fine',
+          groundWeightGrams: 20,
+          preparationNotes: 'WDT + tamp',
+          brewDate: new Date('2025-02-01'),
+          isFavourite: true,
+        },
+        {
+          id: privateV1Id,
+          recipeId: privateRecipeId,
+          versionNumber: 1,
+          brewMethod: 'french_press',
+          drinkType: 'drip_coffee',
+          preparationNotes: 'Steep 4min',
+          brewDate: new Date('2025-01-15'),
+          isFavourite: false,
+        },
+        {
+          id: privateV2Id,
+          recipeId: privateRecipeId,
+          versionNumber: 2,
+          brewMethod: 'aeropress',
+          drinkType: 'drip_coffee',
+          preparationNotes: 'Inverted 2min',
+          brewDate: new Date('2025-03-01'),
+          isFavourite: false,
+        },
+        {
+          id: otherVersionId,
+          recipeId: otherRecipeId,
+          versionNumber: 1,
+          brewMethod: 'cold_brew',
+          drinkType: 'cold_brew',
+          preparationNotes: '12h steep',
+          brewDate: new Date('2025-04-01'),
+          isFavourite: false,
+        },
+      ]);
+    });
+
+    afterAll(async () => {
+      const allVersionIds = [v1Id, v2Id, privateV1Id, privateV2Id, otherVersionId];
+      await db.delete(recipeTasteNotes).where(
+        inArray(recipeTasteNotes.recipeVersionId, allVersionIds),
+      );
+      await db.delete(recipeEquipment).where(
+        inArray(recipeEquipment.recipeVersionId, allVersionIds),
+      );
+      await db.delete(recipeVersions).where(inArray(recipeVersions.id, allVersionIds));
+      await db.delete(recipes).where(
+        inArray(recipes.id, [publicRecipeId, privateRecipeId, otherRecipeId]),
+      );
+      for (const u of [author, outsider, admin]) {
+        await db.delete(userBadges).where(eq(userBadges.userId, u.id));
+        await db.delete(users).where(eq(users.id, u.id));
+      }
+      deps.optionalAuthMiddleware = originalOptionalAuth;
+    });
+
+    function diffUrl(slug: string, v1: string, v2?: string) {
+      const params = new URLSearchParams({ v1 });
+      if (v2) params.set('v2', v2);
+      return `/api/v1/recipes/${slug}/versions/diff?${params}`;
+    }
+
+    const publicSlug = () => `diff-pub-${publicRecipeId.slice(0, 8)}`;
+    const privateSlug = () => `diff-priv-${privateRecipeId.slice(0, 8)}`;
+
+    it('anonymous user can diff a public recipe', async () => {
+      const app = createAnonymousApp();
+      const res = await app.request(diffUrl(publicSlug(), v1Id, v2Id));
+      // deno-lint-ignore no-explicit-any -- test assertion cast
+      const body = await res.json() as any;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.version1).toBeDefined();
+      expect(body.data.version2).toBeDefined();
+    });
+
+    it('non-author cannot diff a private recipe', async () => {
+      const app = createAuthApp(outsider.id);
+      const res = await app.request(diffUrl(privateSlug(), privateV1Id, privateV2Id));
+      // deno-lint-ignore no-explicit-any -- test assertion cast
+      const body = await res.json() as any;
+
+      expect(res.status).toBe(404);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('NOT_FOUND');
+    });
+
+    it('admin can diff a private recipe', async () => {
+      const app = createAuthApp(admin.id, true);
+      const res = await app.request(diffUrl(privateSlug(), privateV1Id, privateV2Id));
+      // deno-lint-ignore no-explicit-any -- test assertion cast
+      const body = await res.json() as any;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.version1).toBeDefined();
+    });
+
+    it('returns 400 when v2 is missing', async () => {
+      const app = createAnonymousApp();
+      const res = await app.request(diffUrl(publicSlug(), v1Id));
+      // deno-lint-ignore no-explicit-any -- test assertion cast
+      const body = await res.json() as any;
+
+      expect(res.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 400 when v1 === v2', async () => {
+      const app = createAnonymousApp();
+      const res = await app.request(diffUrl(publicSlug(), v1Id, v1Id));
+      // deno-lint-ignore no-explicit-any -- test assertion cast
+      const body = await res.json() as any;
+
+      expect(res.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 404 when version belongs to a different recipe', async () => {
+      const app = createAnonymousApp();
+      const res = await app.request(diffUrl(publicSlug(), v1Id, otherVersionId));
+      // deno-lint-ignore no-explicit-any -- test assertion cast
+      const body = await res.json() as any;
+
+      expect(res.status).toBe(404);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('VERSION_NOT_FOUND');
+    });
+
+    it('returns full diff response shape', async () => {
+      const app = createAuthApp(author.id);
+      const res = await app.request(diffUrl(publicSlug(), v1Id, v2Id));
+      // deno-lint-ignore no-explicit-any -- test assertion cast
+      const body = await res.json() as any;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.version1.id).toBe(v1Id);
+      expect(body.data.version2.id).toBe(v2Id);
+      expect(body.data.fields).toBeInstanceOf(Array);
+      expect(body.data.tasteNotes).toBeDefined();
+      expect(body.data.equipment).toBeDefined();
+
+      const brewMethod = body.data.fields.find(
+        // deno-lint-ignore no-explicit-any -- test assertion cast
+        (f: any) => f.field === 'brewMethod',
+      );
+      expect(brewMethod).toBeDefined();
+      expect(brewMethod.status).toBe('modified');
+      expect(brewMethod.value1).toBe('v60');
+      expect(brewMethod.value2).toBe('espresso_machine');
+    });
+  },
+);

--- a/apps/api/src/modules/recipe/diff.test.ts
+++ b/apps/api/src/modules/recipe/diff.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for the `diffVersions` service function.
+ *
+ * Exercises scalar-field status logic (added/removed/modified/unchanged),
+ * same-version and cross-recipe guards, and set-diff behaviour for taste
+ * notes and equipment against a PostgreSQL test database.
+ */
+
+import '../../test-setup.ts';
+import { afterEach, beforeEach, describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { eq, inArray } from 'drizzle-orm';
+import { db } from '@brewform/db';
+import {
+  equipment,
+  recipeEquipment,
+  recipes,
+  recipeTasteNotes,
+  recipeVersions,
+  tasteNotes,
+  users,
+} from '@brewform/db/schema';
+import { diffVersions } from './service.ts';
+
+describe('diffVersions', { sanitizeOps: false, sanitizeResources: false }, () => {
+  let userId: string;
+  let recipeId: string;
+  let otherRecipeId: string;
+  let v1Id: string;
+  let v2Id: string;
+  let otherVersionId: string;
+  let tnA: string;
+  let tnB: string;
+  let tnC: string;
+  let eqA: string;
+  let eqB: string;
+
+  beforeEach(async () => {
+    userId = crypto.randomUUID();
+    recipeId = crypto.randomUUID();
+    otherRecipeId = crypto.randomUUID();
+    v1Id = crypto.randomUUID();
+    v2Id = crypto.randomUUID();
+    otherVersionId = crypto.randomUUID();
+    tnA = crypto.randomUUID();
+    tnB = crypto.randomUUID();
+    tnC = crypto.randomUUID();
+    eqA = crypto.randomUUID();
+    eqB = crypto.randomUUID();
+
+    await db.insert(users).values({
+      id: userId,
+      email: `diff-${userId}@example.com`,
+      username: `diff-${userId.slice(0, 8)}`,
+      passwordHash: 'hash',
+    });
+
+    await db.insert(recipes).values([
+      {
+        id: recipeId,
+        slug: `diff-r1-${recipeId.slice(0, 8)}`,
+        title: 'Diff Recipe',
+        authorId: userId,
+        visibility: 'public',
+      },
+      {
+        id: otherRecipeId,
+        slug: `diff-r2-${otherRecipeId.slice(0, 8)}`,
+        title: 'Other Recipe',
+        authorId: userId,
+        visibility: 'public',
+      },
+    ]);
+
+    await db.insert(recipeVersions).values({
+      id: v1Id,
+      recipeId,
+      versionNumber: 1,
+      brewMethod: 'v60',
+      drinkType: 'pour_over',
+      grindSize: 'medium',
+      groundWeightGrams: 18,
+      preparationNotes: 'Bloom 30s',
+      brewDate: new Date('2025-01-01'),
+      isFavourite: false,
+    });
+    await db.insert(recipeVersions).values({
+      id: v2Id,
+      recipeId,
+      versionNumber: 2,
+      brewMethod: 'espresso_machine',
+      drinkType: 'pour_over',
+      grindSize: null,
+      groundWeightGrams: 18,
+      personalNotes: 'new notes',
+      preparationNotes: 'WDT + tamp',
+      brewDate: new Date('2025-02-01'),
+      isFavourite: false,
+    });
+    await db.insert(recipeVersions).values({
+      id: otherVersionId,
+      recipeId: otherRecipeId,
+      versionNumber: 1,
+      brewMethod: 'french_press',
+      drinkType: 'french_press',
+      preparationNotes: 'steep 4min',
+      brewDate: new Date(),
+      isFavourite: false,
+    });
+
+    await db.insert(tasteNotes).values([
+      { id: tnA, name: `NoteA-${tnA.slice(0, 8)}` },
+      { id: tnB, name: `NoteB-${tnB.slice(0, 8)}` },
+      { id: tnC, name: `NoteC-${tnC.slice(0, 8)}` },
+    ]);
+
+    await db.insert(equipment).values([
+      { id: eqA, name: `EqA-${eqA.slice(0, 8)}`, type: 'grinder' },
+      { id: eqB, name: `EqB-${eqB.slice(0, 8)}`, type: 'kettle' },
+    ]);
+
+    await db.insert(recipeTasteNotes).values([
+      { recipeVersionId: v1Id, tasteNoteId: tnA, intensity: 3 },
+      { recipeVersionId: v1Id, tasteNoteId: tnB, intensity: 2 },
+      { recipeVersionId: v2Id, tasteNoteId: tnB, intensity: 2 },
+      { recipeVersionId: v2Id, tasteNoteId: tnC, intensity: 3 },
+    ]);
+
+    await db.insert(recipeEquipment).values([
+      { recipeVersionId: v1Id, equipmentId: eqA },
+      { recipeVersionId: v2Id, equipmentId: eqA },
+      { recipeVersionId: v2Id, equipmentId: eqB },
+    ]);
+  });
+
+  afterEach(async () => {
+    const versionIds = [v1Id, v2Id, otherVersionId];
+    await db.delete(recipeTasteNotes).where(
+      inArray(recipeTasteNotes.recipeVersionId, versionIds),
+    );
+    await db.delete(recipeEquipment).where(
+      inArray(recipeEquipment.recipeVersionId, versionIds),
+    );
+    await db.delete(recipeVersions).where(inArray(recipeVersions.id, versionIds));
+    await db.delete(recipes).where(inArray(recipes.id, [recipeId, otherRecipeId]));
+    await db.delete(tasteNotes).where(inArray(tasteNotes.id, [tnA, tnB, tnC]));
+    await db.delete(equipment).where(inArray(equipment.id, [eqA, eqB]));
+    await db.delete(users).where(eq(users.id, userId));
+  });
+
+  it('returns correct field statuses for two versions with different fields', async () => {
+    const result = await diffVersions(recipeId, v1Id, v2Id);
+
+    expect(result.version1.id).toBe(v1Id);
+    expect(result.version1.versionNumber).toBe(1);
+    expect(result.version2.id).toBe(v2Id);
+    expect(result.version2.versionNumber).toBe(2);
+
+    const byField = Object.fromEntries(result.fields.map((f) => [f.field, f.status]));
+    expect(byField.brewMethod).toBe('modified');
+    expect(byField.grindSize).toBe('removed');
+    expect(byField.groundWeightGrams).toBe('unchanged');
+    expect(byField.personalNotes).toBe('added');
+    expect(byField.drinkType).toBe('unchanged');
+    expect(byField.preparationNotes).toBe('modified');
+  });
+
+  it('throws SAME_VERSION when v1Id equals v2Id', async () => {
+    await expect(diffVersions(recipeId, v1Id, v1Id)).rejects.toThrow('SAME_VERSION');
+  });
+
+  it('throws VERSION_NOT_FOUND when version belongs to a different recipe', async () => {
+    await expect(diffVersions(recipeId, v1Id, otherVersionId)).rejects.toThrow(
+      'VERSION_NOT_FOUND',
+    );
+  });
+
+  it('marks fields as unchanged when both versions have null', async () => {
+    const result = await diffVersions(recipeId, v1Id, v2Id);
+    const tds = result.fields.find((f) => f.field === 'tds');
+    expect(tds).toBeDefined();
+    expect(tds!.status).toBe('unchanged');
+    expect(tds!.value1).toBeNull();
+    expect(tds!.value2).toBeNull();
+  });
+
+  it('computes taste note set diffs', async () => {
+    const result = await diffVersions(recipeId, v1Id, v2Id);
+    const nameA = (await db.select({ name: tasteNotes.name }).from(tasteNotes).where(
+      eq(tasteNotes.id, tnA),
+    ))[0].name;
+    const nameB = (await db.select({ name: tasteNotes.name }).from(tasteNotes).where(
+      eq(tasteNotes.id, tnB),
+    ))[0].name;
+    const nameC = (await db.select({ name: tasteNotes.name }).from(tasteNotes).where(
+      eq(tasteNotes.id, tnC),
+    ))[0].name;
+
+    expect(result.tasteNotes.added).toEqual([nameC]);
+    expect(result.tasteNotes.removed).toEqual([nameA]);
+    expect(result.tasteNotes.unchanged).toEqual([nameB]);
+  });
+
+  it('computes equipment set diffs', async () => {
+    const result = await diffVersions(recipeId, v1Id, v2Id);
+    const nameA = (await db.select({ name: equipment.name }).from(equipment).where(
+      eq(equipment.id, eqA),
+    ))[0].name;
+    const nameB = (await db.select({ name: equipment.name }).from(equipment).where(
+      eq(equipment.id, eqB),
+    ))[0].name;
+
+    expect(result.equipment.added).toEqual([nameB]);
+    expect(result.equipment.removed).toEqual([]);
+    expect(result.equipment.unchanged).toEqual([nameA]);
+  });
+});

--- a/apps/api/src/modules/recipe/index.ts
+++ b/apps/api/src/modules/recipe/index.ts
@@ -18,6 +18,7 @@ import {
   RecipeRateSchema,
   RecipeUpdateSchema,
   successEnvelope,
+  VersionDiffOutputSchema,
 } from '@brewform/shared/schemas';
 import { jsonRequestBody } from '../../utils/openapi/index.ts';
 import { authMiddleware, optionalAuthMiddleware } from '../../middleware/auth.ts';
@@ -300,6 +301,90 @@ recipe.get(
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       if (message === 'RECIPE_NOT_FOUND') return error(c, 'NOT_FOUND', 'Recipe not found', 404);
+      throw err;
+    }
+  },
+);
+
+const VersionDiffQuerySchema = z.object({
+  v1: z.string().uuid(),
+  v2: z.string().uuid(),
+});
+
+recipe.get(
+  '/:slug/versions/diff',
+  describeRoute({
+    tags: ['Recipes'],
+    summary: 'Diff two versions of a recipe',
+    description:
+      'Returns a field-by-field comparison between two versions of the same recipe, including scalar field diffs and set diffs for taste notes and equipment.',
+    parameters: [
+      {
+        name: 'slug',
+        in: 'path',
+        required: true,
+        schema: { type: 'string' },
+      },
+      {
+        name: 'v1',
+        in: 'query',
+        required: true,
+        description: 'UUID of the first version',
+        schema: { type: 'string', format: 'uuid' },
+      },
+      {
+        name: 'v2',
+        in: 'query',
+        required: true,
+        description: 'UUID of the second version',
+        schema: { type: 'string', format: 'uuid' },
+      },
+    ],
+    responses: {
+      200: {
+        description: 'Version diff payload',
+        content: {
+          'application/json': {
+            schema: resolver(successEnvelope(VersionDiffOutputSchema)),
+          },
+        },
+      },
+      400: {
+        description: 'Missing params or same version requested',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+      404: {
+        description: 'Recipe or version not found',
+        content: { 'application/json': { schema: resolver(ErrorEnvelopeSchema) } },
+      },
+    },
+  }),
+  optionalAuthGuard,
+  zValidator('query', VersionDiffQuerySchema, zodValidationHook),
+  async (c) => {
+    const { slug } = c.req.param();
+    const { v1, v2 } = c.req.valid('query');
+    try {
+      const recipe = await service.getRecipe(slug);
+      if (!recipe) return error(c, 'NOT_FOUND', 'Recipe not found', 404);
+      if (!service.canViewRecipe(recipe, c.get('userId'), c.get('user')?.isAdmin)) {
+        return error(c, 'NOT_FOUND', 'Recipe not found', 404);
+      }
+      const diff = await service.diffVersions(recipe.id, v1, v2);
+      return success(c, diff);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === 'RECIPE_NOT_FOUND') return error(c, 'NOT_FOUND', 'Recipe not found', 404);
+      if (message === 'SAME_VERSION') {
+        return error(c, 'VALIDATION_ERROR', 'v1 and v2 must be different versions', 400);
+      }
+      if (message === 'VERSION_NOT_FOUND') {
+        return error(c, 'VERSION_NOT_FOUND', 'Version not found for this recipe', 404);
+      }
       throw err;
     }
   },

--- a/apps/api/src/modules/recipe/service.ts
+++ b/apps/api/src/modules/recipe/service.ts
@@ -795,3 +795,108 @@ export async function mergeRecipes(authorId: string, data: RecipeMerge) {
     throw err;
   }
 }
+
+/** The 20 scalar fields compared between two recipe versions. */
+const DIFF_SCALAR_FIELDS = [
+  'brewMethod',
+  'drinkType',
+  'productName',
+  'coffeeBrand',
+  'coffeeProcessing',
+  'grindSize',
+  'grinder',
+  'brewerDetails',
+  'groundWeightGrams',
+  'extractionTimeSeconds',
+  'extractionVolumeMl',
+  'temperatureCelsius',
+  'brewRatio',
+  'flowRate',
+  'preInfusionTimeSeconds',
+  'tds',
+  'preparationNotes',
+  'personalNotes',
+  'rating',
+  'emojiTag',
+] as const;
+
+/**
+ * Compute a field-by-field diff between two versions of the same recipe.
+ *
+ * @param recipeId - The recipe both versions must belong to.
+ * @param v1Id - UUID of the first (older) version.
+ * @param v2Id - UUID of the second (newer) version.
+ * @returns A structured diff payload matching `VersionDiffOutputSchema`.
+ * @throws Error('VERSION_NOT_FOUND') if either version is missing or belongs to a different recipe.
+ * @throws Error('SAME_VERSION') if v1Id === v2Id.
+ */
+export async function diffVersions(recipeId: string, v1Id: string, v2Id: string) {
+  logger.debug({ recipeId, v1Id, v2Id }, 'diffVersions started');
+
+  if (v1Id === v2Id) throw new Error('SAME_VERSION');
+
+  try {
+    const [v1, v2] = await Promise.all([
+      model.fetchRecipeVersionWithRelations(v1Id),
+      model.fetchRecipeVersionWithRelations(v2Id),
+    ]);
+
+    if (!v1 || !v2 || v1.recipeId !== recipeId || v2.recipeId !== recipeId) {
+      throw new Error('VERSION_NOT_FOUND');
+    }
+
+    const fields = DIFF_SCALAR_FIELDS.map((field) => {
+      const value1 = v1[field] ?? null;
+      const value2 = v2[field] ?? null;
+      let status: 'added' | 'removed' | 'modified' | 'unchanged';
+      if (value1 === null && value2 !== null) status = 'added';
+      else if (value1 !== null && value2 === null) status = 'removed';
+      else if (value1 !== value2) status = 'modified';
+      else status = 'unchanged';
+      return { field, value1, value2, status };
+    });
+
+    const names1 = new Set(v1.tasteNotes.map((tn) => tn.tasteNote.name));
+    const names2 = new Set(v2.tasteNotes.map((tn) => tn.tasteNote.name));
+    const tasteNotes = {
+      added: [...names2].filter((n) => !names1.has(n)),
+      removed: [...names1].filter((n) => !names2.has(n)),
+      unchanged: [...names1].filter((n) => names2.has(n)),
+    };
+
+    const equip1 = new Set(v1.equipment.map((e) => e.equipment.name));
+    const equip2 = new Set(v2.equipment.map((e) => e.equipment.name));
+    const equipment = {
+      added: [...equip2].filter((n) => !equip1.has(n)),
+      removed: [...equip1].filter((n) => !equip2.has(n)),
+      unchanged: [...equip1].filter((n) => equip2.has(n)),
+    };
+
+    const result = {
+      version1: {
+        id: v1.id,
+        versionNumber: v1.versionNumber,
+        brewDate: new Date(v1.brewDate).toISOString(),
+      },
+      version2: {
+        id: v2.id,
+        versionNumber: v2.versionNumber,
+        brewDate: new Date(v2.brewDate).toISOString(),
+      },
+      fields,
+      tasteNotes,
+      equipment,
+    };
+
+    logger.debug({ recipeId, v1Id, v2Id }, 'diffVersions completed');
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message === 'VERSION_NOT_FOUND') {
+      logger.debug({ recipeId, v1Id, v2Id }, 'diffVersions version not found');
+    } else {
+      logger.error({ err, recipeId, v1Id, v2Id }, 'diffVersions failed');
+    }
+    throw err;
+  }
+}

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -34,6 +34,7 @@ import type {
   TasteNoteOutput,
   UnreadCountOutput,
   UserProfileUpdate,
+  VersionDiffOutput,
 } from '@brewform/shared/schemas';
 import { api, ApiError } from './client.ts';
 import { createLogger } from '@/utils/logger.ts';
@@ -105,6 +106,9 @@ export const recipeApi = {
   saveNotes: (id: string, notes: string) =>
     api.post<{ message: string }>(`/recipes/${id}/notes`, { notes } as RecipeNotes),
   merge: (body: RecipeMerge) => api.post<RecipeDetailOutput, RecipeMerge>('/recipes/merge', body),
+  /** Fetch a field-by-field diff between two versions of a recipe. */
+  diffVersions: (slug: string, v1: string, v2: string) =>
+    api.get<VersionDiffOutput>(`/recipes/${slug}/versions/diff?v1=${v1}&v2=${v2}`),
 };
 
 /** Taste-note API client — full hierarchy, name search, and flat list. */

--- a/apps/web/src/components/recipe/DiffHighlighter.test.tsx
+++ b/apps/web/src/components/recipe/DiffHighlighter.test.tsx
@@ -42,4 +42,41 @@ describe('DiffHighlighter', () => {
     render(<DiffHighlighter labelKey='recipe.dose' value1={null} value2={null} />);
     expect(screen.getAllByText('-')).toHaveLength(2);
   });
+
+  it('uses added status colors when status="added"', () => {
+    render(<DiffHighlighter labelKey='recipe.dose' value1={null} value2={20} status='added' />);
+    const row = screen.getByText('recipe.dose').closest('.grid') as HTMLElement;
+    expect(row.style.backgroundColor).toBe('var(--diff-added-bg)');
+    expect((screen.getByText('20') as HTMLElement).style.color).toBe('var(--diff-added-text)');
+  });
+
+  it('uses removed status colors when status="removed"', () => {
+    render(<DiffHighlighter labelKey='recipe.dose' value1={18} value2={null} status='removed' />);
+    const row = screen.getByText('recipe.dose').closest('.grid') as HTMLElement;
+    expect(row.style.backgroundColor).toBe('var(--diff-removed-bg)');
+    expect((screen.getByText('18') as HTMLElement).style.color).toBe('var(--diff-removed-text)');
+  });
+
+  it('uses modified status colors when status="modified"', () => {
+    render(<DiffHighlighter labelKey='recipe.dose' value1={18} value2={20} status='modified' />);
+    const row = screen.getByText('recipe.dose').closest('.grid') as HTMLElement;
+    expect(row.style.backgroundColor).toBe('var(--diff-modified-bg)');
+    expect((screen.getByText('18') as HTMLElement).style.color).toBe('var(--diff-modified-text)');
+    expect((screen.getByText('20') as HTMLElement).style.color).toBe('var(--diff-modified-text)');
+  });
+
+  it('uses transparent bg and primary text when status="unchanged"', () => {
+    render(<DiffHighlighter labelKey='recipe.dose' value1={18} value2={18} status='unchanged' />);
+    const row = screen.getByText('recipe.dose').closest('.grid') as HTMLElement;
+    expect(row.style.backgroundColor).toBe('transparent');
+    expect((screen.getAllByText('18')[0] as HTMLElement).style.color).toBe('var(--text-primary)');
+  });
+
+  it('preserves binary highlight when no status prop and values differ', () => {
+    render(<DiffHighlighter labelKey='recipe.dose' value1={18} value2={20} />);
+    const row = screen.getByText('recipe.dose').closest('.grid') as HTMLElement;
+    expect(row.style.backgroundColor).toBe('var(--diff-highlight, rgba(255, 200, 0, 0.1))');
+    expect((screen.getByText('18') as HTMLElement).style.color).toBe('var(--accent-primary)');
+    expect((screen.getByText('20') as HTMLElement).style.color).toBe('var(--accent-secondary)');
+  });
 });

--- a/apps/web/src/components/recipe/DiffHighlighter.tsx
+++ b/apps/web/src/components/recipe/DiffHighlighter.tsx
@@ -1,27 +1,58 @@
 import { useTranslation } from '../../contexts/I18nContext.tsx';
 
+/** Props for {@link DiffHighlighter}. */
 interface DiffHighlighterProps {
   labelKey: string;
   value1: string | number | null;
   value2: string | number | null;
   formatter?: (val: string | number | null) => string;
+  status?: 'added' | 'removed' | 'modified' | 'unchanged';
 }
 
-export function DiffHighlighter({ labelKey, value1, value2, formatter }: DiffHighlighterProps) {
+const statusStyles: Record<
+  NonNullable<DiffHighlighterProps['status']>,
+  { bg: string; text: string }
+> = {
+  added: { bg: 'var(--diff-added-bg)', text: 'var(--diff-added-text)' },
+  removed: { bg: 'var(--diff-removed-bg)', text: 'var(--diff-removed-text)' },
+  modified: { bg: 'var(--diff-modified-bg)', text: 'var(--diff-modified-text)' },
+  unchanged: { bg: 'transparent', text: 'var(--text-primary)' },
+};
+
+/**
+ * Renders a side-by-side diff row with a centered label.
+ * When `status` is provided it drives colors; otherwise falls back to binary differ detection.
+ */
+export function DiffHighlighter({
+  labelKey,
+  value1,
+  value2,
+  formatter,
+  status,
+}: DiffHighlighterProps) {
   const { t } = useTranslation();
   const display1 = formatter ? formatter(value1) : (value1 ?? '-');
   const display2 = formatter ? formatter(value2) : (value2 ?? '-');
   const differs = display1 !== display2;
+
+  const s = status ? statusStyles[status] : undefined;
+  const bgColor = s
+    ? s.bg
+    : differs
+    ? 'var(--diff-highlight, rgba(255, 200, 0, 0.1))'
+    : 'transparent';
+  const leftColor = s ? s.text : differs ? 'var(--accent-primary)' : 'var(--text-primary)';
+  const rightColor = s ? s.text : differs ? 'var(--accent-secondary)' : 'var(--text-primary)';
 
   return (
     <div
       className='grid grid-cols-3 gap-2 py-2 text-sm'
       style={{
         borderBottom: '1px solid var(--border-primary)',
-        backgroundColor: differs ? 'var(--diff-highlight, rgba(255, 200, 0, 0.1))' : 'transparent',
+        backgroundColor: bgColor,
       }}
     >
-      <div style={{ color: differs ? 'var(--accent-primary)' : 'var(--text-primary)' }}>
+      <div style={{ color: leftColor }}>
         {display1}
       </div>
       <div className='text-center font-medium' style={{ color: 'var(--text-secondary)' }}>
@@ -29,7 +60,7 @@ export function DiffHighlighter({ labelKey, value1, value2, formatter }: DiffHig
       </div>
       <div
         className='text-right'
-        style={{ color: differs ? 'var(--accent-secondary)' : 'var(--text-primary)' }}
+        style={{ color: rightColor }}
       >
         {display2}
       </div>

--- a/apps/web/src/pages/recipes/RecipeVersionsPage.test.tsx
+++ b/apps/web/src/pages/recipes/RecipeVersionsPage.test.tsx
@@ -1,123 +1,146 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { RecipeVersionsPage } from './RecipeVersionsPage.tsx';
-import { MemoryRouter } from 'react-router';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 
-const { mockLogger } = vi.hoisted(() => ({
-  mockLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+vi.mock('@/utils/logger.ts', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+  }),
 }));
-vi.mock('@/utils/logger.ts', () => ({ createLogger: () => mockLogger }));
 
-vi.mock('react-router', async () => {
-  const actual = await vi.importActual('react-router');
-  return { ...actual, useParams: vi.fn() };
-});
+vi.mock('../../contexts/I18nContext.tsx', () => ({
+  useTranslation: () => ({
+    t: (k: string) => k,
+    locale: 'en',
+    setLocale: vi.fn(),
+    availableLocales: ['en', 'tr'],
+  }),
+}));
 
-vi.mock('../../api/client.ts', () => ({ api: { get: vi.fn() } }));
-vi.mock('../../contexts/I18nContext.tsx', () => ({ useTranslation: vi.fn() }));
-vi.mock(
-  '../../hooks/useUnitSystem.ts',
-  () => ({ useUnitSystem: vi.fn().mockReturnValue('metric') }),
-);
+vi.mock('../../hooks/useUnitSystem.ts', () => ({
+  useUnitSystem: () => 'metric',
+}));
 
-import { useParams } from 'react-router';
+vi.mock('../../api/client.ts', () => ({
+  api: { get: vi.fn() },
+}));
+
 import { api } from '../../api/client.ts';
-import { useTranslation } from '../../contexts/I18nContext.tsx';
+import { RecipeVersionsPage } from './RecipeVersionsPage.tsx';
 
-const mockUseParams = vi.mocked(useParams);
-const mockApi = vi.mocked(api);
-const mockUseTranslation = vi.mocked(useTranslation);
+const mockApiGet = vi.mocked(api.get);
 
-const enT = (key: string) => {
-  const map: Record<string, string> = {
-    'common.loading': 'Loading...',
-    'common.back': 'Back',
-    'recipe.versionHistory': 'Version History',
-    'common.noResults': 'No results found',
-  };
-  return map[key] ?? key;
-};
+const mockVersions = [
+  {
+    id: 'v1-id',
+    versionNumber: 3,
+    brewDate: '2024-03-01',
+    brewMethod: 'v60',
+    groundWeightGrams: 18,
+    extractionVolumeMl: 300,
+    extractionTimeSeconds: 150,
+    temperatureCelsius: 93,
+  },
+  {
+    id: 'v2-id',
+    versionNumber: 2,
+    brewDate: '2024-02-01',
+    brewMethod: 'v60',
+    groundWeightGrams: 17,
+    extractionVolumeMl: 280,
+    extractionTimeSeconds: 140,
+    temperatureCelsius: 92,
+  },
+  {
+    id: 'v3-id',
+    versionNumber: 1,
+    brewDate: '2024-01-01',
+    brewMethod: 'french_press',
+    groundWeightGrams: 30,
+    extractionVolumeMl: 500,
+    extractionTimeSeconds: 240,
+    temperatureCelsius: 96,
+  },
+];
+
+function renderPage() {
+  const router = createMemoryRouter(
+    [{ path: '/recipes/:slug/versions', element: <RecipeVersionsPage /> }],
+    { initialEntries: ['/recipes/test-recipe/versions'] },
+  );
+  render(<RouterProvider router={router} />);
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockLogger.debug.mockClear();
-  mockLogger.info.mockClear();
-  mockLogger.warn.mockClear();
-  mockLogger.error.mockClear();
-  mockUseParams.mockReturnValue({ slug: 'test-recipe' });
-  mockUseTranslation.mockReturnValue({
-    locale: 'en' as const,
-    setLocale: vi.fn(),
-    t: enT,
-    availableLocales: ['en', 'tr'],
+  mockApiGet.mockResolvedValue({
+    title: 'Test Recipe',
+    slug: 'test-recipe',
+    versions: mockVersions,
   });
 });
 
 describe('RecipeVersionsPage', () => {
-  it('logs mount and unmount', async () => {
-    mockApi.get.mockResolvedValue({
-      title: 'My Recipe',
-      slug: 'test-recipe',
-      versions: [],
+  it('renders version rows after loading', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('v3')).toBeInTheDocument();
     });
-    const { unmount } = render(
-      <MemoryRouter>
-        <RecipeVersionsPage />
-      </MemoryRouter>,
-    );
-    await waitFor(() =>
-      expect(mockLogger.debug).toHaveBeenCalledWith({}, 'RecipeVersionsPage mounted')
-    );
-    unmount();
-    await waitFor(() =>
-      expect(mockLogger.debug).toHaveBeenCalledWith({}, 'RecipeVersionsPage unmounted')
-    );
+    expect(screen.getByText('v2')).toBeInTheDocument();
+    expect(screen.getByText('v1')).toBeInTheDocument();
   });
 
-  it('renders version list on successful load', async () => {
-    mockApi.get.mockResolvedValue({
-      title: 'My Recipe',
-      slug: 'test-recipe',
-      versions: [
-        {
-          id: 'v1',
-          versionNumber: 1,
-          brewDate: '2026-01-01T00:00:00Z',
-          brewMethod: 'v60',
-          groundWeightGrams: 18,
-          extractionVolumeMl: 250,
-          extractionTimeSeconds: 180,
-          temperatureCelsius: 93,
-        },
-      ],
-    });
-
-    render(
-      <MemoryRouter>
-        <RecipeVersionsPage />
-      </MemoryRouter>,
-    );
-
+  it('selects a version when checkbox is clicked', async () => {
+    renderPage();
     await waitFor(() => {
-      expect(screen.getByText('v1')).toBeInTheDocument();
+      expect(screen.getByText('v3')).toBeInTheDocument();
     });
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    expect(checkboxes[0]).toBeChecked();
   });
 
-  it('shows no results when api fails', async () => {
-    mockApi.get.mockRejectedValue(new Error('Not found'));
-
-    render(
-      <MemoryRouter>
-        <RecipeVersionsPage />
-      </MemoryRouter>,
-    );
-
+  it('disables third checkbox when 2 are selected', async () => {
+    renderPage();
     await waitFor(() => {
-      expect(screen.getByText('No results found')).toBeInTheDocument();
+      expect(screen.getByText('v3')).toBeInTheDocument();
     });
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      { err: expect.any(Error) },
-      'RecipeVersionsPage loadData failed',
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+    expect(checkboxes[2]).toBeDisabled();
+  });
+
+  it('shows compare link only when exactly 2 selected', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('v3')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('versionDiff.compareSelected')).not.toBeInTheDocument();
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    expect(screen.queryByText('versionDiff.compareSelected')).not.toBeInTheDocument();
+    fireEvent.click(checkboxes[1]);
+    expect(screen.getByText('versionDiff.compareSelected')).toBeInTheDocument();
+  });
+
+  it('compare link points to correct diff URL', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('v3')).toBeInTheDocument();
+    });
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+    const link = screen.getByText('versionDiff.compareSelected').closest('a');
+    expect(link).toHaveAttribute(
+      'href',
+      '/recipes/test-recipe/versions/diff?v1=v1-id&v2=v2-id',
     );
   });
 });

--- a/apps/web/src/pages/recipes/RecipeVersionsPage.tsx
+++ b/apps/web/src/pages/recipes/RecipeVersionsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router';
+import { Link, useParams } from 'react-router';
 import { api } from '../../api/client.ts';
 import { useTranslation } from '../../contexts/I18nContext.tsx';
 import { SEOHead } from '../../components/seo/SEOHead.tsx';
@@ -27,6 +27,14 @@ export function RecipeVersionsPage() {
     { title: string; slug: string; versions: RecipeVersionRow[] } | null
   >(null);
   const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  /** Toggle a version ID in the selection set (max 2). */
+  const toggleSelect = (id: string) => {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : prev.length >= 2 ? prev : [...prev, id]
+    );
+  };
 
   useEffect(() => {
     log.debug({}, 'RecipeVersionsPage mounted');
@@ -39,6 +47,7 @@ export function RecipeVersionsPage() {
     if (!slug) return;
     setLoading(true);
     setData(null);
+    setSelected([]);
     api.get<{ title: string; slug: string; versions: RecipeVersionRow[] }>(
       `/recipes/${slug}/versions`,
     )
@@ -85,6 +94,14 @@ export function RecipeVersionsPage() {
           <h1 className='text-2xl font-bold text-[color:var(--text-primary)]'>
             {data.title} – {t('recipe.versionHistory')}
           </h1>
+          {selected.length === 2 && (
+            <Link
+              to={`/recipes/${data.slug}/versions/diff?v1=${selected[0]}&v2=${selected[1]}`}
+              className='mt-2 inline-block rounded-md bg-[color:var(--accent-primary)] px-3 py-1.5 text-sm font-medium text-white'
+            >
+              {t('versionDiff.compareSelected')}
+            </Link>
+          )}
         </div>
 
         <div className='space-y-3'>
@@ -94,9 +111,18 @@ export function RecipeVersionsPage() {
               className='rounded-lg p-4 bg-[color:var(--bg-secondary)] border border-[color:var(--border-primary)]'
             >
               <div className='flex items-center justify-between'>
-                <span className='font-semibold text-[color:var(--text-primary)]'>
-                  v{v.versionNumber}
-                </span>
+                <label className='flex items-center gap-2'>
+                  <input
+                    type='checkbox'
+                    checked={selected.includes(v.id)}
+                    onChange={() => toggleSelect(v.id)}
+                    disabled={!selected.includes(v.id) && selected.length >= 2}
+                    className='h-4 w-4 accent-[color:var(--accent-primary)]'
+                  />
+                  <span className='font-semibold text-[color:var(--text-primary)]'>
+                    v{v.versionNumber}
+                  </span>
+                </label>
                 <span className='text-sm text-[color:var(--text-tertiary)]'>
                   {formatDate(v.brewDate, locale)}
                 </span>

--- a/apps/web/src/pages/recipes/VersionDiffPage.test.tsx
+++ b/apps/web/src/pages/recipes/VersionDiffPage.test.tsx
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+
+vi.mock('@/utils/logger.ts', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+  }),
+}));
+
+vi.mock('../../contexts/I18nContext.tsx', () => ({
+  useTranslation: () => ({
+    t: (k: string) => k,
+    locale: 'en',
+    setLocale: vi.fn(),
+    availableLocales: ['en', 'tr'],
+  }),
+}));
+
+vi.mock('../../hooks/useUnitSystem.ts', () => ({
+  useUnitSystem: () => 'metric',
+}));
+
+vi.mock('../../api/index.ts', () => ({
+  recipeApi: {
+    diffVersions: vi.fn(),
+  },
+}));
+
+import { recipeApi } from '../../api/index.ts';
+import type { VersionDiffOutput } from '@brewform/shared/schemas';
+import { VersionDiffPage } from './VersionDiffPage.tsx';
+
+const mockRecipeApi = vi.mocked(recipeApi);
+
+const mockDiff: VersionDiffOutput = {
+  version1: { id: 'v1', versionNumber: 1, brewDate: '2025-01-01' },
+  version2: { id: 'v2', versionNumber: 2, brewDate: '2025-02-01' },
+  fields: [
+    { field: 'brewMethod', value1: 'espresso_machine', value2: 'v60', status: 'modified' },
+    { field: 'groundWeightGrams', value1: 18, value2: 18, status: 'unchanged' },
+    { field: 'temperatureCelsius', value1: null, value2: 93, status: 'added' },
+  ],
+  tasteNotes: { added: ['chocolate'], removed: ['citrus'], unchanged: ['caramel'] },
+  equipment: { added: [], removed: [], unchanged: ['Hario V60'] },
+};
+
+function renderPage() {
+  const router = createMemoryRouter(
+    [{ path: '/recipes/:slug/versions/diff', element: <VersionDiffPage /> }],
+    { initialEntries: ['/recipes/test-recipe/versions/diff?v1=1&v2=2'] },
+  );
+  render(<RouterProvider router={router} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRecipeApi.diffVersions.mockResolvedValue(mockDiff);
+});
+
+describe('VersionDiffPage', () => {
+  it('shows loading state initially', () => {
+    mockRecipeApi.diffVersions.mockReturnValue(new Promise(() => {}));
+    renderPage();
+    expect(screen.getByText('common.loading')).toBeInTheDocument();
+  });
+
+  it('renders diff fields with correct statuses after load', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('recipe.brewMethod')).toBeInTheDocument();
+    });
+    expect(screen.getByText('espresso_machine')).toBeInTheDocument();
+    expect(screen.getByText('v60')).toBeInTheDocument();
+    expect(screen.getByText('recipe.temperature')).toBeInTheDocument();
+  });
+
+  it('renders taste notes and equipment sections', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('recipe.tasteNotes')).toBeInTheDocument();
+    });
+    expect(screen.getByText('+ chocolate')).toBeInTheDocument();
+    expect(screen.getByText('- citrus')).toBeInTheDocument();
+    expect(screen.getByText('caramel')).toBeInTheDocument();
+    expect(screen.getByText('equipment.title')).toBeInTheDocument();
+    expect(screen.getByText('Hario V60')).toBeInTheDocument();
+  });
+
+  it('shows empty state on error', async () => {
+    mockRecipeApi.diffVersions.mockRejectedValue(new Error('fail'));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('common.noResults')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/pages/recipes/VersionDiffPage.tsx
+++ b/apps/web/src/pages/recipes/VersionDiffPage.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from 'react';
+import { useParams, useSearchParams } from 'react-router';
+import { recipeApi } from '../../api/index.ts';
+import { useTranslation } from '../../contexts/I18nContext.tsx';
+import { SEOHead } from '../../components/seo/SEOHead.tsx';
+import { Breadcrumb } from '../../components/ui/Breadcrumb.tsx';
+import { PageContainer } from '../../components/ui/PageContainer.tsx';
+import { LoadingState } from '../../components/ui/LoadingState.tsx';
+import { EmptyState } from '../../components/ui/EmptyState.tsx';
+import { DiffHighlighter } from '../../components/recipe/DiffHighlighter.tsx';
+import { useUnitSystem } from '../../hooks/useUnitSystem.ts';
+import { createLogger } from '../../utils/logger.ts';
+import { formatTemperature, formatVolume, formatWeight } from '@brewform/shared/utils';
+import { formatDate } from '../../utils/format.ts';
+import type { VersionDiffOutput } from '@brewform/shared/schemas';
+
+const log = createLogger('VersionDiffPage');
+
+const FIELD_LABELS: Record<string, string> = {
+  brewMethod: 'recipe.brewMethod',
+  drinkType: 'recipe.drinkType',
+  productName: 'recipe.productName',
+  coffeeBrand: 'recipe.coffeeBrand',
+  coffeeProcessing: 'recipe.coffeeProcessing',
+  grindSize: 'recipe.grindSize',
+  grinder: 'recipe.grinder',
+  brewerDetails: 'recipe.brewerDetails',
+  groundWeightGrams: 'recipe.groundWeight',
+  extractionTimeSeconds: 'recipe.extractionTime',
+  extractionVolumeMl: 'recipe.extractionVolume',
+  temperatureCelsius: 'recipe.temperature',
+  brewRatio: 'recipe.ratio',
+  flowRate: 'recipe.flowRate',
+  preInfusionTimeSeconds: 'recipe.preInfusionTime',
+  tds: 'recipe.tds',
+  preparationNotes: 'recipe.preparationNotes',
+  personalNotes: 'recipe.personalNotes',
+  rating: 'recipe.rating',
+  emojiTag: 'recipe.emojiTag',
+};
+
+function DiffTagList({ items, label }: {
+  items: { added: string[]; removed: string[]; unchanged: string[] };
+  label: string;
+}) {
+  return (
+    <div className='mt-4'>
+      <h3 className='mb-2 text-sm font-medium' style={{ color: 'var(--text-secondary)' }}>
+        {label}
+      </h3>
+      <div className='flex flex-wrap gap-2'>
+        {items.added.map((item) => (
+          <span
+            key={item}
+            className='rounded px-2 py-0.5 text-xs'
+            style={{ color: 'var(--diff-added-text)', backgroundColor: 'var(--diff-added-bg)' }}
+          >
+            + {item}
+          </span>
+        ))}
+        {items.removed.map((item) => (
+          <span
+            key={item}
+            className='rounded px-2 py-0.5 text-xs'
+            style={{ color: 'var(--diff-removed-text)', backgroundColor: 'var(--diff-removed-bg)' }}
+          >
+            - {item}
+          </span>
+        ))}
+        {items.unchanged.map((item) => (
+          <span
+            key={item}
+            className='rounded px-2 py-0.5 text-xs'
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            {item}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Displays a field-by-field diff between two recipe versions, with unit-aware
+ * formatting for scalar fields and colored tag lists for taste notes/equipment.
+ */
+export function VersionDiffPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const [searchParams] = useSearchParams();
+  const v1 = searchParams.get('v1') ?? '';
+  const v2 = searchParams.get('v2') ?? '';
+  const { t, locale } = useTranslation();
+  const unitSystem = useUnitSystem();
+  const [data, setData] = useState<VersionDiffOutput | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    log.debug({}, 'VersionDiffPage mounted');
+    return () => {
+      log.debug({}, 'VersionDiffPage unmounted');
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!slug || !v1 || !v2) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setData(null);
+    recipeApi.diffVersions(slug, v1, v2)
+      .then(setData)
+      .catch((err) => {
+        log.error({ err, slug }, 'VersionDiffPage loadDiff failed');
+        setData(null);
+      })
+      .finally(() => setLoading(false));
+  }, [slug, v1, v2]);
+
+  const getFormatter = (field: string) => {
+    if (field === 'groundWeightGrams') {
+      return (v: string | number | null) => v != null ? formatWeight(Number(v), unitSystem) : '-';
+    }
+    if (field === 'extractionVolumeMl') {
+      return (v: string | number | null) => v != null ? formatVolume(Number(v), unitSystem) : '-';
+    }
+    if (field === 'temperatureCelsius') {
+      return (v: string | number | null) =>
+        v != null
+          ? formatTemperature(Number(v), unitSystem === 'imperial' ? 'fahrenheit' : 'celsius')
+          : '-';
+    }
+    if (field === 'extractionTimeSeconds' || field === 'preInfusionTimeSeconds') {
+      return (v: string | number | null) => v != null ? `${v}s` : '-';
+    }
+    return undefined;
+  };
+
+  if (loading) {
+    return (
+      <PageContainer width='4xl'>
+        <LoadingState />
+      </PageContainer>
+    );
+  }
+
+  if (!data) {
+    return (
+      <PageContainer width='4xl'>
+        <EmptyState message={t('common.noResults')} />
+      </PageContainer>
+    );
+  }
+
+  return (
+    <>
+      <SEOHead title={`${slug} – ${t('versionDiff.title')}`} />
+      <PageContainer width='4xl'>
+        <div className='mb-6'>
+          <Breadcrumb
+            items={[
+              { label: t('recipe.list.title'), to: '/recipes' },
+              { label: slug ?? '', to: `/recipes/${slug}` },
+              { label: t('versionDiff.title') },
+            ]}
+          />
+        </div>
+
+        <h1 className='mb-4 text-2xl font-bold'>{t('versionDiff.title')}</h1>
+
+        <div className='mb-6 flex gap-8 text-sm' style={{ color: 'var(--text-secondary)' }}>
+          <span>
+            v{data.version1.versionNumber} — {formatDate(data.version1.brewDate, locale)}
+          </span>
+          <span>
+            v{data.version2.versionNumber} — {formatDate(data.version2.brewDate, locale)}
+          </span>
+        </div>
+
+        <h2 className='mb-2 text-lg font-semibold'>{t('versionDiff.parameters')}</h2>
+        <div className='mb-6'>
+          {data.fields.map((f) => (
+            <DiffHighlighter
+              key={f.field}
+              labelKey={FIELD_LABELS[f.field] ?? f.field}
+              value1={f.value1}
+              value2={f.value2}
+              status={f.status}
+              formatter={getFormatter(f.field)}
+            />
+          ))}
+        </div>
+
+        <DiffTagList items={data.tasteNotes} label={t('recipe.tasteNotes')} />
+        <DiffTagList items={data.equipment} label={t('equipment.title')} />
+      </PageContainer>
+    </>
+  );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -116,6 +116,13 @@ export const router = createBrowserRouter([
           return { Component: RecipeComparePage };
         },
       },
+      {
+        path: 'recipes/:slug/versions/diff',
+        lazy: async () => {
+          const { VersionDiffPage } = await import('./pages/recipes/VersionDiffPage.tsx');
+          return { Component: VersionDiffPage };
+        },
+      },
       { path: 'recipes/:slug/versions', element: <RecipeVersionsPage /> },
       {
         path: 'recipes/:slug',

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -53,6 +53,12 @@
     --error-bg: #fef2f2;
     --info: #2563eb;
     --diff-highlight: rgba(255, 200, 0, 0.1);
+    --diff-added-bg: rgba(22, 163, 74, 0.1);
+    --diff-added-text: #15803d;
+    --diff-removed-bg: rgba(220, 38, 38, 0.1);
+    --diff-removed-text: #b91c1c;
+    --diff-modified-bg: rgba(217, 119, 6, 0.1);
+    --diff-modified-text: #92400e;
   }
 
   .dark {
@@ -73,6 +79,12 @@
     --error-bg: #450a0a;
     --info: #3b82f6;
     --diff-highlight: rgba(255, 200, 0, 0.15);
+    --diff-added-bg: rgba(34, 197, 94, 0.15);
+    --diff-added-text: #22c55e;
+    --diff-removed-bg: rgba(239, 68, 68, 0.15);
+    --diff-removed-text: #ef4444;
+    --diff-modified-bg: rgba(245, 158, 11, 0.15);
+    --diff-modified-text: #f59e0b;
   }
 
   .coffee {
@@ -93,6 +105,12 @@
     --error-bg: #4e2320;
     --info: #93c5fd;
     --diff-highlight: rgba(255, 200, 0, 0.12);
+    --diff-added-bg: rgba(134, 239, 172, 0.12);
+    --diff-added-text: #86efac;
+    --diff-removed-bg: rgba(252, 165, 165, 0.12);
+    --diff-removed-text: #fca5a5;
+    --diff-modified-bg: rgba(251, 191, 36, 0.12);
+    --diff-modified-text: #fbbf24;
   }
 
   body {

--- a/openspec/changes/f09-version-diff/tasks.md
+++ b/openspec/changes/f09-version-diff/tasks.md
@@ -2,29 +2,29 @@
 
 ## Phase 1: Shared schema + API
 
-- [ ] **T1**: Add `VersionDiffOutputSchema` (+ `DiffFieldSchema`, `VersionMetaSchema`, `ListDiffSchema`) to `packages/shared/src/schemas/responses/recipe.ts` with TSDoc docblocks; export from barrel
-- [ ] **T2**: Add schema unit test `packages/shared/src/schemas/recipe.version-diff.test.ts` (valid payload, invalid status enum, missing fields)
-- [ ] **T3**: Add `diffVersions(recipeId, v1Id, v2Id)` to `apps/api/src/modules/recipe/service.ts` with TSDoc docblock + entry/exit/error structured logging — reuse `model.fetchRecipeVersionWithRelations`, assert same recipe, reject v1===v2, compare 20 scalar fields + taste notes + equipment
-- [ ] **T4**: Add service test `apps/api/src/modules/recipe/diff.test.ts` (happy path, same-version guard, cross-recipe guard, all-null fields, taste/equipment set diffs)
-- [ ] **T5**: Add `GET /:slug/versions/diff` route to `apps/api/src/modules/recipe/index.ts` — register BEFORE catch-all `/:slugOrId`; `optionalAuthGuard`, `canViewRecipe`, v1===v2 → 400, full OpenAPI `describeRoute()` with `resolver(successEnvelope(VersionDiffOutputSchema))` + error envelopes + `parameters`
-- [ ] **T6**: Add route test `apps/api/src/modules/recipe/diff.route.test.ts` (auth, visibility, admin bypass, 400 missing params, 400 same version, 404 wrong recipe, happy path) — requires `brewform_test` DB
+- [x] **T1**: Add `VersionDiffOutputSchema` (+ `DiffFieldSchema`, `VersionMetaSchema`, `ListDiffSchema`) to `packages/shared/src/schemas/responses/recipe.ts` with TSDoc docblocks; export from barrel
+- [x] **T2**: Add schema unit test `packages/shared/src/schemas/recipe.version-diff.test.ts` (valid payload, invalid status enum, missing fields)
+- [x] **T3**: Add `diffVersions(recipeId, v1Id, v2Id)` to `apps/api/src/modules/recipe/service.ts` with TSDoc docblock + entry/exit/error structured logging — reuse `model.fetchRecipeVersionWithRelations`, assert same recipe, reject v1===v2, compare 20 scalar fields + taste notes + equipment
+- [x] **T4**: Add service test `apps/api/src/modules/recipe/diff.test.ts` (happy path, same-version guard, cross-recipe guard, all-null fields, taste/equipment set diffs)
+- [x] **T5**: Add `GET /:slug/versions/diff` route to `apps/api/src/modules/recipe/index.ts` — register BEFORE catch-all `/:slugOrId`; `optionalAuthGuard`, `canViewRecipe`, v1===v2 → 400, full OpenAPI `describeRoute()` with `resolver(successEnvelope(VersionDiffOutputSchema))` + error envelopes + `parameters`
+- [x] **T6**: Add route test `apps/api/src/modules/recipe/diff.route.test.ts` (auth, visibility, admin bypass, 400 missing params, 400 same version, 404 wrong recipe, happy path) — requires `brewform_test` DB
 
 ## Phase 2: Frontend
 
-- [ ] **T7**: Extend `DiffHighlighter` with optional `status` prop + status-specific CSS var colors; preserve existing `labelKey` behavior when status absent; add TSDoc to component + props interface
-- [ ] **T8**: Extend `DiffHighlighter.test.tsx` — status prop rendering (all 4 statuses), backward compat (no status prop)
-- [ ] **T9**: Add CSS variables (`--diff-added-bg/text`, `--diff-removed-bg/text`, `--diff-modified-bg/text`) to all 3 theme blocks in `globals.css`
-- [ ] **T10**: Add typed `recipeApi.diffVersions(slug, v1, v2)` method to `apps/web/src/api/index.ts` with TSDoc
-- [ ] **T11**: Create `VersionDiffPage.tsx` with TSDoc — fetch diff, render via DiffHighlighter + DiffTagList, unit formatting, i18n labels, PageContainer/LoadingState/EmptyState/Breadcrumb, mount/unmount logger
-- [ ] **T12**: Add page test `apps/web/src/pages/recipes/VersionDiffPage.test.tsx` (loading, error, render with statuses, unit formatting)
-- [ ] **T13**: Add router entry for `recipes/:slug/versions/diff` (lazy import, near compare route, BEFORE `:slug` catch-all)
-- [ ] **T14**: Add version selection checkboxes + "Compare Selected" link to `RecipeVersionsPage.tsx` with TSDoc on new helpers
-- [ ] **T15**: Add/extend `RecipeVersionsPage.test.tsx` — checkbox selection (max 2), compare link visibility + href
-- [ ] **T16**: Add i18n keys to `en.json` + `tr.json` (page chrome + missing field labels)
+- [x] **T7**: Extend `DiffHighlighter` with optional `status` prop + status-specific CSS var colors; preserve existing `labelKey` behavior when status absent; add TSDoc to component + props interface
+- [x] **T8**: Extend `DiffHighlighter.test.tsx` — status prop rendering (all 4 statuses), backward compat (no status prop)
+- [x] **T9**: Add CSS variables (`--diff-added-bg/text`, `--diff-removed-bg/text`, `--diff-modified-bg/text`) to all 3 theme blocks in `globals.css`
+- [x] **T10**: Add typed `recipeApi.diffVersions(slug, v1, v2)` method to `apps/web/src/api/index.ts` with TSDoc
+- [x] **T11**: Create `VersionDiffPage.tsx` with TSDoc — fetch diff, render via DiffHighlighter + DiffTagList, unit formatting, i18n labels, PageContainer/LoadingState/EmptyState/Breadcrumb, mount/unmount logger
+- [x] **T12**: Add page test `apps/web/src/pages/recipes/VersionDiffPage.test.tsx` (loading, error, render with statuses, unit formatting)
+- [x] **T13**: Add router entry for `recipes/:slug/versions/diff` (lazy import, near compare route, BEFORE `:slug` catch-all)
+- [x] **T14**: Add version selection checkboxes + "Compare Selected" link to `RecipeVersionsPage.tsx` with TSDoc on new helpers
+- [x] **T15**: Add/extend `RecipeVersionsPage.test.tsx` — checkbox selection (max 2), compare link visibility + href
+- [x] **T16**: Add i18n keys to `en.json` + `tr.json` (page chrome + missing field labels)
 
 ## Phase 3: Verification
 
-- [ ] **T17**: `make check` — type-check all workspaces
-- [ ] **T18**: `make lint` — lint all apps/packages
-- [ ] **T19**: `make fmt` — format
-- [ ] **T20**: `make test` — full test suite (includes `openapi.coverage.test.ts`)
+- [x] **T17**: `make check` — type-check all workspaces
+- [x] **T18**: `make lint` — lint all apps/packages
+- [x] **T19**: `make fmt` — format
+- [x] **T20**: `make test` — full test suite (includes `openapi.coverage.test.ts`)

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -121,6 +121,9 @@
   "recipe.coffeeBrand": "Coffee Brand",
   "recipe.coffeeProcessing": "Coffee Processing",
   "recipe.productName": "Product Name",
+  "recipe.preInfusionTime": "Pre-infusion Time",
+  "recipe.tds": "TDS",
+  "recipe.brewerDetails": "Brewer Details",
   "recipe.notFound": "Recipe not found",
   "recipe.unavailable.title": "This recipe is no longer available",
   "recipe.unavailable.message": "It may have been deleted, set to private, or returned to draft.",
@@ -887,5 +890,15 @@
   "admin.audit.loadError": "Failed to load audit log.",
   "admin.coffeeVarieties.saveError": "Failed to save coffee variety.",
   "admin.coffeeVarieties.deleteFailed": "Failed to delete coffee variety.",
-  "admin.users.deleteFailed": "Failed to delete user."
+  "admin.users.deleteFailed": "Failed to delete user.",
+  "versionDiff.title": "Version Comparison",
+  "versionDiff.parameters": "Parameters",
+  "versionDiff.tasteNotes": "Taste Notes",
+  "versionDiff.equipment": "Equipment",
+  "versionDiff.compareSelected": "Compare Selected",
+  "versionDiff.added": "Added",
+  "versionDiff.removed": "Removed",
+  "versionDiff.unchanged": "Unchanged",
+  "versionDiff.version": "Version",
+  "versionDiff.brewDate": "Brew Date"
 }

--- a/packages/shared/src/i18n/tr.json
+++ b/packages/shared/src/i18n/tr.json
@@ -121,6 +121,9 @@
   "recipe.coffeeBrand": "Kahve Markası",
   "recipe.coffeeProcessing": "Kahve İşleme Yöntemi",
   "recipe.productName": "Ürün Adı",
+  "recipe.preInfusionTime": "Ön Demleme Süresi",
+  "recipe.tds": "TDS",
+  "recipe.brewerDetails": "Demleyici Detayları",
   "recipe.notFound": "Tarif bulunamadı",
   "recipe.unavailable.title": "Bu tarif artık kullanılamıyor",
   "recipe.unavailable.message": "Tarif silinmiş, gizli yapılmış veya taslağa dönmüş olabilir.",
@@ -887,5 +890,15 @@
   "admin.audit.loadError": "Denetim günlüğü yüklenemedi.",
   "admin.coffeeVarieties.saveError": "Kahve çeşidi kaydedilemedi.",
   "admin.coffeeVarieties.deleteFailed": "Kahve çeşidi silinemedi.",
-  "admin.users.deleteFailed": "Kullanıcı silinemedi."
+  "admin.users.deleteFailed": "Kullanıcı silinemedi.",
+  "versionDiff.title": "Sürüm Karşılaştırması",
+  "versionDiff.parameters": "Parametreler",
+  "versionDiff.tasteNotes": "Tat Notaları",
+  "versionDiff.equipment": "Ekipman",
+  "versionDiff.compareSelected": "Seçilenleri Karşılaştır",
+  "versionDiff.added": "Eklenen",
+  "versionDiff.removed": "Kaldırılan",
+  "versionDiff.unchanged": "Değişmeyen",
+  "versionDiff.version": "Sürüm",
+  "versionDiff.brewDate": "Demleme Tarihi"
 }

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -102,7 +102,10 @@ export * from './responses/index.ts';
 // file declares `export type X = z.infer<typeof XSchema>;`; mirror that here so
 // `import type { RecipeDetailOutput } from '@brewform/shared/schemas'` resolves.
 export type {
+  DiffField,
+  DiffStatus,
   FeedRecipeOutput,
+  ListDiff,
   RecipeDetailOutput,
   RecipeDetailVersionOutput,
   RecipeListItemOutput,
@@ -110,6 +113,8 @@ export type {
   RecipeVersionRow,
   RecipeWithAuthorOutput,
   RecipeWithVersionsOutput,
+  VersionDiffOutput,
+  VersionMeta,
 } from './responses/recipe.ts';
 export type { BeanOutput } from './responses/bean.ts';
 export type { BadgeOutput, UserBadgeOutput } from './responses/badge.ts';

--- a/packages/shared/src/schemas/recipe.version-diff.test.ts
+++ b/packages/shared/src/schemas/recipe.version-diff.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for the version-diff schemas in `responses/recipe.ts`:
+ * VersionDiffOutputSchema, DiffFieldSchema, DiffStatusSchema,
+ * VersionMetaSchema, and ListDiffSchema.
+ */
+import { describe, it } from 'jsr:@std/testing/bdd';
+import { expect } from 'jsr:@std/expect';
+import { VersionDiffOutputSchema } from './responses/recipe.ts';
+
+function validPayload() {
+  return {
+    version1: { id: 'v-1', versionNumber: 1, brewDate: '2024-01-01' },
+    version2: { id: 'v-2', versionNumber: 2, brewDate: '2024-02-01' },
+    fields: [
+      { field: 'brewMethod', value1: 'v60', value2: 'aeropress', status: 'modified' },
+      { field: 'ratio', value1: 16, value2: 15, status: 'modified' },
+      { field: 'grindSize', value1: null, value2: 'medium', status: 'added' },
+    ],
+    tasteNotes: { added: ['floral'], removed: [], unchanged: ['chocolate'] },
+    equipment: { added: [], removed: ['scale'], unchanged: ['kettle'] },
+  };
+}
+
+describe('VersionDiffOutputSchema', () => {
+  it('parses a complete valid payload', () => {
+    const result = VersionDiffOutputSchema.safeParse(validPayload());
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(validPayload());
+  });
+
+  it('rejects an invalid diff status enum value', () => {
+    const payload = validPayload();
+    payload.fields[0].status = 'changed';
+    expect(VersionDiffOutputSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it('rejects when the fields array is missing', () => {
+    const { fields: _omit, ...rest } = validPayload();
+    expect(VersionDiffOutputSchema.safeParse(rest).success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/responses/index.ts
+++ b/packages/shared/src/schemas/responses/index.ts
@@ -27,7 +27,10 @@ export {
   EquipmentRecipesResponseSchema,
 } from './equipment.ts';
 export {
+  DiffFieldSchema,
+  DiffStatusSchema,
   FeedRecipeOutputSchema,
+  ListDiffSchema,
   RecipeDetailAuthorOutputSchema,
   RecipeDetailOutputSchema,
   RecipeDetailVersionOutputSchema,
@@ -36,6 +39,8 @@ export {
   RecipeVersionRowSchema,
   RecipeWithAuthorOutputSchema,
   RecipeWithVersionsOutputSchema,
+  VersionDiffOutputSchema,
+  VersionMetaSchema,
 } from './recipe.ts';
 export {
   CommentOutputSchema,

--- a/packages/shared/src/schemas/responses/recipe.ts
+++ b/packages/shared/src/schemas/responses/recipe.ts
@@ -286,3 +286,59 @@ export const RecipeDetailOutputSchema = RecipeRowSchema.extend({
 
 /** Inferred type of {@link RecipeDetailOutputSchema}. */
 export type RecipeDetailOutput = z.infer<typeof RecipeDetailOutputSchema>;
+
+/** Status of a single field comparison between two recipe versions. */
+export const DiffStatusSchema = z.enum(['added', 'removed', 'modified', 'unchanged']);
+
+/** Inferred type of {@link DiffStatusSchema}. */
+export type DiffStatus = z.infer<typeof DiffStatusSchema>;
+
+/**
+ * A single scalar field comparison between two recipe versions.
+ * `field` is a machine key (e.g. `"brewMethod"`), not a translated label.
+ */
+export const DiffFieldSchema = z.object({
+  field: z.string(),
+  value1: z.union([z.string(), z.number(), z.null()]),
+  value2: z.union([z.string(), z.number(), z.null()]),
+  status: DiffStatusSchema,
+});
+
+/** Inferred type of {@link DiffFieldSchema}. */
+export type DiffField = z.infer<typeof DiffFieldSchema>;
+
+/** Minimal version metadata included in a diff response. */
+export const VersionMetaSchema = z.object({
+  id: z.string(),
+  versionNumber: z.number().int(),
+  brewDate: z.string(),
+});
+
+/** Inferred type of {@link VersionMetaSchema}. */
+export type VersionMeta = z.infer<typeof VersionMetaSchema>;
+
+/** Set-diff result for list relations (taste notes, equipment). */
+export const ListDiffSchema = z.object({
+  added: z.array(z.string()),
+  removed: z.array(z.string()),
+  unchanged: z.array(z.string()),
+});
+
+/** Inferred type of {@link ListDiffSchema}. */
+export type ListDiff = z.infer<typeof ListDiffSchema>;
+
+/**
+ * Full version-diff payload returned by `GET /recipes/:slug/versions/diff`.
+ * Contains metadata for both versions, per-field scalar diffs, and set diffs
+ * for taste notes and equipment.
+ */
+export const VersionDiffOutputSchema = z.object({
+  version1: VersionMetaSchema,
+  version2: VersionMetaSchema,
+  fields: z.array(DiffFieldSchema),
+  tasteNotes: ListDiffSchema,
+  equipment: ListDiffSchema,
+});
+
+/** Inferred type of {@link VersionDiffOutputSchema}. */
+export type VersionDiffOutput = z.infer<typeof VersionDiffOutputSchema>;


### PR DESCRIPTION
## Summary

Implements F09: field-by-field comparison between two versions of the same recipe.

### API
- `GET /api/v1/recipes/:slug/versions/diff?v1=&v2=` — full OpenAPI docs, optionalAuth, canViewRecipe
- `diffVersions` service: compares 20 scalar fields + taste notes + equipment set diffs
- `VersionDiffOutputSchema` in shared schemas (typed boundary per D42)

### Frontend
- `VersionDiffPage` with unit-aware formatting, i18n labels, DiffHighlighter + DiffTagList
- `DiffHighlighter` extended with optional `status` prop (backward-compatible)
- Version selection checkboxes + "Compare Selected" link on RecipeVersionsPage
- CSS variables for diff colors in all 3 theme blocks
- Router entry for `/recipes/:slug/versions/diff`

### Tests
- Schema test, service test (6 cases), route test (7 cases)
- DiffHighlighter status prop tests, VersionDiffPage tests, RecipeVersionsPage selection tests
- OpenAPI coverage test passes

### Verification
- `make check` ✓
- `make lint` ✓
- `make fmt` ✓
- `make test` — 449 passed, 1 pre-existing failure in admin/model.test.ts (unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recipe version comparison from the version history page.
  * Compare two selected versions, including recipe parameters, taste notes, and equipment.
  * Added clear indicators for added, removed, modified, and unchanged values.
  * Added support for light, dark, and coffee themes, with English and Turkish translations.

* **Bug Fixes**
  * Added validation and access controls for version comparisons, including invalid or unavailable versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->